### PR TITLE
Add --template flag to melange build

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.18
 
 require (
 	chainguard.dev/apko v0.4.1-0.20220701165036-c5450771a18e
+	github.com/google/go-cmp v0.5.8
 	github.com/psanford/memfs v0.0.0-20210214183328-a001468d78ef
 	github.com/spf13/cobra v1.5.0
 	github.com/stretchr/testify v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -851,6 +851,7 @@ github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
+github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-containerregistry v0.7.1-0.20211118220127-abdc633f8305/go.mod h1:6cMIl1RfryEiPzBE67OgtZdEiLWz4myqCQIiBMy3CsM=
 github.com/google/go-containerregistry v0.10.0 h1:qd/fv2nQajGZJenaNcdaghlwSPjQ0NphN9hzArr2WWg=
 github.com/google/go-containerregistry v0.10.0/go.mod h1:C7uwbB1QUAtvnknyd3ethxJRd4gtEjU/9WLXzckfI1Y=

--- a/pkg/build/build_test.go
+++ b/pkg/build/build_test.go
@@ -1,0 +1,147 @@
+// Copyright 2022 Chainguard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build
+
+import (
+	"io/ioutil"
+	"path/filepath"
+	"testing"
+
+	apko_types "chainguard.dev/apko/pkg/build/types"
+	"github.com/google/go-cmp/cmp"
+)
+
+const defaultTemplateYaml = `package:
+  name: nginx
+  version: 100
+`
+
+const templatized = `package:
+  name: {{ .Package }}
+  version: {{ .Version }}
+`
+
+func TestApplyTemplate(t *testing.T) {
+	tests := []struct {
+		description string
+		contents    string
+		template    string
+		expected    string
+		shouldErr   bool
+	}{
+		{
+			description: "no template",
+			contents:    defaultTemplateYaml,
+			expected:    defaultTemplateYaml,
+		}, {
+			description: "valid template",
+			contents:    templatized,
+			template:    `{"Package": "nginx", "Version": 100}`,
+			expected:    defaultTemplateYaml,
+		}, {
+			description: "incomplete template",
+			contents:    templatized,
+			template:    `{"Package": "nginx"}`,
+			shouldErr:   true,
+		}, {
+			description: "invalid template",
+			contents:    templatized,
+			template:    `{"Package": "nginx", "Version": 100`,
+			shouldErr:   true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			actual, err := applyTemplate([]byte(test.contents), test.template)
+			if err != nil && test.shouldErr {
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if d := cmp.Diff(string(actual), test.expected); d != "" {
+				t.Fatalf("actual didn't match expected: %s", d)
+			}
+		})
+	}
+}
+
+func TestLoadConfiguration(t *testing.T) {
+	expected := &Configuration{
+		Package: Package{Name: "nginx", Version: "100"},
+	}
+	expected.Environment.Accounts.Users = []apko_types.User{{
+		UserName: "build",
+		UID:      1000,
+		GID:      1000,
+	}}
+	expected.Environment.Accounts.Groups = []apko_types.Group{{
+		GroupName: "build",
+		GID:       1000,
+		Members:   []string{"build"},
+	}}
+
+	tests := []struct {
+		description string
+		contents    string
+		template    string
+		expected    *Configuration
+		shouldErr   bool
+	}{
+		{
+			description: "no template",
+			contents:    defaultTemplateYaml,
+			expected:    expected,
+		}, {
+			description: "valid template",
+			contents:    templatized,
+			template:    `{"Package": "nginx", "Version": 100}`,
+			expected:    expected,
+		}, {
+			description: "incomplete template",
+			contents:    templatized,
+			template:    `{"Package": "nginx"}`,
+			shouldErr:   true,
+		}, {
+			description: "invalid template",
+			contents:    templatized,
+			template:    `{"Hello": "world"}`,
+			shouldErr:   true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			dir := t.TempDir()
+			f := filepath.Join(dir, "config")
+			if err := ioutil.WriteFile(f, []byte(test.contents), 0755); err != nil {
+				t.Fatal(err)
+			}
+
+			cfg := &Configuration{}
+			err := cfg.Load(f, test.template)
+			if test.shouldErr && err == nil {
+				t.Fatal("expected test to fail but it passed")
+			}
+			if test.shouldErr {
+				return
+			}
+			if d := cmp.Diff(cfg, test.expected); d != "" {
+				t.Fatalf("actual didn't match expected: %s", d)
+			}
+		})
+	}
+}

--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -39,6 +39,7 @@ func Build() *cobra.Command {
 	var archstrs []string
 	var extraKeys []string
 	var extraRepos []string
+	var template string
 
 	cmd := &cobra.Command{
 		Use:     "build",
@@ -58,6 +59,7 @@ func Build() *cobra.Command {
 				build.WithOutDir(outDir),
 				build.WithExtraKeys(extraKeys),
 				build.WithExtraRepos(extraRepos),
+				build.WithTemplate(template),
 			}
 
 			if len(args) > 0 {
@@ -89,6 +91,7 @@ func Build() *cobra.Command {
 	cmd.Flags().BoolVar(&useProot, "use-proot", false, "whether to use proot for fakeroot")
 	cmd.Flags().BoolVar(&emptyWorkspace, "empty-workspace", false, "whether the build workspace should be empty")
 	cmd.Flags().StringVar(&outDir, "out-dir", filepath.Join(cwd, "packages"), "directory where packages will be output")
+	cmd.Flags().StringVar(&template, "template", "", "template to apply to melange config (optional)")
 	cmd.Flags().StringSliceVar(&archstrs, "arch", nil, "architectures to build for (e.g., x86_64,ppc64le,arm64) -- default is all, unless specified in config.")
 	cmd.Flags().StringSliceVarP(&extraKeys, "keyring-append", "k", []string{}, "path to extra keys to include in the build environment keyring")
 	cmd.Flags().StringSliceVarP(&extraRepos, "repository-append", "r", []string{}, "path to extra repositories to include in the build environment")


### PR DESCRIPTION
I'm thinking this will make it easier to build and release multiple versions of the same package  (e.g. nginx:1.20.3, nginx:1.20). 

My plan is that in CI, we can use the Github actions [matrix strategy](https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#using-a-matrix-strategy) to run the melange/apko jobs for different versions of the same package. The specific version can passed in via the flag, and will be applied to `melange.yaml` in code: 

So, melange.yaml could look like this:

```
package:
  name: nginx
  version: {{ .Version }}
```

and we'd pass in 
```
melange build --template '{"Version": "1.20.3"}'
```

Signed-off-by: Priya Wadhwa <priya@chainguard.dev>