### PR TITLE
add support for overlaid /bin/sh

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -549,6 +549,7 @@ func (ctx *Context) OverlayBinSh() error {
 	if err != nil {
 		return fmt.Errorf("copying overlay /bin/sh: %w", err)
 	}
+	defer outF.Close()
 
 	if _, err := io.Copy(outF, inF); err != nil {
 		return fmt.Errorf("copying overlay /bin/sh: %w", err)

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -108,6 +108,7 @@ type Context struct {
 	ExtraKeys         []string
 	ExtraRepos        []string
 	DependencyLog     string
+	BinShOverlay      string
 	ignorePatterns    []*xignore.Pattern
 }
 
@@ -318,6 +319,15 @@ func WithTemplate(template string) Option {
 func WithDependencyLog(logFile string) Option {
 	return func(ctx *Context) error {
 		ctx.DependencyLog = logFile
+		return nil
+	}
+}
+
+// WithBinShOverlay sets a filename to copy from when installing /bin/sh
+// into a build environment.
+func WithBinShOverlay(binShOverlay string) Option {
+	return func(ctx *Context) error {
+		ctx.BinShOverlay = binShOverlay
 		return nil
 	}
 }

--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -41,6 +41,7 @@ func Build() *cobra.Command {
 	var extraRepos []string
 	var template string
 	var dependencyLog string
+	var overlayBinSh string
 
 	cmd := &cobra.Command{
 		Use:     "build",
@@ -62,6 +63,7 @@ func Build() *cobra.Command {
 				build.WithExtraRepos(extraRepos),
 				build.WithTemplate(template),
 				build.WithDependencyLog(dependencyLog),
+				build.WithBinShOverlay(overlayBinSh),
 			}
 
 			if len(args) > 0 {
@@ -95,6 +97,7 @@ func Build() *cobra.Command {
 	cmd.Flags().StringVar(&outDir, "out-dir", filepath.Join(cwd, "packages"), "directory where packages will be output")
 	cmd.Flags().StringVar(&template, "template", "", "template to apply to melange config (optional)")
 	cmd.Flags().StringVar(&dependencyLog, "dependency-log", "", "log dependencies to a specified file")
+	cmd.Flags().StringVar(&overlayBinSh, "overlay-binsh", "", "use specified file as /bin/sh overlay in build environment")
 	cmd.Flags().StringSliceVar(&archstrs, "arch", nil, "architectures to build for (e.g., x86_64,ppc64le,arm64) -- default is all, unless specified in config.")
 	cmd.Flags().StringSliceVarP(&extraKeys, "keyring-append", "k", []string{}, "path to extra keys to include in the build environment keyring")
 	cmd.Flags().StringSliceVarP(&extraRepos, "repository-append", "r", []string{}, "path to extra repositories to include in the build environment")


### PR DESCRIPTION
This can be used to speed up QEMU builds by overlaying a native `/bin/sh`.  As the overlay is strictly for /bin/sh, it has no noticeable effects on the build environment itself.

The overlay `/bin/sh` must be staticly linked, as it is running inside the build environment.

For example, it is possible to do: `melange build --overlay-binsh /bin/busybox.static` on Alpine to speed up QEMU builds.