### PR TITLE
Fix input check that triggers tar extraction on fetch pipeline

### DIFF
--- a/pkg/build/pipelines/fetch.yaml
+++ b/pkg/build/pipelines/fetch.yaml
@@ -61,6 +61,6 @@ pipeline:
         printf "%s  %s\n" '${{inputs.expected-sha512}}' $bn | sha512sum -c
       fi
 
-      if [ "${{inputs.extract}}" = "true" ]; then
+      if [ "${{inputs.extract}}" == "true" ]; then
         tar -x '--strip-components=${{inputs.strip-components}}' -f $bn
       fi


### PR DESCRIPTION
While trying to use the fetch pipeline to download `composer.phar`, I was getting some errors related to trying to unpack the file, even when setting the `extract` input to `false`. Then I found this comparison at the end of the pipeline missing a `=`.