### PR TITLE
Docker env for running melange without alpine

### DIFF
--- a/hack/run-devenv.sh
+++ b/hack/run-devenv.sh
@@ -16,7 +16,7 @@ function run() {
 }
 
 function docker_run() {
-    docker run --rm -w /melange -v $(pwd):/melange --entrypoint /melange/hack/run-devenv.sh apko-inception:latest run $@
+    docker run --privileged --rm -w /melange -v $(pwd):/melange --entrypoint /melange/hack/run-devenv.sh apko-inception:latest run $@
 }
 
 case "$1" in

--- a/hack/run-devenv.sh
+++ b/hack/run-devenv.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+# Copyright 2022 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+function run() {
+
+    # Can we dogfood and do the following with apkgo?
+
+    go install golang.org/x/tools/cmd/goimports@latest 
+    export PATH=$PATH:/root/go/bin
+    make melange
+    make install
+
+    melange "$@"
+}
+
+function docker_run() {
+    docker run --rm -w /melange -v $(pwd):/melange --entrypoint /melange/hack/run-devenv.sh apko-inception:latest run $@
+}
+
+case "$1" in
+    "run")
+        run ${@:4};;
+    *)
+	docker_run $@;;
+esac
+


### PR DESCRIPTION
Created a script based on apko's apko-inception for running melange.

It has a few issues currently:

 - requires a modified version of the apko-inception image with bubblewrap.
 - Should we host the image somewhere? GHCR?
 - As part of a run script, it installs a go module and makes melange. I guess the next step would be to see if this can be done with apko?
 - Currently requires "--priviliged" for bubblewrap; i'll look into the exact caps required.

Anyway, I thought I'd make it available now for people to play with, but I'm interested in what direction people think it should go in.