### PR TITLE
Try removing LDFLAGS from ko build

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -24,4 +24,3 @@ builds:
   - -trimpath
   ldflags:
   - -extldflags "-static"
-  - "{{ .Env.LDFLAGS }}"


### PR DESCRIPTION
Just to make it easier to build the image on systems without LDFLAGS env, remove the last line form .ko.yaml.