### PR TITLE
build: stop looking for default config filenames when one is found

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -124,6 +124,7 @@ func New(opts ...Option) (*Context, error) {
 			if _, err := os.Stat(chk); err == nil {
 				ctx.Logger.Printf("no configuration file provided -- using %s", chk)
 				ctx.ConfigFile = chk
+				break
 			}
 		}
 	}


### PR DESCRIPTION
Previously, it would keep checking for possible config filenames if multiple ones existed.