### PR TITLE
Creating Github action to automatically add issues to project board.

### DIFF
--- a/.github/workflows/add-issues.yaml
+++ b/.github/workflows/add-issues.yaml
@@ -1,0 +1,20 @@
+name: Add melange repo issues to Images project board
+
+on:
+  issues:
+    types:
+      - opened
+
+permissions:
+  contents: read
+  issues: write 
+
+jobs:
+  add-to-project:
+    name: Add issue to project board
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@main
+        with:
+          project-url: https://github.com/orgs/chainguard-dev/projects/12
+          github-token: ${{ secrets.PROJECT_WRITER }}


### PR DESCRIPTION
A Github action that will automatically add all new issues from melange to the Images Tent Pole Github project board.

https://github.com/orgs/chainguard-dev/projects/12/

