### PR TITLE
fix: check for errors when computing the installed size

### DIFF
--- a/pkg/build/package.go
+++ b/pkg/build/package.go
@@ -122,6 +122,10 @@ func (pc *PackageContext) EmitPackage() error {
 
 	fsys := os.DirFS(pc.WorkspaceSubdir())
 	if err := fs.WalkDir(fsys, ".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
 		fi, err := d.Info()
 		if err != nil {
 			return err


### PR DESCRIPTION
Note that `d` can be nil if there's an error