### PR TITLE
Add note to README on how to get a dev env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@
 # Dependency directories (remove the comment below to include it)
 # vendor/
 .vscode/*
+
+melange

--- a/README.md
+++ b/README.md
@@ -101,6 +101,23 @@ And then pass the `--signing-key` argument to `melange build`.
 You can also sign APK indexes (generated with the `apk index`
 command) using `melange sign-index`.
 
+The quickest way to get an environment for running melange on Mac or Linux
+is to clone the repo and run the following:
+
+```
+docker run --rm -w "${PWD}" -v "${PWD}:${PWD}" -ti --privileged --entrypoint sh \
+  distroless.dev/melange:latest -c \
+    'apk add make --force-broken-world && \
+      apk add go --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community --force-broken-world && \
+      printf "\nWelcome to the melange development environment!\n\n\n" && \
+      export PS1="[melange] ❯ " && sh -i'
+```
+
+Then inside the environment, to re-build/re-install melange with local changes:
+```
+make melange install
+```
+
 ## Usage with apko
 
 To use a melange built APK in apko, either upload it to a package repository or


### PR DESCRIPTION
This replaces #23 and #76

If we were to add make and go into the melange image, then this could be even simpler