### PR TITLE
Remove deprecated ioutil calls

### DIFF
--- a/internal/sign/rsa.go
+++ b/internal/sign/rsa.go
@@ -11,7 +11,7 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 )
 
 var (
@@ -28,7 +28,7 @@ func RSASignSHA1Digest(sha1Digest []byte, keyFile, passphrase string) ([]byte, e
 		return nil, errDigestNotSH1
 	}
 
-	keyFileContent, err := ioutil.ReadFile(keyFile)
+	keyFileContent, err := os.ReadFile(keyFile)
 	if err != nil {
 		return nil, fmt.Errorf("reading key file: %w", err)
 	}
@@ -74,7 +74,7 @@ func RSAVerifySHA1Digest(sha1Digest, signature []byte, publicKeyFile string) err
 		return errDigestNotSH1
 	}
 
-	keyFileContent, err := ioutil.ReadFile(publicKeyFile)
+	keyFileContent, err := os.ReadFile(publicKeyFile)
 	if err != nil {
 		return fmt.Errorf("reading key file: %w", err)
 	}


### PR DESCRIPTION
(ioutil was deprecated since go 1.16)
Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>