### PR TITLE
build: add support for --keyring-append and --repository-append like apko

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -92,6 +92,8 @@ type Context struct {
 	OutDir            string
 	Logger            *log.Logger
 	Arch              apko_types.Architecture
+	ExtraKeys         []string
+	ExtraRepos        []string
 }
 
 type Dependencies struct {
@@ -220,6 +222,22 @@ func WithArch(arch apko_types.Architecture) Option {
 	}
 }
 
+// WithExtraKeys adds a set of extra keys to the build context.
+func WithExtraKeys(extraKeys []string) Option {
+	return func(ctx *Context) error {
+		ctx.ExtraKeys = extraKeys
+		return nil
+	}
+}
+
+// WithExtraRepos adds a set of extra repos to the build context.
+func WithExtraRepos(extraRepos []string) Option {
+	return func(ctx *Context) error {
+		ctx.ExtraRepos = extraRepos
+		return nil
+	}
+}
+
 // Load the configuration data from the build context configuration file.
 func (cfg *Configuration) Load(configFile string) error {
 	data, err := os.ReadFile(configFile)
@@ -260,6 +278,8 @@ func (ctx *Context) BuildWorkspace(workspaceDir string) error {
 		apko_build.WithImageConfiguration(ctx.Configuration.Environment),
 		apko_build.WithProot(ctx.UseProot),
 		apko_build.WithArch(ctx.Arch),
+		apko_build.WithExtraKeys(ctx.ExtraKeys),
+		apko_build.WithExtraRepos(ctx.ExtraRepos),
 	)
 	if err != nil {
 		return fmt.Errorf("unable to create build context: %w", err)

--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -34,6 +34,8 @@ func Build() *cobra.Command {
 	var useProot bool
 	var outDir string
 	var archstrs []string
+	var extraKeys []string
+	var extraRepos []string
 
 	cmd := &cobra.Command{
 		Use:     "build",
@@ -50,6 +52,8 @@ func Build() *cobra.Command {
 				build.WithSigningKey(signingKey),
 				build.WithUseProot(useProot),
 				build.WithOutDir(outDir),
+				build.WithExtraKeys(extraKeys),
+				build.WithExtraRepos(extraRepos),
 			}
 
 			if len(args) > 0 {
@@ -72,6 +76,8 @@ func Build() *cobra.Command {
 	cmd.Flags().BoolVar(&useProot, "use-proot", false, "whether to use proot for fakeroot")
 	cmd.Flags().StringVar(&outDir, "out-dir", filepath.Join(cwd, "packages"), "directory where packages will be output")
 	cmd.Flags().StringSliceVar(&archstrs, "arch", nil, "architectures to build for (e.g., x86_64,ppc64le,arm64) -- default is all, unless specified in config.")
+	cmd.Flags().StringSliceVarP(&extraKeys, "keyring-append", "k", []string{}, "path to extra keys to include in the build environment keyring")
+	cmd.Flags().StringSliceVarP(&extraRepos, "repository-append", "r", []string{}, "path to extra repositories to include in the build environment")
 
 	return cmd
 }


### PR DESCRIPTION
this is needed to allow compatibility between github actions and other
github action runners like act, which place the github workspace in
slightly different locations