### PR TITLE
dependency logging feature

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -107,6 +107,7 @@ type Context struct {
 	Arch              apko_types.Architecture
 	ExtraKeys         []string
 	ExtraRepos        []string
+	DependencyLog     string
 	ignorePatterns    []*xignore.Pattern
 }
 
@@ -309,6 +310,14 @@ func WithExtraRepos(extraRepos []string) Option {
 func WithTemplate(template string) Option {
 	return func(ctx *Context) error {
 		ctx.Template = template
+		return nil
+	}
+}
+
+// WithDependencyLog sets a filename to use for dependency logging.
+func WithDependencyLog(logFile string) Option {
+	return func(ctx *Context) error {
+		ctx.DependencyLog = logFile
 		return nil
 	}
 }

--- a/pkg/build/package.go
+++ b/pkg/build/package.go
@@ -20,6 +20,7 @@ import (
 	"crypto/sha256"
 	"debug/elf"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"hash"
 	"io"
@@ -213,6 +214,18 @@ func generateCmdProviders(pc *PackageContext, generated *Dependencies) error {
 func generateSharedObjectNameDeps(pc *PackageContext, generated *Dependencies) error {
 	pc.Logger.Printf("scanning for shared object dependencies...")
 
+	deplog := &io.Discard
+
+	if pc.Context.DependencyLog != "" {
+		deplog, err := os.Create(pc.Context.DependencyLog)
+		if err != nil {
+			pc.Logger.Printf("WARNING: Unable to open dependency log: %v", err)
+		}
+		defer deplog.Close()
+	}
+
+	depends := map[string][]string{}
+
 	fsys := apkofs.DirFS(pc.WorkspaceSubdir())
 	if err := fs.WalkDir(fsys, ".", func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
@@ -250,6 +263,7 @@ func generateSharedObjectNameDeps(pc *PackageContext, generated *Dependencies) e
 			for _, lib := range libs {
 				if strings.Contains(lib, ".so.") {
 					generated.Runtime = append(generated.Runtime, fmt.Sprintf("so:%s", lib))
+					depends[lib] = append(depends[lib], path)
 				}
 			}
 
@@ -278,6 +292,11 @@ func generateSharedObjectNameDeps(pc *PackageContext, generated *Dependencies) e
 
 		return nil
 	}); err != nil {
+		return err
+	}
+
+	je := json.NewEncoder(*deplog)
+	if err := je.Encode(depends); err != nil {
 		return err
 	}
 

--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -40,6 +40,7 @@ func Build() *cobra.Command {
 	var extraKeys []string
 	var extraRepos []string
 	var template string
+	var dependencyLog string
 
 	cmd := &cobra.Command{
 		Use:     "build",
@@ -60,6 +61,7 @@ func Build() *cobra.Command {
 				build.WithExtraKeys(extraKeys),
 				build.WithExtraRepos(extraRepos),
 				build.WithTemplate(template),
+				build.WithDependencyLog(dependencyLog),
 			}
 
 			if len(args) > 0 {
@@ -92,6 +94,7 @@ func Build() *cobra.Command {
 	cmd.Flags().BoolVar(&emptyWorkspace, "empty-workspace", false, "whether the build workspace should be empty")
 	cmd.Flags().StringVar(&outDir, "out-dir", filepath.Join(cwd, "packages"), "directory where packages will be output")
 	cmd.Flags().StringVar(&template, "template", "", "template to apply to melange config (optional)")
+	cmd.Flags().StringVar(&dependencyLog, "dependency-log", "", "log dependencies to a specified file")
 	cmd.Flags().StringSliceVar(&archstrs, "arch", nil, "architectures to build for (e.g., x86_64,ppc64le,arm64) -- default is all, unless specified in config.")
 	cmd.Flags().StringSliceVarP(&extraKeys, "keyring-append", "k", []string{}, "path to extra keys to include in the build environment keyring")
 	cmd.Flags().StringSliceVarP(&extraRepos, "repository-append", "r", []string{}, "path to extra repositories to include in the build environment")


### PR DESCRIPTION
This adds a new option `--dependency-log` to `melange build`, which dumps a dependency graph sorted by SONAME (e.g. `libc.so.6: [...]`).  It is intended to be used for debugging why an unexpected SONAME dependency is detected during a build.