### PR TITLE
fetch: support expected-sha512

### DIFF
--- a/pipelines/fetch.yaml
+++ b/pipelines/fetch.yaml
@@ -18,10 +18,12 @@ inputs:
   expected-sha256:
     description: |
       The expected SHA256 of the downloaded artifact.
+    default: ""
 
   expected-sha512:
     description: |
       The expected SHA512 of the downloaded artifact.
+    default: ""
 
   uri:
     description: |

--- a/pipelines/fetch.yaml
+++ b/pipelines/fetch.yaml
@@ -18,12 +18,12 @@ inputs:
   expected-sha256:
     description: |
       The expected SHA256 of the downloaded artifact.
-    default: ""
+    default: "NOTSET"
 
   expected-sha512:
     description: |
       The expected SHA512 of the downloaded artifact.
-    default: ""
+    default: "NOTSET"
 
   uri:
     description: |
@@ -34,13 +34,13 @@ pipeline:
   - runs: |
       wget ${{inputs.uri}}
       bn=$(basename ${{inputs.uri}})
-      if [ "${{inputs.expected-sha256}}" != "" ]; then
+      if [ "${{inputs.expected-sha256}}" != "NOTSET" ]; then
         printf "%s  %s\n" '${{inputs.expected-sha256}}' $bn | sha256sum -c
       fi
-      if [ "${{inputs.expected-sha512}}" != "" ]; then
+      if [ "${{inputs.expected-sha512}}" != "NOTSET" ]; then
         printf "%s  %s\n" '${{inputs.expected-sha512}}' $bn | sha512sum -c
       fi
-      if [ "${{inputs.expected-sha512}}" == "" && "${{inputs.expected-sha256}}" == "" ]; then
+      if [ "${{inputs.expected-sha512}}" == "NOTSET" && "${{inputs.expected-sha256}}" == "NOTSET" ]; then
         printf "One of expected-sha256 or expected-sha512 is required"
         exit 1
       fi

--- a/pipelines/fetch.yaml
+++ b/pipelines/fetch.yaml
@@ -18,7 +18,10 @@ inputs:
   expected-sha256:
     description: |
       The expected SHA256 of the downloaded artifact.
-    required: true
+
+  expected-sha512:
+    description: |
+      The expected SHA512 of the downloaded artifact.
 
   uri:
     description: |
@@ -29,7 +32,17 @@ pipeline:
   - runs: |
       wget ${{inputs.uri}}
       bn=$(basename ${{inputs.uri}})
-      printf "%s  %s\n" '${{inputs.expected-sha256}}' $bn | sha256sum -c
+      if [ "${{inputs.expected-sha256}}" != "" ]; then
+        printf "%s  %s\n" '${{inputs.expected-sha256}}' $bn | sha256sum -c
+      fi
+      if [ "${{inputs.expected-sha512}}" != "" ]; then
+        printf "%s  %s\n" '${{inputs.expected-sha512}}' $bn | sha512sum -c
+      fi
+      if [ "${{inputs.expected-sha512}}" == "" && "${{inputs.expected-sha256}}" == "" ]; then
+        printf "One of expected-sha256 or expected-sha512 is required"
+        exit 1
+      fi
+
       if [ "${{inputs.extract}}" = "true" ]; then
         bn=$(basename ${{inputs.uri}})
         tar -x '--strip-components=${{inputs.strip-components}}' -f $bn


### PR DESCRIPTION
This came up while trying to build ICU, which only provides sha512s of its source, e.g., https://github.com/unicode-org/icu/releases/tag/release-71-1

cc @jdolitsky 