### PR TITLE
Implement 'package needs' for pipelines

### DIFF
--- a/examples/sshfs.yaml
+++ b/examples/sshfs.yaml
@@ -28,9 +28,7 @@ environment:
       - fuse3-dev
       - glib-dev
       - coreutils
-      - meson
       - py3-docutils
-      - git
 
 pipeline:
   - uses: git-checkout

--- a/examples/sshfs.yaml
+++ b/examples/sshfs.yaml
@@ -38,3 +38,8 @@ pipeline:
   - uses: meson/compile
   - uses: meson/install
   - uses: strip
+
+subpackages:
+  - name: "sshfs-doc"
+    pipeline:
+      - uses: split/manpages

--- a/pipelines/autoconf/make-install.yaml
+++ b/pipelines/autoconf/make-install.yaml
@@ -1,4 +1,8 @@
 name: Run autoconf make install
 
+needs:
+  packages:
+    - make
+
 pipeline:
   - runs: make install DESTDIR="${{targets.destdir}}"

--- a/pipelines/autoconf/make.yaml
+++ b/pipelines/autoconf/make.yaml
@@ -1,4 +1,8 @@
 name: Run autoconf make
 
+needs:
+  packages:
+    - make
+
 pipeline:
   - runs: make -j$(nproc)

--- a/pipelines/fetch.yaml
+++ b/pipelines/fetch.yaml
@@ -1,5 +1,9 @@
 name: Fetch and extract external object into workspace
 
+needs:
+  packages:
+    - wget
+
 inputs:
   strip-components:
     description: |

--- a/pipelines/git-checkout.yaml
+++ b/pipelines/git-checkout.yaml
@@ -1,5 +1,9 @@
 name: Check out sources from git
 
+needs:
+  packages:
+    - git
+
 inputs:
   repository:
     description: |

--- a/pipelines/meson/compile.yaml
+++ b/pipelines/meson/compile.yaml
@@ -1,5 +1,9 @@
 name: Compile project with meson
 
+needs:
+  packages:
+    - meson
+
 inputs:
   output-dir:
     description: |

--- a/pipelines/meson/configure.yaml
+++ b/pipelines/meson/configure.yaml
@@ -16,4 +16,6 @@ inputs:
 
 pipeline:
   - runs: |
-      meson . ${{inputs.output-dir}} ${{inputs.opts}}
+      meson . ${{inputs.output-dir}} \
+        --prefix=/usr \
+        ${{inputs.opts}}

--- a/pipelines/meson/configure.yaml
+++ b/pipelines/meson/configure.yaml
@@ -1,5 +1,9 @@
 name: Configure project with meson
 
+needs:
+  packages:
+    - meson
+
 inputs:
   output-dir:
     description: |

--- a/pipelines/meson/install.yaml
+++ b/pipelines/meson/install.yaml
@@ -1,5 +1,9 @@
 name: Install project with meson
 
+needs:
+  packages:
+    - meson
+
 inputs:
   output-dir:
     description: |

--- a/pipelines/patch.yaml
+++ b/pipelines/patch.yaml
@@ -1,5 +1,9 @@
 name: Apply patches
 
+needs:
+  packages:
+    - patch
+
 inputs:
   strip-components:
     description: |

--- a/pipelines/strip.yaml
+++ b/pipelines/strip.yaml
@@ -1,5 +1,9 @@
 name: Strip binaries
 
+needs:
+  packages:
+    - binutils
+
 pipeline:
   - runs: |
       cd "${{targets.destdir}}"

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -45,6 +45,10 @@ type Copyright struct {
 	License     string
 }
 
+type Needs struct {
+	Packages []string
+}
+
 type Pipeline struct {
 	Name     string
 	Uses     string
@@ -52,6 +56,7 @@ type Pipeline struct {
 	Runs     string
 	Pipeline []Pipeline
 	Inputs   map[string]Input
+	Needs    Needs
 	logger   *log.Logger
 }
 


### PR DESCRIPTION
This implements a new section for a pipeline:

```yaml
needs:
  packages:
    - foo
    - bar
```

These package needs are deduplicated and merged with the configured build environment, which, when combined with apko inheritance, will allow for the YAML files to focus on the explicit dependencies needed by a package.