### PR TITLE
build: use a temporary directory for workspace by default

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -112,7 +112,6 @@ type Dependencies struct {
 
 func New(opts ...Option) (*Context, error) {
 	ctx := Context{
-		WorkspaceDir:    "./workspace",
 		WorkspaceIgnore: ".melangeignore",
 		PipelineDir:     "/usr/share/melange/pipelines",
 		SourceDir:       ".",
@@ -125,6 +124,19 @@ func New(opts ...Option) (*Context, error) {
 		if err := opt(&ctx); err != nil {
 			return nil, err
 		}
+	}
+
+	// If no workspace directory is explicitly requested, create a
+	// temporary directory for it.  Otherwise, ensure we are in a
+	// subdir for this specific build context.
+	if ctx.WorkspaceDir != "" {
+		ctx.WorkspaceDir = filepath.Join(ctx.WorkspaceDir, ctx.Arch.ToAPK())
+	} else {
+		tmpdir, err := os.MkdirTemp("", "melange-workspace-*")
+		if err != nil {
+			return nil, fmt.Errorf("unable to create workspace dir: %w", err)
+		}
+		ctx.WorkspaceDir = tmpdir
 	}
 
 	// If no config file is explicitly requested for the build context
@@ -164,7 +176,6 @@ func New(opts ...Option) (*Context, error) {
 		ctx.SourceDateEpoch = time.Unix(sec, 0)
 	}
 
-	ctx.WorkspaceDir = filepath.Join(ctx.WorkspaceDir, ctx.Arch.ToAPK())
 	ctx.Logger.SetPrefix(fmt.Sprintf("melange (%s/%s): ", ctx.Configuration.Package.Name, ctx.Arch.ToAPK()))
 
 	return &ctx, nil

--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -81,7 +81,7 @@ func Build() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&buildDate, "build-date", "", "date used for the timestamps of the files inside the image")
-	cmd.Flags().StringVar(&workspaceDir, "workspace-dir", filepath.Join(cwd, "workspace"), "directory used for the workspace at /home/build")
+	cmd.Flags().StringVar(&workspaceDir, "workspace-dir", "", "directory used for the workspace at /home/build")
 	cmd.Flags().StringVar(&pipelineDir, "pipeline-dir", "/usr/share/melange/pipelines", "directory used to store defined pipelines")
 	cmd.Flags().StringVar(&sourceDir, "source-dir", "", "directory used for included sources")
 	cmd.Flags().StringVar(&signingKey, "signing-key", "", "key to use for signing")


### PR DESCRIPTION
In the very early days of melange, we defaulted to use the current
directory as the workspace directory.  This had a lot of problems,
and evolved to ./workspace instead.

When copying from the source directory to the workspace was
implemented, this resulted in workspaces being copied over.

Using a temporary directory also ensures that the build begins
from a clean state every time.

Fixes #66.
Fixes #73.