### PR TITLE
make install: work around CVE-2022-24765

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ melange: $(SRCS) ## Builds melange
 	CGO_ENABLED=0 go build -trimpath -ldflags "$(LDFLAGS)" -o $@ ./
 
 .PHONY: install
-install: $(SRCS) melange ## Builds and moves melange into BINDIR (default /usr/bin)
+install: $(SRCS) ## Installs melange into BINDIR (default /usr/bin)
 	install -Dm755 melange ${DESTDIR}${BINDIR}/melange
 	install -dm755 ${DESTDIR}/usr/share/melange/pipelines
 	tar c -C pipelines . | tar x -C "${DESTDIR}/usr/share/melange/pipelines"


### PR DESCRIPTION
previously, we made sure melange was already built.
thanks to CVE-2022-24765, rebuilding melange as a different user,
e.g. root, is no longer possible, so just make the install step
install only