### PR TITLE
multiarch support

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -32,26 +32,23 @@ jobs:
         ./melange keygen
         mv melange.rsa.pub /etc/apk/keys
     - name: Build stage2 melange package with bootstrap melange
-      run: ./melange build --pipeline-dir=pipelines/ --signing-key=melange.rsa
+      run: ./melange build --pipeline-dir=pipelines/ --signing-key=melange.rsa --arch x86_64
     - name: Install stage2 melange package
-      run: apk add ./melange-*.apk
+      run: apk add ./packages/x86_64/melange-*.apk
     - name: Move stage2 artifacts to stage2 directory
       run: |
-        mkdir stage2
-        mv melange-*.apk stage2
+        mv packages stage2
     - name: Verify operation of stage2 melange
       run: melange version
     - name: Build stage3 melange package with stage2 melange
-      run: melange build --signing-key=melange.rsa
+      run: melange build --signing-key=melange.rsa --arch x86_64
     - name: Install stage3 melange package
-      run: apk add ./melange-*.apk
+      run: apk add ./packages/x86_64/melange-*.apk
     - name: Move stage3 artifacts to stage3 directory
       run: |
-        mkdir stage3
-        mv melange-*.apk stage3
+        mv packages stage3
     - name: Ensure melange package is reproducible
       run: |
-        sha256sum stage2/*.apk | sed -e 's:stage2/:stage3/:g' | sha256sum -c
+        sha256sum stage2/x86_64/*.apk | sed -e 's:stage2/:stage3/:g' | sha256sum -c
     - name: Verify operation of stage3 melange
       run: melange version
-

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -31,12 +31,11 @@ jobs:
       run: |
         ./melange keygen
         mv melange.rsa.pub /etc/apk/keys
-    - name: Prepare build workspace
+    - name: Prepare build workspace for stage2
       run: |
-        mkdir workspace/
-        git clone . workspace/x86_64
+        git clone . workspace-stage2/x86_64
     - name: Build stage2 melange package with bootstrap melange
-      run: ./melange build --pipeline-dir=pipelines/ --signing-key=melange.rsa --arch x86_64 --workspace-dir workspace/
+      run: ./melange build --pipeline-dir=pipelines/ --signing-key=melange.rsa --arch x86_64 --workspace-dir workspace-stage2/
     - name: Install stage2 melange package
       run: apk add ./packages/x86_64/melange-*.apk
     - name: Move stage2 artifacts to stage2 directory
@@ -44,8 +43,11 @@ jobs:
         mv packages stage2
     - name: Verify operation of stage2 melange
       run: melange version
+    - name: Prepare build workspace for stage3
+      run: |
+        git clone . workspace-stage3/x86_64
     - name: Build stage3 melange package with stage2 melange
-      run: melange build --signing-key=melange.rsa --arch x86_64 --workspace-dir workspace/
+      run: melange build --signing-key=melange.rsa --arch x86_64 --workspace-dir workspace-stage3/
     - name: Install stage3 melange package
       run: apk add ./packages/x86_64/melange-*.apk
     - name: Move stage3 artifacts to stage3 directory

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -31,8 +31,12 @@ jobs:
       run: |
         ./melange keygen
         mv melange.rsa.pub /etc/apk/keys
+    - name: Prepare build workspace
+      run: |
+        mkdir workspace/
+        git clone . workspace/x86_64
     - name: Build stage2 melange package with bootstrap melange
-      run: ./melange build --pipeline-dir=pipelines/ --signing-key=melange.rsa --arch x86_64
+      run: ./melange build --pipeline-dir=pipelines/ --signing-key=melange.rsa --arch x86_64 --workspace-dir workspace/
     - name: Install stage2 melange package
       run: apk add ./packages/x86_64/melange-*.apk
     - name: Move stage2 artifacts to stage2 directory
@@ -41,7 +45,7 @@ jobs:
     - name: Verify operation of stage2 melange
       run: melange version
     - name: Build stage3 melange package with stage2 melange
-      run: melange build --signing-key=melange.rsa --arch x86_64
+      run: melange build --signing-key=melange.rsa --arch x86_64 --workspace-dir workspace/
     - name: Install stage3 melange package
       run: apk add ./packages/x86_64/melange-*.apk
     - name: Move stage3 artifacts to stage3 directory

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/psanford/memfs v0.0.0-20210214183328-a001468d78ef
 	github.com/spf13/cobra v1.4.0
 	github.com/stretchr/testify v1.7.1
+	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 	sigs.k8s.io/release-utils v0.5.0
 )
@@ -30,5 +31,4 @@ require (
 	github.com/vbatts/tar-split v0.11.2 // indirect
 	gitlab.alpinelinux.org/alpine/go v0.3.1 // indirect
 	go.lsp.dev/uri v0.3.0 // indirect
-	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
 )

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -19,6 +19,7 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
 	"strconv"
 	"time"
@@ -119,6 +120,7 @@ func New(opts ...Option) (*Context, error) {
 		ctx.SourceDateEpoch = time.Unix(sec, 0)
 	}
 
+	ctx.WorkspaceDir = filepath.Join(ctx.WorkspaceDir, ctx.Arch.ToAPK())
 	ctx.Logger.SetPrefix(fmt.Sprintf("melange (%s/%s): ", ctx.Configuration.Package.Name, ctx.Arch.ToAPK()))
 
 	return &ctx, nil

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -194,6 +194,14 @@ func WithOutDir(outDir string) Option {
 	}
 }
 
+// WithArch sets the build architecture to use for this build context.
+func WithArch(arch apko_types.Architecture) Option {
+	return func(ctx *Context) error {
+		ctx.Arch = arch
+		return nil
+	}
+}
+
 // Load the configuration data from the build context configuration file.
 func (cfg *Configuration) Load(configFile string) error {
 	data, err := os.ReadFile(configFile)

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -119,6 +119,8 @@ func New(opts ...Option) (*Context, error) {
 		ctx.SourceDateEpoch = time.Unix(sec, 0)
 	}
 
+	ctx.Logger.SetPrefix(fmt.Sprintf("melange (%s/%s): ", ctx.Configuration.Package.Name, ctx.Arch.ToAPK()))
+
 	return &ctx, nil
 }
 

--- a/pkg/build/package.go
+++ b/pkg/build/package.go
@@ -55,7 +55,7 @@ func (spkg *Subpackage) Emit(ctx *PipelineContext) error {
 		Context:     ctx.Context,
 		Origin:      &ctx.Context.Configuration.Package,
 		PackageName: spkg.Name,
-		OutDir:      ctx.Context.OutDir,
+		OutDir:      filepath.Join(ctx.Context.OutDir, ctx.Context.Arch.ToAPK()),
 		Logger:      log.New(log.Writer(), fmt.Sprintf("melange (%s/%s): ", spkg.Name, ctx.Context.Arch.ToAPK()), log.LstdFlags|log.Lmsgprefix),
 	}
 	return pc.EmitPackage()

--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"path/filepath"
 
+	apko_types "chainguard.dev/apko/pkg/build/types"
 	"chainguard.dev/melange/pkg/build"
 	"github.com/spf13/cobra"
 )
@@ -31,6 +32,7 @@ func Build() *cobra.Command {
 	var signingKey string
 	var useProot bool
 	var outDir string
+	var archstrs []string
 
 	cmd := &cobra.Command{
 		Use:     "build",
@@ -39,6 +41,7 @@ func Build() *cobra.Command {
 		Example: `  melange build [config.yaml]`,
 		Args:    cobra.MinimumNArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			archs := apko_types.ParseArchitectures(archstrs)
 			options := []build.Option{
 				build.WithBuildDate(buildDate),
 				build.WithWorkspaceDir(workspaceDir),
@@ -52,7 +55,7 @@ func Build() *cobra.Command {
 				options = append(options, build.WithConfig(args[0]))
 			}
 
-			return BuildCmd(cmd.Context(), options...)
+			return BuildCmd(cmd.Context(), archs, options...)
 		},
 	}
 
@@ -67,18 +70,27 @@ func Build() *cobra.Command {
 	cmd.Flags().StringVar(&signingKey, "signing-key", "", "key to use for signing")
 	cmd.Flags().BoolVar(&useProot, "use-proot", false, "whether to use proot for fakeroot")
 	cmd.Flags().StringVar(&outDir, "out-dir", filepath.Join(cwd, "packages"), "directory where packages will be output")
+	cmd.Flags().StringSliceVar(&archstrs, "arch", nil, "architectures to build for (e.g., x86_64,ppc64le,arm64) -- default is all, unless specified in config.")
 
 	return cmd
 }
 
-func BuildCmd(ctx context.Context, opts ...build.Option) error {
-	bc, err := build.New(opts...)
-	if err != nil {
-		return err
+func BuildCmd(ctx context.Context, archs []apko_types.Architecture, base_opts ...build.Option) error {
+	if len(archs) == 0 {
+		archs = apko_types.AllArchs
 	}
 
-	if err := bc.BuildPackage(); err != nil {
-		return fmt.Errorf("failed to build package: %w", err)
+	for _, arch := range archs {
+		opts := append(base_opts, build.WithArch(arch))
+
+		bc, err := build.New(opts...)
+		if err != nil {
+			return err
+		}
+
+		if err := bc.BuildPackage(); err != nil {
+			return fmt.Errorf("failed to build package: %w", err)
+		}
 	}
 
 	return nil

--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"chainguard.dev/melange/pkg/build"
 	"github.com/spf13/cobra"
@@ -65,7 +66,7 @@ func Build() *cobra.Command {
 	cmd.Flags().StringVar(&pipelineDir, "pipeline-dir", "/usr/share/melange/pipelines", "directory used to store defined pipelines")
 	cmd.Flags().StringVar(&signingKey, "signing-key", "", "key to use for signing")
 	cmd.Flags().BoolVar(&useProot, "use-proot", false, "whether to use proot for fakeroot")
-	cmd.Flags().StringVar(&outDir, "out-dir", cwd, "directory where packages will be output")
+	cmd.Flags().StringVar(&outDir, "out-dir", filepath.Join(cwd, "packages"), "directory where packages will be output")
 
 	return cmd
 }


### PR DESCRIPTION
This PR adds support for building packages for all architectures in parallel.  Some work needs to be done to skip architectures where the package is not declared supported, but that's out of scope for this PR.

Like with `docker buildx`, qemu-binfmt will need to be configured to make use of multiarch.