### PR TITLE
Add dir input for autoconf pipelines

### DIFF
--- a/pipelines/autoconf/configure.yaml
+++ b/pipelines/autoconf/configure.yaml
@@ -1,7 +1,14 @@
 name: Run autoconf configure script
 
+inputs:
+  dir:
+    description: |
+      The directory containing the configure script.
+    default: .
+
 pipeline:
   - runs: |
+      cd ${{inputs.dir}}
       ./configure \
         --prefix=/usr \
         --libdir=/usr/lib \

--- a/pipelines/autoconf/make-install.yaml
+++ b/pipelines/autoconf/make-install.yaml
@@ -1,8 +1,16 @@
 name: Run autoconf make install
 
+inputs:
+  dir:
+    description: |
+      The directory containing the Makefile.
+    default: .
+
 needs:
   packages:
     - make
 
 pipeline:
-  - runs: make install DESTDIR="${{targets.destdir}}"
+  - runs: |
+      cd ${{inputs.dir}}
+      make install DESTDIR="${{targets.destdir}}"

--- a/pipelines/autoconf/make.yaml
+++ b/pipelines/autoconf/make.yaml
@@ -1,8 +1,16 @@
 name: Run autoconf make
 
+inputs:
+  dir:
+    description: |
+      The directory containing the Makefile.
+    default: .
+
 needs:
   packages:
     - make
 
 pipeline:
-  - runs: make -j$(nproc)
+  - runs: |
+      cd ${{inputs.dir}}
+      make -j$(nproc)


### PR DESCRIPTION
On using the fetch pipeline, some tarballs contain nested locations for `configure` or `Makefile`. This allows using the autoconf pipelines in a different directory.