### PR TITLE
Add devenv setup similar to apko

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,8 @@
 # Dependency directories (remove the comment below to include it)
 # vendor/
 .vscode/*
+
+melange
+melange-devenv-apko.yaml
+apko/
+workspace/

--- a/README.md
+++ b/README.md
@@ -101,6 +101,18 @@ And then pass the `--signing-key` argument to `melange build`.
 You can also sign APK indexes (generated with the `apk index`
 command) using `melange sign-index`.
 
+The quickest way to get an environment for running apko on Mac or Linux is to clone the repo and use the scripts under the hack
+directory:
+
+```
+$ ./hack/make-devenv.sh
+...
+[melange] ❯ make install
+...
+[melange] ❯ melange build examples/gnu-hello.yaml --arch x86_64
+...
+```
+
 ## Usage with apko
 
 To use a melange built APK in apko, either upload it to a package repository or

--- a/hack/make-devenv.sh
+++ b/hack/make-devenv.sh
@@ -1,0 +1,102 @@
+#!/bin/sh
+
+# Copyright 2022 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+BUILDER_ALPINE_TAG="3.16.0@sha256:4ff3ca91275773af45cb4b0834e12b7eb47d1c18f770a0b151381cd227f4c253"
+DEVENV_IMAGE_TARBALL="melange-devenv.tar.gz"
+IMAGE_TAG="melange-devenv"
+APKO_REPO="${APKO_REPO:-"https://github.com/chainguard-dev/apko.git"}"
+APKO_REF="${APKO_REF:-main}"
+
+checkrepo() {
+    grep "module chainguard.dev/melange" go.mod &> /dev/null && return
+    echo;
+    echo "Please run me from the melange repository root. Thank you!";
+    echo
+    exit 1;
+}
+
+run_builder() {
+    if ! (docker inspect ${IMAGE_TAG}:latest &> /dev/null ); then
+        set -e
+        mkdir _output > /dev/null 2>&1 || : 
+        docker run --rm -v $(pwd):/melange -w /melange -ti \
+            -e BUILD_UID=$(id -u) -e BUILD_GID=$(id -g) \
+            alpine:${BUILDER_ALPINE_TAG} \
+            /bin/sh hack/make-devenv.sh build_image
+        load_image
+        rm _output/${DEVENV_IMAGE_TARBALL}
+    fi
+    run
+}
+
+build_image() {
+    set -e
+    cat /etc/os-release
+
+    # Install apko and build devenv ... using apko
+    rm -f melange-devenv-apko.yaml
+    cat <<EOT > melange-devenv-apko.yaml
+contents:
+  repositories:
+    - https://dl-cdn.alpinelinux.org/alpine/edge/main
+    - https://dl-cdn.alpinelinux.org/alpine/edge/community
+    - https://dl-cdn.alpinelinux.org/alpine/edge/testing
+  packages:
+    - go
+    - cosign
+    - build-base
+    - git
+    - bubblewrap
+    - alpine-base
+    - jq
+    - tree
+    - make
+    - docker-cli
+  entrypoint:
+    command: /bin/sh -l
+EOT
+    rm -rf apko
+    apk add git go
+    git clone "${APKO_REPO}" -b "${APKO_REF}"
+    (cd apko && go run main.go build --sbom=false ../melange-devenv-apko.yaml ${IMAGE_TAG} ../_output/${DEVENV_IMAGE_TARBALL})
+    rm -rf apko
+
+    chown ${BUILD_UID}:${BUILD_GID} _output/${DEVENV_IMAGE_TARBALL}
+}
+
+load_image() {
+    set -e
+    docker rmi ${IMAGE_TAG}:latest 2>&1 || :
+    docker load < _output/${DEVENV_IMAGE_TARBALL}
+}
+
+run() {
+    docker run --rm -w /melange -v $(pwd):/melange -ti \
+        --cap-add NET_ADMIN --cap-add SYS_ADMIN \
+        --security-opt seccomp=unconfined --security-opt apparmor:unconfined \
+        ${IMAGE_TAG}:latest hack/make-devenv.sh setup
+}
+
+setup() {
+    echo
+    echo "Welcome to the melange development environment!"
+    echo
+    echo
+    alias ll="ls -l"
+    export PS1="[melange] ❯ "
+    sh -i
+}
+
+checkrepo
+case "$1" in
+    "")
+        run_builder;;
+    "build_image")
+        build_image;;
+    "run")
+        run;;
+    "setup")
+        setup;;
+esac


### PR DESCRIPTION
Just worked on this.. but did not see #23 until now!

The `melange build` example currently fails with
```
2022/07/01 00:14:59 melange (hello/s390x): bwrap: Creating new namespace failed: Invalid argument
Error: failed to build package: unable to run pipeline: exit status 1
```
