### PR TITLE
Updated README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ the form of OCI container images with [apko][apko].
 
 ## Install
 
-Melange has a dependency on [Alpine Linux](https://www.alpinelinux.org/)
+Melange has a dependency on [apk-tools](https://gitlab.alpinelinux.org/alpine/apk-tools).
 tooling. Currently the easiest way to run melange is inside an Alpine VM or
 container. If you're on MacOS, you can use a Lima VM, as [documented for
 apko](https://github.com/chainguard-dev/apko/blob/main/mac/README.md).

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ the form of OCI container images with [apko][apko].
 ## Install
 
 Melange has a dependency on [apk-tools](https://gitlab.alpinelinux.org/alpine/apk-tools).
-tooling. Currently the easiest way to run melange is inside an Alpine VM or
+Currently the easiest way to run melange is inside an Alpine VM or
 container. If you're on MacOS, you can use a Lima VM, as [documented for
 apko](https://github.com/chainguard-dev/apko/blob/main/mac/README.md).
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,22 @@
 # melange
 
-Build APK packages using declarative pipelines!
+Build APK packages using declarative pipelines.
+
+Commonly used to provide custom packages for container images built with
+[apko][apko].
+
+Key features:
+
+ - **Pipeline-oriented builds.** Every step of the build pipeline is defined and
+   controlled by you, unlike traditional package managers which have distinct
+   phases.
+ - **Multi-architecture by default.** QEMU is used to emulate various
+   architectures, avoiding the need for cross-compilation steps.
 
 ## Why
 
 Secure software factories are the evolution of DevOps, allowing a
-user to prove the provenance of all artifacts that get incorporated
+user to prove the provenance of all artifacts incorporated
 into a software appliance.  By building and capturing software
 artifacts into packages, DevOps teams can manage their software
 artifacts as if they were any other component of an image.
@@ -15,16 +26,67 @@ the form of OCI container images with [apko][apko].
 
    [apko]: https://github.com/chainguard-dev/apko
 
-## How
+## Install
 
-To build an unsigned APK, use the `melange build` command:
+Melange has a dependency on [Alpine Linux](https://www.alpinelinux.org/)
+tooling. Currently the easiest way to run melange is inside an Alpine VM or
+container. If you're on MacOS, you can use a Lima VM, as [documented for
+apko](https://github.com/chainguard-dev/apko/blob/main/mac/README.md).
+
+## Quickstart
+
+A melange build file looks like:
+
+```
+package:
+  name: hello
+  version: 2.12
+  epoch: 0
+  description: "the GNU hello world program"
+  target-architecture:
+    - all
+  copyright:
+    - paths:
+      - "*"
+      attestation: |
+        Copyright 1992, 1995, 1996, 1997, 1998, 1999, 2000, 2001, 2002, 2005,
+        2006, 2007, 2008, 2010, 2011, 2013, 2014, 2022 Free Software Foundation,
+        Inc.
+      license: GPL-3.0-or-later
+  dependencies:
+    runtime:
+
+environment:
+  contents:
+    repositories:
+      - https://dl-cdn.alpinelinux.org/alpine/edge/main
+    packages:
+      - alpine-baselayout-data
+      - busybox
+      - build-base
+      - scanelf
+      - ssl_client
+      - ca-certificates-bundle
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://ftp.gnu.org/gnu/hello/hello-${{package.version}}.tar.gz
+      expected-sha256: cf04af86dc085268c5f4470fbae49b18afbc221b78096aab842d934a76bad0ab
+  - uses: autoconf/configure
+  - uses: autoconf/make
+  - uses: autoconf/make-install
+  - uses: strip
+```
+
+We can build this with:
 
     # melange build examples/gnu-hello.yaml
 
-This will create a set of APKs for every architecture supported
-by the package.  You can use `--arch $(uname -m)` to bound the
-architecture set to only the current system architecture if
-desired.
+This will create a `packages` folder, with an entry for each architecture
+supported by the package. If you only want to build for the current
+architecture, `--arch $(uname -m)`. Inside the architecture directory will be
+APK files for each package built in the pipeline.
 
 If you want to sign your APKs, create a signing key with the
 `melange keygen` command:
@@ -39,23 +101,17 @@ And then pass the `--signing-key` argument to `melange build`.
 You can also sign APK indexes (generated with the `apk index`
 command) using `melange sign-index`.
 
-## Features
+## Usage with apko
 
-### Multi-architecture builds by default.
-
-No having to fuss with cross-compilation, like BuildKit, Melange
-supports the use of QEMU to emulate various architectures, usually
-at half-native speed.
-
-### Pipeline oriented builds.
-
-Every step of the build pipeline is defined and controlled by you,
-unlike traditional package managers which have distinct phases.
-
-Implement whatever build logic you want!
+To use a melange built APK in apko, either upload it to a package repository or
+use a "local" repository. Using a local repository allows a melange build and
+apko build to run in the same directory (or GitHub repo) without using external
+storage. An example of this approach can be seen in the [nginx-image-demo
+repo](https://github.com/chainguard-dev/nginx-image-demo/). 
 
 ### Coming soon: Keyless signatures
 
-We are working to enable keyless signatures using Sigstore Fulcio,
-which can be used with traditional signed indices to remove the need
-to have sensitive key material inside the build environment.
+We are working to enable keyless signatures using [Sigstore
+Fulcio](https://github.com/SigStore/fulcio), which can be used with traditional
+signed indices to remove the need to have sensitive key material inside the
+build environment.


### PR DESCRIPTION
I mainly moved things about and extended the example. Plus some installation instructions (not enough really, I'll extend when we have a development image).

I was considering removing this section:

>"Secure software factories are the evolution of DevOps, allowing a
>user to prove the provenance of all artifacts incorporated
>into a software appliance.  By building and capturing software
>artifacts into packages, DevOps teams can manage their software
>artifacts as if they were any other component of an image."

I like the writing, but it feels like the beginning of a blog rather than a README. Anyway, I've left it for the moment.
