### PR TITLE
Automatically index and sign on build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@
 .vscode/*
 
 melange
+melange.rsa
+melange.rsa.pub
+packages/

--- a/examples/minimal.yaml
+++ b/examples/minimal.yaml
@@ -1,0 +1,15 @@
+package:
+  name: minimal
+  version: 0.0.1
+  description: a very basic melange example
+environment:
+  contents:
+    repositories:
+      - https://dl-cdn.alpinelinux.org/alpine/edge/main
+    packages:
+      - alpine-baselayout-data
+      - busybox
+pipeline:
+  - runs: |
+      mkdir -p "${{targets.destdir}}"
+      echo "hello" > "${{targets.destdir}}/hello"

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -1,0 +1,58 @@
+// Copyright 2022 Chainguard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package index
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"os"
+
+	apkrepo "gitlab.alpinelinux.org/alpine/go/repository"
+)
+
+// TODO: solidify this API and move into pkg/
+func Index(logger *log.Logger, apkIndexFilename string, apkFiles []string) error {
+	packages := []*apkrepo.Package{}
+	for _, apkFile := range apkFiles {
+		logger.Printf("processing package %s", apkFile)
+		f, err := os.Open(apkFile)
+		if err != nil {
+			return fmt.Errorf("failed to open package %s: %w", apkFile, err)
+		}
+		pkg, err := apkrepo.ParsePackage(f)
+		if err != nil {
+			return fmt.Errorf("failed to parse package %s: %w", apkFile, err)
+		}
+		packages = append(packages, pkg)
+	}
+	index := &apkrepo.ApkIndex{
+		Packages: packages,
+	}
+	logger.Printf("generating index at %s", apkIndexFilename)
+	archive, err := apkrepo.ArchiveFromIndex(index)
+	if err != nil {
+		return fmt.Errorf("failed to create archive from index object: %w", err)
+	}
+	outFile, err := os.Create(apkIndexFilename)
+	if err != nil {
+		return fmt.Errorf("failed to create archive file: %w", err)
+	}
+	defer outFile.Close()
+	if _, err = io.Copy(outFile, archive); err != nil {
+		return fmt.Errorf("failed to write contents to archive file: %w", err)
+	}
+	return nil
+}

--- a/internal/sign/sign.go
+++ b/internal/sign/sign.go
@@ -1,0 +1,142 @@
+// Copyright 2022 Chainguard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sign
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"crypto/sha1" // nolint:gosec
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"chainguard.dev/apko/pkg/tarball"
+	"github.com/psanford/memfs"
+)
+
+// TODO: solidify this API and move into pkg/
+func SignIndex(logger *log.Logger, signingKey string, indexFile string) error {
+	if indexIsAlreadySigned(indexFile) {
+		logger.Printf("index %s is already signed, doing nothing", indexFile)
+		return nil
+	}
+
+	logger.Printf("signing index %s with key %s", indexFile, signingKey)
+
+	indexData, indexDigest, err := readAndHashIndex(indexFile)
+	if err != nil {
+		return err
+	}
+
+	sigData, err := RSASignSHA1Digest(indexDigest, signingKey, "")
+	if err != nil {
+		return fmt.Errorf("unable to sign index: %w", err)
+	}
+
+	logger.Printf("appending signature to index %s", indexFile)
+
+	sigFS := memfs.New()
+	if err := sigFS.WriteFile(fmt.Sprintf(".SIGN.RSA.%s.pub", filepath.Base(signingKey)), sigData, 0644); err != nil {
+		return fmt.Errorf("unable to append signature: %w", err)
+	}
+
+	// prepare control.tar.gz
+	multitarctx, err := tarball.NewContext(
+		tarball.WithOverrideUIDGID(0, 0),
+		tarball.WithOverrideUname("root"),
+		tarball.WithOverrideGname("root"),
+		tarball.WithSkipClose(true),
+	)
+	if err != nil {
+		return fmt.Errorf("unable to build tarball context: %w", err)
+	}
+
+	logger.Printf("writing signed index to %s", indexFile)
+
+	var sigBuffer bytes.Buffer
+	if err := multitarctx.WriteArchive(&sigBuffer, sigFS); err != nil {
+		return fmt.Errorf("unable to write signature tarball: %w", err)
+	}
+
+	idx, err := os.Create(indexFile)
+	if err != nil {
+		return fmt.Errorf("unable to open index for writing: %w", err)
+	}
+	defer idx.Close()
+
+	if _, err := io.Copy(idx, &sigBuffer); err != nil {
+		return fmt.Errorf("unable to write index signature: %w", err)
+	}
+
+	if _, err := idx.Write(indexData); err != nil {
+		return fmt.Errorf("unable to write index data: %w", err)
+	}
+
+	logger.Printf("signed index %s with key %s", indexFile, signingKey)
+
+	return nil
+}
+
+func indexIsAlreadySigned(indexFile string) bool {
+	index, err := os.Open(indexFile)
+	if err != nil {
+		log.Fatalf("cannot open index %s: %v", indexFile, err)
+	}
+	defer index.Close()
+
+	gzi, err := gzip.NewReader(index)
+	if err != nil {
+		log.Fatalf("cannot open index %s: %v", indexFile, err)
+	}
+	defer gzi.Close()
+
+	tari := tar.NewReader(gzi)
+	for {
+		hdr, err := tari.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			log.Fatalf("cannot read index %s: %v", indexFile, err)
+		}
+
+		if strings.HasPrefix(hdr.Name, ".SIGN.RSA") {
+			return true
+		}
+	}
+
+	return false
+}
+
+func readAndHashIndex(indexFile string) ([]byte, []byte, error) {
+	index, err := os.Open(indexFile)
+	if err != nil {
+		return nil, nil, fmt.Errorf("unable to open index for signing: %w", err)
+	}
+	defer index.Close()
+
+	digest := sha1.New() // nolint:gosec
+	hasher := io.TeeReader(index, digest)
+	indexBuf, err := io.ReadAll(hasher)
+	if err != nil {
+		return nil, nil, fmt.Errorf("unable to read index: %w", err)
+	}
+
+	return indexBuf, digest.Sum(nil), nil
+}

--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -33,6 +33,7 @@ func Build() *cobra.Command {
 	var pipelineDir string
 	var sourceDir string
 	var signingKey string
+	var generateIndex bool
 	var useProot bool
 	var emptyWorkspace bool
 	var outDir string
@@ -56,6 +57,7 @@ func Build() *cobra.Command {
 				build.WithWorkspaceDir(workspaceDir),
 				build.WithPipelineDir(pipelineDir),
 				build.WithSigningKey(signingKey),
+				build.WithGenerateIndex(generateIndex),
 				build.WithUseProot(useProot),
 				build.WithEmptyWorkspace(emptyWorkspace),
 				build.WithOutDir(outDir),
@@ -92,6 +94,7 @@ func Build() *cobra.Command {
 	cmd.Flags().StringVar(&pipelineDir, "pipeline-dir", "/usr/share/melange/pipelines", "directory used to store defined pipelines")
 	cmd.Flags().StringVar(&sourceDir, "source-dir", "", "directory used for included sources")
 	cmd.Flags().StringVar(&signingKey, "signing-key", "", "key to use for signing")
+	cmd.Flags().BoolVar(&generateIndex, "generate-index", true, "whether to generate APKINDEX.tar.gz")
 	cmd.Flags().BoolVar(&useProot, "use-proot", false, "whether to use proot for fakeroot")
 	cmd.Flags().BoolVar(&emptyWorkspace, "empty-workspace", false, "whether the build workspace should be empty")
 	cmd.Flags().StringVar(&outDir, "out-dir", filepath.Join(cwd, "packages"), "directory where packages will be output")

--- a/pkg/cli/index.go
+++ b/pkg/cli/index.go
@@ -16,13 +16,11 @@ package cli
 
 import (
 	"context"
-	"fmt"
-	"io"
 	"log"
-	"os"
 
 	"github.com/spf13/cobra"
-	apkrepo "gitlab.alpinelinux.org/alpine/go/repository"
+
+	"chainguard.dev/melange/internal/index"
 )
 
 func Index() *cobra.Command {
@@ -42,32 +40,5 @@ func Index() *cobra.Command {
 }
 
 func IndexCmd(ctx context.Context, apkIndexFilename string, apkFiles []string) error {
-	packages := []*apkrepo.Package{}
-	for _, apkFile := range apkFiles {
-		log.Printf("processing package %s", apkFile)
-		f, err := os.Open(apkFile)
-		if err != nil {
-			return fmt.Errorf("failed to open package %s: %w", apkFile, err)
-		}
-		pkg, err := apkrepo.ParsePackage(f)
-		if err != nil {
-			return fmt.Errorf("failed to parse package %s: %w", apkFile, err)
-		}
-		packages = append(packages, pkg)
-	}
-	index := &apkrepo.ApkIndex{
-		Packages: packages,
-	}
-	log.Printf("generating index at %s", apkIndexFilename)
-	archive, err := apkrepo.ArchiveFromIndex(index)
-	if err != nil {
-		return err
-	}
-	outFile, err := os.Create(apkIndexFilename)
-	if err != nil {
-		return err
-	}
-	defer outFile.Close()
-	_, err = io.Copy(outFile, archive)
-	return err
+	return index.Index(log.Default(), apkIndexFilename, apkFiles)
 }

--- a/pkg/cli/sign.go
+++ b/pkg/cli/sign.go
@@ -15,21 +15,10 @@
 package cli
 
 import (
-	"archive/tar"
-	"bytes"
-	"compress/gzip"
 	"context"
-	"crypto/sha1" // nolint:gosec
-	"fmt"
-	"io"
 	"log"
-	"os"
-	"path/filepath"
-	"strings"
 
-	"chainguard.dev/apko/pkg/tarball"
 	"chainguard.dev/melange/internal/sign"
-	"github.com/psanford/memfs"
 	"github.com/spf13/cobra"
 )
 
@@ -52,112 +41,6 @@ func SignIndex() *cobra.Command {
 	return cmd
 }
 
-func indexIsAlreadySigned(indexFile string) bool {
-	index, err := os.Open(indexFile)
-	if err != nil {
-		log.Fatalf("cannot open index %s: %v", indexFile, err)
-	}
-	defer index.Close()
-
-	gzi, err := gzip.NewReader(index)
-	if err != nil {
-		log.Fatalf("cannot open index %s: %v", indexFile, err)
-	}
-	defer gzi.Close()
-
-	tari := tar.NewReader(gzi)
-	for {
-		hdr, err := tari.Next()
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			log.Fatalf("cannot read index %s: %v", indexFile, err)
-		}
-
-		if strings.HasPrefix(hdr.Name, ".SIGN.RSA") {
-			return true
-		}
-	}
-
-	return false
-}
-
-func readAndHashIndex(indexFile string) ([]byte, []byte, error) {
-	index, err := os.Open(indexFile)
-	if err != nil {
-		return nil, nil, fmt.Errorf("unable to open index for signing: %w", err)
-	}
-	defer index.Close()
-
-	digest := sha1.New() // nolint:gosec
-	hasher := io.TeeReader(index, digest)
-	indexBuf, err := io.ReadAll(hasher)
-	if err != nil {
-		return nil, nil, fmt.Errorf("unable to read index: %w", err)
-	}
-
-	return indexBuf, digest.Sum(nil), nil
-}
-
 func SignIndexCmd(ctx context.Context, signingKey string, indexFile string) error {
-	if indexIsAlreadySigned(indexFile) {
-		log.Printf("index %s is already signed, doing nothing", indexFile)
-		return nil
-	}
-
-	log.Printf("signing index %s with key %s", indexFile, signingKey)
-
-	indexData, indexDigest, err := readAndHashIndex(indexFile)
-	if err != nil {
-		return err
-	}
-
-	sigData, err := sign.RSASignSHA1Digest(indexDigest, signingKey, "")
-	if err != nil {
-		return fmt.Errorf("unable to sign index: %w", err)
-	}
-
-	log.Printf("appending signature to index %s", indexFile)
-
-	sigFS := memfs.New()
-	if err := sigFS.WriteFile(fmt.Sprintf(".SIGN.RSA.%s.pub", filepath.Base(signingKey)), sigData, 0644); err != nil {
-		return fmt.Errorf("unable to append signature: %w", err)
-	}
-
-	// prepare control.tar.gz
-	multitarctx, err := tarball.NewContext(
-		tarball.WithOverrideUIDGID(0, 0),
-		tarball.WithOverrideUname("root"),
-		tarball.WithOverrideGname("root"),
-		tarball.WithSkipClose(true),
-	)
-	if err != nil {
-		return fmt.Errorf("unable to build tarball context: %w", err)
-	}
-
-	log.Printf("writing signed index to %s", indexFile)
-
-	var sigBuffer bytes.Buffer
-	if err := multitarctx.WriteArchive(&sigBuffer, sigFS); err != nil {
-		return fmt.Errorf("unable to write signature tarball: %w", err)
-	}
-
-	idx, err := os.Create(indexFile)
-	if err != nil {
-		return fmt.Errorf("unable to open index for writing: %w", err)
-	}
-	defer idx.Close()
-
-	if _, err := io.Copy(idx, &sigBuffer); err != nil {
-		return fmt.Errorf("unable to write index signature: %w", err)
-	}
-
-	if _, err := idx.Write(indexData); err != nil {
-		return fmt.Errorf("unable to write index data: %w", err)
-	}
-
-	log.Printf("signed index %s with key %s", indexFile, signingKey)
-
-	return nil
+	return sign.SignIndex(log.Default(), signingKey, indexFile)
 }


### PR DESCRIPTION
Add new flag --generate-index (defaulting to true) which will generate the index after build.

In addition, if --signing-key is provided, proceed to sign the index after it is generated.

Also moved index and signing code into internal/sign/in order to prevent circular dependency.

Lastly, added examples/minimal.yaml to have a melange build to quickly test these things with.
