### PR TITLE
Support range for subpackages; drop templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,27 +167,6 @@ pipeline:
     runs: mkdir ${{targets.destdir}}/var/lib/${{package.name}}/tmp
 ```
 
-## Build File Templating
-
-The build file can be templated via [Go templates](https://pkg.go.dev/text/template).
-The template is then passed in as a JSON string via the `--template` flag.
-With templating the same build file can be used for building multiple packages.
-
-For example, use templating to build nginx at multiple versions first by formatting the build file:
-
-```yaml
-package:
-  name: nginx
-  version: {{ .Version }}
-```
-
-and passing in the template via the `--template` flag:
-
-```shell
-melange build --template '{"Version": "1.20.3"}'
-melange build --template '{"Version": "1.22.0"}'
-```
-
 ## Usage with apko
 
 To use a melange built APK in apko, either upload it to a package repository or use a "local" repository. Using a local repository allows a melange build and apko build to run in the same directory (or GitHub repo) without using external storage.

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.18
 
 require (
 	chainguard.dev/apko v0.5.1-0.20221108210157-867765719b6f
-	github.com/Masterminds/sprig/v3 v3.2.2
 	github.com/google/go-cmp v0.5.9
 	github.com/psanford/memfs v0.0.0-20210214183328-a001468d78ef
 	github.com/spf13/cobra v1.6.1
@@ -18,8 +17,6 @@ require (
 
 require (
 	github.com/MakeNowJust/heredoc v1.0.0 // indirect
-	github.com/Masterminds/goutils v1.1.1 // indirect
-	github.com/Masterminds/semver/v3 v3.1.1 // indirect
 	github.com/Microsoft/go-winio v0.6.0 // indirect
 	github.com/ProtonMail/go-crypto v0.0.0-20220824120805-4b6e5c587895 // indirect
 	github.com/acomagu/bufpipe v1.0.3 // indirect
@@ -45,10 +42,8 @@ require (
 	github.com/go-openapi/swag v0.22.3 // indirect
 	github.com/go-openapi/validate v0.22.0 // indirect
 	github.com/google/go-containerregistry v0.12.0 // indirect
-	github.com/google/uuid v1.3.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
-	github.com/huandu/xstrings v1.3.1 // indirect
 	github.com/imdario/mergo v0.3.13 // indirect
 	github.com/inconshreveable/mousetrap v1.0.1 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
@@ -57,22 +52,18 @@ require (
 	github.com/kevinburke/ssh_config v1.2.0 // indirect
 	github.com/klauspost/compress v1.15.11 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
-	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
-	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/oklog/ulid v1.3.1 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.0-rc2 // indirect
 	github.com/package-url/packageurl-go v0.1.1-0.20220203205134-d70459300c8a // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/sergi/go-diff v1.2.0 // indirect
-	github.com/shopspring/decimal v1.2.0 // indirect
 	github.com/sigstore/cosign v1.13.1 // indirect
 	github.com/sigstore/rekor v0.12.1 // indirect
 	github.com/sirupsen/logrus v1.9.0 // indirect
 	github.com/spf13/afero v1.8.2 // indirect
-	github.com/spf13/cast v1.5.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/vbatts/tar-split v0.11.2 // indirect
 	github.com/xanzy/ssh-agent v0.3.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -42,12 +42,6 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
 github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
-github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=
-github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
-github.com/Masterminds/semver/v3 v3.1.1 h1:hLg3sBzpNErnxhQtUy/mmLR2I9foDujNK030IGemrRc=
-github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
-github.com/Masterminds/sprig/v3 v3.2.2 h1:17jRggJu518dr3QaafizSXOjKYp94wKfABxUmyxvxX8=
-github.com/Masterminds/sprig/v3 v3.2.2/go.mod h1:UoaO7Yp8KlPnJIYWTFkMaqPUYKTfGFPhxNuwnnxkKlk=
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
 github.com/Microsoft/go-winio v0.4.16/go.mod h1:XB6nPKklQyQ7GC9LdcBEcBl8PF76WugXOPRXwdLnMv0=
 github.com/Microsoft/go-winio v0.5.2/go.mod h1:WpS1mjBmmwHBEWmogvA2mj8546UReBk4v8QkMxJ6pZY=
@@ -111,7 +105,6 @@ github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.m
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/frankban/quicktest v1.14.0/go.mod h1:NeW+ay9A/U67EYXNFA1nPE8e/tnQv/09mUdL/ijj8og=
-github.com/frankban/quicktest v1.14.3 h1:FJKSZTDHjyhriyC81FLQ0LY93eSai0ZyR/ZIkd3ZUKE=
 github.com/gliderlabs/ssh v0.2.2/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=
 github.com/gliderlabs/ssh v0.3.3 h1:mBQ8NiOgDkINJrZtoizkC3nDNYgSaWtxyem6S2XHBtA=
 github.com/go-git/gcfg v1.5.0 h1:Q5ViNfGF8zFgyJWPqYwA7qGFoMTEiBmdlkcfRmpIMa4=
@@ -248,7 +241,6 @@ github.com/google/renameio v1.0.1/go.mod h1:t/HQoYBZSsWSNK35C6CO/TpPLDVWvxOHboWU
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
-github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/googleapis/google-cloud-go-testing v0.0.0-20200911160855-bcd43fbb19e8/go.mod h1:dvDLG8qkwmyD9a/MJJN3XJcT3xFxOKAvTZGvuZmac9g=
@@ -259,11 +251,8 @@ github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+l
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
-github.com/huandu/xstrings v1.3.1 h1:4jgBlKK6tLKFvO8u5pmYjG91cqytmDCDvGh7ECVFfFs=
-github.com/huandu/xstrings v1.3.1/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
-github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.13 h1:lFzP57bqS/wsqKssCGmtLAb8A0wKjLGrve2q3PPVcBk=
 github.com/imdario/mergo v0.3.13/go.mod h1:4lJ1jqUDcsbIECGy0RUJAXNIhg+6ocWgb1ALK2O4oXg=
@@ -309,9 +298,6 @@ github.com/markbates/oncer v0.0.0-20181203154359-bf2de49a0be2/go.mod h1:Ld9puTsI
 github.com/markbates/safe v1.0.1/go.mod h1:nAqgmRi7cY2nqMc92/bSEeQA+R4OheNU2T1kNSCBdG0=
 github.com/matryer/is v1.2.0 h1:92UTHpy8CDwaJ08GqLDzhhuixiBUUD1p3AU6PHddz4A=
 github.com/matryer/is v1.2.0/go.mod h1:2fLPjFQM9rhQ15aVEtbuwhJinnOqrmgXPNdZsdwlWXA=
-github.com/mitchellh/copystructure v1.0.0/go.mod h1:SNtv71yrdKgLRyLFxmLdkAbkKEFWgYaq1OVrnRcwhnw=
-github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=
-github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/mapstructure v1.3.3/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
@@ -319,9 +305,6 @@ github.com/mitchellh/mapstructure v1.4.1/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RR
 github.com/mitchellh/mapstructure v1.4.3/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
-github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
-github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
-github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/oklog/ulid v1.3.1 h1:EGfNDEx6MqHz8B3uNV6QAib1UR2Lm97sHi3ocA6ESJ4=
@@ -356,8 +339,6 @@ github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/sergi/go-diff v1.2.0 h1:XU+rvMAioB0UC3q1MFrIQy4Vo5/4VsRDQQXHsEya6xQ=
 github.com/sergi/go-diff v1.2.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
-github.com/shopspring/decimal v1.2.0 h1:abSATXmQEYyShuxI4/vyW3tV1MrKAJzCZ/0zLUXYbsQ=
-github.com/shopspring/decimal v1.2.0/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sigstore/cosign v1.13.1 h1:+5oF8jisEcDw2TuXxCADC1u5//HfdnJhGbpv9Isiwu4=
 github.com/sigstore/cosign v1.13.1/go.mod h1:PlfJODkovUOKsLrGI7Su57Ie/Eb/Ks7hRHw3tn5hQS4=
@@ -372,9 +353,6 @@ github.com/sirupsen/logrus v1.9.0/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVs
 github.com/spf13/afero v1.2.0/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
 github.com/spf13/afero v1.8.2 h1:xehSyVa0YnHWsJ49JFljMpg1HX19V6NDZ1fkm1Xznbo=
 github.com/spf13/afero v1.8.2/go.mod h1:CtAatgMJh6bJEIs48Ay/FOnkljP3WeGUG0MC1RfAqwo=
-github.com/spf13/cast v1.3.1/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
-github.com/spf13/cast v1.5.0 h1:rj3WzYc11XZaIZMPKmwP96zkFEnnAmV8s6XbB2aY32w=
-github.com/spf13/cast v1.5.0/go.mod h1:SpXXQ5YoyJw6s3/6cMTQuxvgRl3PCJiyaX9p6b155UU=
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/cobra v1.6.1 h1:o94oiPyS4KD1mPy2fmcYYHHfCxLqYjJOhGsCHFZtEzA=
 github.com/spf13/cobra v1.6.1/go.mod h1:IOw/AERYS7UzyrGinqmz6HLUo219MORXGxhbaJUqzrY=
@@ -441,7 +419,6 @@ golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200302210943-78000ba7a073/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
-golang.org/x/crypto v0.0.0-20200414173820-0848c9571904/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201216223049-8b5274cf687f/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -15,8 +15,6 @@
 package build
 
 import (
-	"bytes"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -28,13 +26,11 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
-	"text/template"
 	"time"
 
 	apko_build "chainguard.dev/apko/pkg/build"
 	apko_types "chainguard.dev/apko/pkg/build/types"
 	apkofs "chainguard.dev/apko/pkg/fs"
-	"github.com/Masterminds/sprig/v3"
 	"github.com/zealic/xignore"
 	"gopkg.in/yaml.v3"
 
@@ -96,6 +92,7 @@ type Pipeline struct {
 }
 
 type Subpackage struct {
+	Range        string        `yaml:"range"`
 	Name         string        `yaml:"name"`
 	Pipeline     []Pipeline    `yaml:"pipeline,omitempty"`
 	Dependencies Dependencies  `yaml:"dependencies,omitempty"`
@@ -113,8 +110,18 @@ type Input struct {
 type Configuration struct {
 	Package     Package
 	Environment apko_types.ImageConfiguration
-	Pipeline    []Pipeline
-	Subpackages []Subpackage
+	Pipeline    []Pipeline   `yaml:"pipeline,omitempty"`
+	Subpackages []Subpackage `yaml:"subpackages,omitempty"`
+	Data        []RangeData  `yaml:"data,omitempty"`
+}
+
+type RangeData struct {
+	Name  string     `yaml:"name"`
+	Items []DataItem `yaml:"items,omitempty"`
+}
+
+type DataItem struct {
+	Key, Value string
 }
 
 type Context struct {
@@ -129,7 +136,6 @@ type Context struct {
 	GuestDir           string
 	SigningKey         string
 	SigningPassphrase  string
-	Template           string
 	GenerateIndex      bool
 	UseProot           bool
 	EmptyWorkspace     bool
@@ -205,7 +211,7 @@ func New(opts ...Option) (*Context, error) {
 		return nil, fmt.Errorf("melange.yaml is missing")
 	}
 
-	if err := ctx.Configuration.Load(ctx.ConfigFile, ctx.Template); err != nil {
+	if err := ctx.Configuration.Load(ctx.ConfigFile); err != nil {
 		return nil, fmt.Errorf("failed to load configuration: %w", err)
 	}
 
@@ -386,13 +392,6 @@ func WithExtraRepos(extraRepos []string) Option {
 	}
 }
 
-func WithTemplate(template string) Option {
-	return func(ctx *Context) error {
-		ctx.Template = template
-		return nil
-	}
-}
-
 // WithDependencyLog sets a filename to use for dependency logging.
 func WithDependencyLog(logFile string) Option {
 	return func(ctx *Context) error {
@@ -429,18 +428,60 @@ func WithContinueLabel(continueLabel string) Option {
 }
 
 // Load the configuration data from the build context configuration file.
-func (cfg *Configuration) Load(configFile, template string) error {
+func (cfg *Configuration) Load(configFile string) error {
 	data, err := os.ReadFile(configFile)
 	if err != nil {
 		return fmt.Errorf("unable to load configuration file: %w", err)
 	}
 
-	config, err := ParseConfig(data, template)
-	if err != nil {
-		return err
+	if err := yaml.Unmarshal(data, cfg); err != nil {
+		return fmt.Errorf("unable to parse configuration file: %w", err)
 	}
 
-	*cfg = *config
+	datas := map[string][]DataItem{}
+	for _, d := range cfg.Data {
+		datas[d.Name] = d.Items
+	}
+	subpackages := []Subpackage{}
+	for _, sp := range cfg.Subpackages {
+		if sp.Range == "" {
+			subpackages = append(subpackages, sp)
+			continue
+		}
+		items, ok := datas[sp.Range]
+		if !ok {
+			return fmt.Errorf("subpackage specified undefined range: %q", sp.Range)
+		}
+
+		for _, it := range items {
+			k, v := it.Key, it.Value
+			replacer := replacerFromMap(map[string]string{
+				"${{range.key}}":   k,
+				"${{range.value}}": v,
+			})
+			thingToAdd := Subpackage{
+				Name:        replacer.Replace(sp.Name),
+				Description: replacer.Replace(sp.Description),
+			}
+			for _, p := range sp.Pipeline {
+				thingToAdd.Pipeline = append(thingToAdd.Pipeline, Pipeline{
+					Name:   p.Name,
+					Uses:   p.Uses,
+					With:   p.With,
+					Inputs: p.Inputs,
+					Needs:  p.Needs,
+					Label:  p.Label,
+					Runs:   replacer.Replace(p.Runs),
+					// TODO: p.Pipeline?
+				})
+			}
+			subpackages = append(subpackages, thingToAdd)
+		}
+	}
+	cfg.Data = nil // TODO: zero this out or not?
+	cfg.Subpackages = subpackages
+
+	// TODO: validate that subpackage ranges have been consumed and applied
 
 	grp := apko_types.Group{
 		GroupName: "build",
@@ -457,75 +498,6 @@ func (cfg *Configuration) Load(configFile, template string) error {
 	cfg.Environment.Accounts.Users = []apko_types.User{usr}
 
 	return nil
-}
-
-// ParseConfig parses a configuration file into a Configuration, applying a template if necessary.
-func ParseConfig(configFile []byte, template string) (*Configuration, error) {
-	templatized, err := applyTemplate(configFile, template)
-	if err != nil {
-		return nil, fmt.Errorf("unable to apply template: %w", err)
-	}
-
-	cfg := &Configuration{}
-
-	if err := yaml.Unmarshal(templatized, cfg); err != nil {
-		return nil, fmt.Errorf("unable to parse configuration file: %w", err)
-	}
-
-	return cfg, nil
-}
-
-func applyTemplate(contents []byte, t string) ([]byte, error) {
-	var i map[string]interface{}
-
-	if t != "" {
-		if err := json.Unmarshal([]byte(t), &i); err != nil {
-			return nil, err
-		}
-	}
-
-	// First, replace all protected pipeline templated vars temporarily
-	// So that we can apply the Go template
-	// We have to do this bc go templates doesn't support ignoring certain fields: https://github.com/golang/go/issues/31147
-
-	sr := substitutionReplacements()
-
-	protected := string(contents)
-	for k, v := range sr {
-		protected = strings.ReplaceAll(protected, k, v)
-	}
-
-	tmpl, err := template.New("").Funcs(sprig.TxtFuncMap()).Parse(protected)
-	if err != nil {
-		return nil, err
-	}
-	tmpl = tmpl.Option("missingkey=error")
-	buf := bytes.NewBuffer([]byte{})
-	if err := tmpl.Execute(buf, i); err != nil {
-		return nil, err
-	}
-
-	// Add the pipeline templating back in
-	templateApplied := buf.String()
-	for k, v := range sr {
-		templateApplied = strings.ReplaceAll(templateApplied, v, k)
-	}
-
-	return []byte(templateApplied), nil
-}
-
-func substitutionReplacements() map[string]string {
-	return map[string]string{
-		substitutionPackageName:          "MELANGE_TEMP_REPLACEMENT_PACAKAGE_NAME",
-		substitutionPackageVersion:       "MELANGE_TEMP_REPLACEMENT_PACAKAGE_VERSION",
-		substitutionPackageEpoch:         "MELANGE_TEMP_REPLACEMENT_PACAKAGE_EPOCH",
-		substitutionTargetsDestdir:       "MELANGE_TEMP_REPLACEMENT_DESTDIR",
-		substitutionSubPkgDir:            "MELANGE_TEMP_REPLACEMENT_SUBPKGDIR",
-		substitutionHostTripletGnu:       "MELANGE_TEMP_REPLACEMENT_HOST_TRIPLET_GNU",
-		substitutionHostTripletRust:      "MELANGE_TEMP_REPLACEMENT_HOST_TRIPLET_RUST",
-		substitutionCrossTripletGnuGlibc: "MELANGE_TEMP_REPLACEMENT_CROSS_TRIPLET_GNU_GLIBC",
-		substitutionCrossTripletGnuMusl:  "MELANGE_TEMP_REPLACEMENT_CROSS_TRIPLET_GNU_MUSL",
-	}
 }
 
 // BuildGuest invokes apko to build the guest environment.

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -144,7 +144,7 @@ func (d *DataItemList) MarshalYAML() (interface{}, error) {
 	if d == nil {
 		return nil, nil
 	}
-	var m map[string]string
+	m := map[string]string{}
 	for _, i := range *d {
 		m[i.Key] = m[i.Value]
 	}

--- a/pkg/build/build_test.go
+++ b/pkg/build/build_test.go
@@ -76,22 +76,15 @@ pipeline:
 data:
   - name: ninja-turtles
     items:
-    - key: Michelangelo
-      value: orange
-    - key: Raphael
-      value: red
-    - key: Leonardo
-      value: blue
-    - key: Donatello
-      value: purple
+      Michelangelo: orange
+      Raphael: red
+      Leonardo: blue
+      Donatello: purple
   - name: animals
     items:
-    - key: dogs
-      value: loyal
-    - key: cats
-      value: angry
-    - key: turtles
-      value: slow
+      dogs: loyal
+      cats: angry
+      turtles: slow
 
 subpackages:
   - range: animals
@@ -105,19 +98,29 @@ subpackages:
 `
 
 	expected := []Subpackage{{
-		Name: "dogs",
-		Pipeline: []Pipeline{{
-			Runs: "dogs are loyal",
-		}},
-	}, {
 		Name: "cats",
 		Pipeline: []Pipeline{{
 			Runs: "cats are angry",
 		}},
 	}, {
+		Name: "dogs",
+		Pipeline: []Pipeline{{
+			Runs: "dogs are loyal",
+		}},
+	}, {
 		Name: "turtles",
 		Pipeline: []Pipeline{{
 			Runs: "turtles are slow",
+		}},
+	}, {
+		Name: "Donatello",
+		Pipeline: []Pipeline{{
+			Runs: "Donatello's color is purple",
+		}},
+	}, {
+		Name: "Leonardo",
+		Pipeline: []Pipeline{{
+			Runs: "Leonardo's color is blue",
 		}},
 	}, {
 		Name: "Michelangelo",
@@ -128,16 +131,6 @@ subpackages:
 		Name: "Raphael",
 		Pipeline: []Pipeline{{
 			Runs: "Raphael's color is red",
-		}},
-	}, {
-		Name: "Leonardo",
-		Pipeline: []Pipeline{{
-			Runs: "Leonardo's color is blue",
-		}},
-	}, {
-		Name: "Donatello",
-		Pipeline: []Pipeline{{
-			Runs: "Donatello's color is purple",
 		}},
 	}}
 

--- a/pkg/build/build_test.go
+++ b/pkg/build/build_test.go
@@ -15,7 +15,7 @@
 package build
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -24,19 +24,13 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 )
 
-const defaultTemplateYaml = `package:
+func TestLoadConfiguration(t *testing.T) {
+	contents := `
+package:
   name: nginx
   version: 100
   test: ${{package.name}}
 `
-
-const templatized = `package:
-  name: {{ .Package }}
-  version: {{ .Version }}
-  test: ${{package.name}}
-`
-
-func TestLoadConfiguration(t *testing.T) {
 	expected := &Configuration{
 		Package: Package{
 			Name:    "nginx",
@@ -55,9 +49,8 @@ func TestLoadConfiguration(t *testing.T) {
 		Members:   []string{"build"},
 	}}
 
-	dir := t.TempDir()
-	f := filepath.Join(dir, "config")
-	if err := ioutil.WriteFile(f, []byte(defaultTemplateYaml), 0755); err != nil {
+	f := filepath.Join(t.TempDir(), "config")
+	if err := os.WriteFile(f, []byte(contents), 0755); err != nil {
 		t.Fatal(err)
 	}
 
@@ -148,9 +141,8 @@ subpackages:
 		}},
 	}}
 
-	dir := t.TempDir()
-	f := filepath.Join(dir, "config")
-	if err := ioutil.WriteFile(f, []byte(contents), 0755); err != nil {
+	f := filepath.Join(t.TempDir(), "config")
+	if err := os.WriteFile(f, []byte(contents), 0755); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -108,7 +108,7 @@ func Build() *cobra.Command {
 	cmd.Flags().BoolVar(&useProot, "use-proot", false, "whether to use proot for fakeroot")
 	cmd.Flags().BoolVar(&emptyWorkspace, "empty-workspace", false, "whether the build workspace should be empty")
 	cmd.Flags().StringVar(&outDir, "out-dir", filepath.Join(cwd, "packages"), "directory where packages will be output")
-	go cmd.Flags().StringVar(&dependencyLog, "dependency-log", "", "log dependencies to a specified file")
+	cmd.Flags().StringVar(&dependencyLog, "dependency-log", "", "log dependencies to a specified file")
 	cmd.Flags().StringVar(&overlayBinSh, "overlay-binsh", "", "use specified file as /bin/sh overlay in build environment")
 	cmd.Flags().StringVar(&breakpointLabel, "breakpoint-label", "", "stop build execution at the specified label")
 	cmd.Flags().StringVar(&continueLabel, "continue-label", "", "continue build execution at the specified label")

--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -44,7 +44,6 @@ func Build() *cobra.Command {
 	var archstrs []string
 	var extraKeys []string
 	var extraRepos []string
-	var template string
 	var dependencyLog string
 	var overlayBinSh string
 	var breakpointLabel string
@@ -71,7 +70,6 @@ func Build() *cobra.Command {
 				build.WithOutDir(outDir),
 				build.WithExtraKeys(extraKeys),
 				build.WithExtraRepos(extraRepos),
-				build.WithTemplate(template),
 				build.WithDependencyLog(dependencyLog),
 				build.WithBinShOverlay(overlayBinSh),
 				build.WithBreakpointLabel(breakpointLabel),
@@ -110,8 +108,7 @@ func Build() *cobra.Command {
 	cmd.Flags().BoolVar(&useProot, "use-proot", false, "whether to use proot for fakeroot")
 	cmd.Flags().BoolVar(&emptyWorkspace, "empty-workspace", false, "whether the build workspace should be empty")
 	cmd.Flags().StringVar(&outDir, "out-dir", filepath.Join(cwd, "packages"), "directory where packages will be output")
-	cmd.Flags().StringVar(&template, "template", "", "template to apply to melange config (optional)")
-	cmd.Flags().StringVar(&dependencyLog, "dependency-log", "", "log dependencies to a specified file")
+	go cmd.Flags().StringVar(&dependencyLog, "dependency-log", "", "log dependencies to a specified file")
 	cmd.Flags().StringVar(&overlayBinSh, "overlay-binsh", "", "use specified file as /bin/sh overlay in build environment")
 	cmd.Flags().StringVar(&breakpointLabel, "breakpoint-label", "", "stop build execution at the specified label")
 	cmd.Flags().StringVar(&continueLabel, "continue-label", "", "continue build execution at the specified label")


### PR DESCRIPTION
Signed-off-by: Jason Hall <jason@chainguard.dev>

This expands on an idea @luhring had in #161 to rely on YAML-defined key/value pairs instead of Go templates.

It's not yet a fully complete idea, just a starting point to discuss how we might like this to work.

As an example:

```
package:
  name: hello
  version: world

pipeline:
- name: hello
  runs: world

data:
  - name: animals
    items:
      dogs: loyal
      cats: angry
      turtles: slow

subpackages:
  - range: animals
    name: ${{range.key}}
    pipeline:
    - runs: ${{range.key}} are ${{range.value}}
```

When a `subpackage` specifies a `range`, key/value pairs for that range must be specified in `data`, where each item in the k/v pair gets expanded in the `subpackages` array before proceeding to the next one.

Multiple named `data`s can be provided, and the order according to `subpackages` is retained.

`range`s are only (currently) supported in `subpackages`, since that's the use case described in #161 and wolfi's glibc locales use case.

With the change as it stands, Go templates are dropped, along with the `--template` flag, but we could consider putting that back, and (I would suggest) only applying templates to YAML string values, and not the whole document.