### PR TITLE
add support for breakpoints and continuation points

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -91,6 +91,7 @@ type Pipeline struct {
 	Pipeline []Pipeline        `yaml:"pipeline,omitempty"`
 	Inputs   map[string]Input  `yaml:"inputs,omitempty"`
 	Needs    Needs             `yaml:"needs,omitempty"`
+	Label    string            `yaml:"label,omitempty"`
 	logger   *log.Logger
 }
 

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -266,6 +266,14 @@ func WithWorkspaceDir(workspaceDir string) Option {
 	}
 }
 
+// WithGuestDir sets the guest directory to use.
+func WithGuestDir(guestDir string) Option {
+	return func(ctx *Context) error {
+		ctx.GuestDir = guestDir
+		return nil
+	}
+}
+
 // WithWorkspaceIgnore sets the workspace ignore rules file to use.
 func WithWorkspaceIgnore(workspaceIgnore string) Option {
 	return func(ctx *Context) error {

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -144,6 +144,7 @@ type Context struct {
 	CacheDir           string
 	BreakpointLabel    string
 	ContinueLabel      string
+	foundContinuation  bool
 }
 
 type Dependencies struct {

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -142,6 +142,7 @@ type Context struct {
 	BinShOverlay       string
 	ignorePatterns     []*xignore.Pattern
 	CacheDir           string
+	BreakpointLabel    string
 }
 
 type Dependencies struct {
@@ -389,6 +390,15 @@ func WithDependencyLog(logFile string) Option {
 func WithBinShOverlay(binShOverlay string) Option {
 	return func(ctx *Context) error {
 		ctx.BinShOverlay = binShOverlay
+		return nil
+	}
+}
+
+// WithBreakpointLabel sets a label to stop build execution at.  The build
+// environment and workspace are preserved.
+func WithBreakpointLabel(breakpointLabel string) Option {
+	return func(ctx *Context) error {
+		ctx.BreakpointLabel = breakpointLabel
 		return nil
 	}
 }

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -172,7 +172,13 @@ func New(opts ...Option) (*Context, error) {
 	// temporary directory for it.  Otherwise, ensure we are in a
 	// subdir for this specific build context.
 	if ctx.WorkspaceDir != "" {
-		ctx.WorkspaceDir = filepath.Join(ctx.WorkspaceDir, ctx.Arch.ToAPK())
+		// If we are continuing the build, do not modify the workspace
+		// directory path.
+		// TODO(kaniini): Clean up the logic for this, perhaps by signalling
+		// multi-arch builds to the build context.
+		if ctx.ContinueLabel == "" {
+			ctx.WorkspaceDir = filepath.Join(ctx.WorkspaceDir, ctx.Arch.ToAPK())
+		}
 	} else {
 		tmpdir, err := os.MkdirTemp("", "melange-workspace-*")
 		if err != nil {

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -143,6 +143,7 @@ type Context struct {
 	ignorePatterns     []*xignore.Pattern
 	CacheDir           string
 	BreakpointLabel    string
+	ContinueLabel      string
 }
 
 type Dependencies struct {
@@ -407,6 +408,15 @@ func WithBinShOverlay(binShOverlay string) Option {
 func WithBreakpointLabel(breakpointLabel string) Option {
 	return func(ctx *Context) error {
 		ctx.BreakpointLabel = breakpointLabel
+		return nil
+	}
+}
+
+// WithContinueLabel sets a label to continue build execution from.  This
+// requires a preserved build environment and workspace.
+func WithContinueLabel(continueLabel string) Option {
+	return func(ctx *Context) error {
+		ctx.ContinueLabel = continueLabel
 		return nil
 	}
 }

--- a/pkg/build/pipeline.go
+++ b/pkg/build/pipeline.go
@@ -269,6 +269,10 @@ func (p *Pipeline) evalRun(ctx *PipelineContext) error {
 }
 
 func (p *Pipeline) Run(ctx *PipelineContext) error {
+	if p.Label != "" && p.Label == ctx.Context.BreakpointLabel {
+		return fmt.Errorf("stopping execution at breakpoint: %s", p.Label)
+	}
+
 	if p.logger == nil {
 		if err := p.initializeFromContext(ctx); err != nil {
 			return err

--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -46,6 +46,7 @@ func Build() *cobra.Command {
 	var template string
 	var dependencyLog string
 	var overlayBinSh string
+	var breakpointLabel string
 
 	cmd := &cobra.Command{
 		Use:     "build",
@@ -70,6 +71,7 @@ func Build() *cobra.Command {
 				build.WithTemplate(template),
 				build.WithDependencyLog(dependencyLog),
 				build.WithBinShOverlay(overlayBinSh),
+				build.WithBreakpointLabel(breakpointLabel),
 			}
 
 			if len(args) > 0 {
@@ -106,6 +108,7 @@ func Build() *cobra.Command {
 	cmd.Flags().StringVar(&template, "template", "", "template to apply to melange config (optional)")
 	cmd.Flags().StringVar(&dependencyLog, "dependency-log", "", "log dependencies to a specified file")
 	cmd.Flags().StringVar(&overlayBinSh, "overlay-binsh", "", "use specified file as /bin/sh overlay in build environment")
+	cmd.Flags().StringVar(&breakpointLabel, "breakpoint-label", "", "stop build execution at the specified label")
 	cmd.Flags().StringSliceVar(&archstrs, "arch", nil, "architectures to build for (e.g., x86_64,ppc64le,arm64) -- default is all, unless specified in config.")
 	cmd.Flags().StringSliceVarP(&extraKeys, "keyring-append", "k", []string{}, "path to extra keys to include in the build environment keyring")
 	cmd.Flags().StringSliceVarP(&extraRepos, "repository-append", "r", []string{}, "path to extra repositories to include in the build environment")

--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -48,6 +48,7 @@ func Build() *cobra.Command {
 	var dependencyLog string
 	var overlayBinSh string
 	var breakpointLabel string
+	var continueLabel string
 
 	cmd := &cobra.Command{
 		Use:     "build",
@@ -74,6 +75,7 @@ func Build() *cobra.Command {
 				build.WithDependencyLog(dependencyLog),
 				build.WithBinShOverlay(overlayBinSh),
 				build.WithBreakpointLabel(breakpointLabel),
+				build.WithContinueLabel(continueLabel),
 			}
 
 			if len(args) > 0 {
@@ -112,6 +114,7 @@ func Build() *cobra.Command {
 	cmd.Flags().StringVar(&dependencyLog, "dependency-log", "", "log dependencies to a specified file")
 	cmd.Flags().StringVar(&overlayBinSh, "overlay-binsh", "", "use specified file as /bin/sh overlay in build environment")
 	cmd.Flags().StringVar(&breakpointLabel, "breakpoint-label", "", "stop build execution at the specified label")
+	cmd.Flags().StringVar(&continueLabel, "continue-label", "", "continue build execution at the specified label")
 	cmd.Flags().StringSliceVar(&archstrs, "arch", nil, "architectures to build for (e.g., x86_64,ppc64le,arm64) -- default is all, unless specified in config.")
 	cmd.Flags().StringSliceVarP(&extraKeys, "keyring-append", "k", []string{}, "path to extra keys to include in the build environment keyring")
 	cmd.Flags().StringSliceVarP(&extraRepos, "repository-append", "r", []string{}, "path to extra repositories to include in the build environment")

--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -35,6 +35,7 @@ func Build() *cobra.Command {
 	var pipelineDir string
 	var sourceDir string
 	var cacheDir string
+	var guestDir string
 	var signingKey string
 	var generateIndex bool
 	var useProot bool
@@ -61,6 +62,7 @@ func Build() *cobra.Command {
 				build.WithWorkspaceDir(workspaceDir),
 				build.WithPipelineDir(pipelineDir),
 				build.WithCacheDir(cacheDir),
+				build.WithGuestDir(guestDir),
 				build.WithSigningKey(signingKey),
 				build.WithGenerateIndex(generateIndex),
 				build.WithUseProot(useProot),
@@ -100,6 +102,7 @@ func Build() *cobra.Command {
 	cmd.Flags().StringVar(&pipelineDir, "pipeline-dir", "", "directory used to extend defined built-in pipelines")
 	cmd.Flags().StringVar(&sourceDir, "source-dir", "", "directory used for included sources")
 	cmd.Flags().StringVar(&cacheDir, "cache-dir", "/var/cache/melange", "directory used for cached inputs")
+	cmd.Flags().StringVar(&guestDir, "guest-dir", "", "directory used for the build environment guest")
 	cmd.Flags().StringVar(&signingKey, "signing-key", "", "key to use for signing")
 	cmd.Flags().BoolVar(&generateIndex, "generate-index", true, "whether to generate APKINDEX.tar.gz")
 	cmd.Flags().BoolVar(&useProot, "use-proot", false, "whether to use proot for fakeroot")


### PR DESCRIPTION
This is a commonly requested feature when debugging builds.

With this PR, you can define labels in pipelines, which can be used as breakpoints and continuation points.  That looks like:

```yaml
pipeline:
  - label: foo
    runs: |
      echo hello!
  - label: bar
  - label: baz
```

When you use `--breakpoint-label=bar`, it will stop before executing `bar`, like a traditional breakpoint.

To continue with the example from above, you can also continue from points in the build with `--continue-label=bar`.  This depends on providing a pre-existing workspace, and optionally, a pre-existing guest environment.  If you provide a pre-existing guest environment, apko will be used to refresh the guest without downloading everything again.

This allows for rerunning build steps that previously failed (e.g. after you rectify an issue in the YAML).

There are some ways that the UX could be improved, but I think this is already helpful enough that it should be merged.