### PR TITLE
Fix bug in template, clashing with pipeline substitutions

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -353,7 +353,7 @@ func applyTemplate(contents []byte, t string) ([]byte, error) {
 	if err := json.Unmarshal([]byte(t), &i); err != nil {
 		return nil, err
 	}
-	tmpl, err := template.New("template").Parse(string(contents))
+	tmpl, err := template.New("template").Delims("[[", "]]").Parse(string(contents))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/build/build_test.go
+++ b/pkg/build/build_test.go
@@ -26,11 +26,13 @@ import (
 const defaultTemplateYaml = `package:
   name: nginx
   version: 100
+  test: ${{package.name}}
 `
 
 const templatized = `package:
-  name: {{ .Package }}
-  version: {{ .Version }}
+  name: [[ .Package ]]
+  version: [[ .Version ]]
+  test: ${{package.name}}
 `
 
 func TestApplyTemplate(t *testing.T) {

--- a/pkg/build/build_test.go
+++ b/pkg/build/build_test.go
@@ -30,8 +30,8 @@ const defaultTemplateYaml = `package:
 `
 
 const templatized = `package:
-  name: [[ .Package ]]
-  version: [[ .Version ]]
+  name: {{ .Package }}
+  version: {{ .Version }}
   test: ${{package.name}}
 `
 
@@ -145,5 +145,22 @@ func TestLoadConfiguration(t *testing.T) {
 				t.Fatalf("actual didn't match expected: %s", d)
 			}
 		})
+	}
+}
+
+// Makes sure the substitution map in pipeline.go matches the one in build.go
+// TODO: priyawadhwa@, it would be better to use a single map so we don't risk losing substitutions
+func TestSubstitutionReplacementMap(t *testing.T) {
+	pipelineMap := substitutionMap(&PipelineContext{
+		Package:    &Package{Name: "package"},
+		Subpackage: &Subpackage{Name: "subpackage"},
+	})
+	buildMap := substitutionReplacements()
+
+	// make sure all the keys in pipelineMap exist in buildMap
+	for k := range pipelineMap {
+		if _, ok := buildMap[k]; !ok {
+			t.Fatalf("please add %s to substitutionReplacements() in build.go", k)
+		}
 	}
 }


### PR DESCRIPTION
the pipeline provides some vars which we replace in code:

```
"${{package.name}}"
"${{package.version}}"
"${{package.epoch}}"
"${{targets.destdir}}"
```
Any config file with these is panicking out w/ template bc it doesn't know how to parse them. Unfortunately go templates don't allow ignoring certain values (TIL a proposal was denied https://github.com/golang/go/issues/31147) 

There are a couple options:
1. change the delimiter from `{{ }}` to `[[ ]]` so go templates can differentiate.
2. do an ugly string substitution before applying the go template and then reset it

I started with (1) but figured that would be really inconvenient for users so switched to (2)

Signed-off-by: Priya Wadhwa <priya@chainguard.dev>