### PR TITLE
melange development environment

### DIFF
--- a/docs/DEVENV.md
+++ b/docs/DEVENV.md
@@ -1,0 +1,58 @@
+# Melange Development Environment
+
+To ease the development of melange, we offer a script that builds
+a [Wolfi](https://github.com/wolfi-dev/community)-based image with
+the required tooling to compile and run melange. When running the
+devenv, you'll drop into a Wolfi shell, with your local fork directory
+will mounted in `$PWD`.
+
+## Launching the DevEnv
+
+To launch the development environment, simply run the script from
+the top of the melange environment:
+
+```bash
+# Clone the melange repo
+
+git clone git@github.com:chainguard-dev/melange.git
+
+cd melange
+
+# Build and launch the devenv:
+
+./hack/make-devenv.sh
+                _                        
+ _ __ ___   ___| | __ _ _ __   __ _  ___ 
+| '_ ` _ \ / _ \ |/ _` | '_ \ / _` |/ _ \
+| | | | | |  __/ | (_| | | | | (_| |  __/
+|_| |_| |_|\___|_|\__,_|_| |_|\__, |\___|
+                              |___/      
+
+Welcome to the melange development environment!
+
+To run melange from your local fork run:
+        go run ./main.go
+
+
+```
+
+The image is built every time it is needed, it will be 
+built using Chainguard's [apko image](https://github.com/chainguard-images/images/tree/main/images/apko).
+
+## Requirements
+
+The only requirement to run the melange development environment
+is to haver docker running in you local system. The script will
+take care of the rest.
+
+# Reset/Delete the Development Environment
+
+The script will only build the Wolfi image when it cannot find it
+in the local docker daemon. If you need to rebuild it, simply 
+delete it using docker:
+
+```bash
+docker rmi melange-inception:latest
+```
+
+Running the script again will force a clean build of the image.

--- a/hack/make-devenv.sh
+++ b/hack/make-devenv.sh
@@ -1,0 +1,74 @@
+#!/bin/sh
+
+# Copyright 2022 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+IMAGE_TAG="melange-inception"
+DEVENV_IMAGE_TARBALL="melange-inception.tar.gz"
+BUILDER_APKO_TAG="sha256:c96d1e6886ae5bafafe2656a3133ee73ce5245f67e60e430a731570b3f76797e"
+
+checkrepo() {
+    grep "module chainguard.dev/melange" go.mod >/dev/null 2>&1 && return
+    echo;
+    echo "Please run me from the melange repository root. Thank you!";
+    echo
+    exit 1;
+}
+
+run_builder() {
+    if ! (docker inspect melange-inception:latest >/dev/null 2>&1 ); then
+        set -e
+        mkdir _output > /dev/null 2>&1 || : 
+        docker run --rm -v $(pwd):/melange -w /melange \
+            cgr.dev/chainguard/apko@${BUILDER_APKO_TAG} build \
+            ./hack/melange-devenv.yaml ${IMAGE_TAG}:latest ./_output/melange-inception.tar.gz  \
+            --sbom=false
+        load_image
+        rm -f _output/${DEVENV_IMAGE_TARBALL}
+    fi
+    run
+}
+
+run() {
+    docker run --rm --privileged -w /melage -v /var/run/docker.sock:/var/run/docker.sock \
+        -v $(pwd):/melage -ti ${IMAGE_TAG}:latest hack/make-devenv.sh setup
+}
+
+setup() {
+cat << EOF
+                _                        
+ _ __ ___   ___| | __ _ _ __   __ _  ___ 
+| '_ \` _ \ / _ \ |/ _\` | '_ \ / _\` |/ _ \\
+| | | | | |  __/ | (_| | | | | (_| |  __/
+|_| |_| |_|\___|_|\__,_|_| |_|\__, |\___|
+                              |___/      
+
+EOF
+
+    echo "Welcome to the melange development environment!"
+    echo
+    echo "To run melange from your local fork run:"
+    echo "        go run ./main.go"
+    echo
+    alias ll="ls -l"
+    export PS1="[melange] ❯ "
+    sh -i
+}
+
+
+load_image() {
+    set -e
+    docker rmi ${IMAGE_TAG}:latest 2>&1 || :
+    docker load < _output/${DEVENV_IMAGE_TARBALL}
+}
+
+checkrepo
+
+case "$1" in
+    "")
+        run_builder;;
+    "run")
+        run;;
+    "setup")
+        setup;;
+esac

--- a/hack/melange-devenv.yaml
+++ b/hack/melange-devenv.yaml
@@ -1,0 +1,35 @@
+# Copyright 2022 Chainguard, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# APKO DEVELOPMENT ENVIRONMENT
+#
+# This image configuration is used by the apko development environment 
+# shell script. It preconfigures some tools to make them available in 
+# the dev shell.
+#
+contents:
+  keyring:
+    - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+  repositories:
+    - https://packages.wolfi.dev/os
+  packages:
+    - wolfi-base
+    - wolfi-baselayout
+    - alpine-keys
+    - go
+    - git
+    - make
+    - bubblewrap
+entrypoint:
+  command: /bin/sh -l


### PR DESCRIPTION
This PR introduces the first iteration of the melange development environment. It is based on the apko equivalent
with two main differences:

1. It uses our apko image to build the devenv image
2. It is based on Wolfi packages :tada:

To run it, execute the same command as the apko devenv:

./hack/make-devenv.sh

It requires https://github.com/wolfi-dev/os/pull/118 to fix a bug with the wolfi key locations and to enable https://github.com/wolfi-dev/os/pull/119 which is required to build the `alpine-keys` wolfi package (required to build the devenv image).


Signed-off-by: Adolfo García Veytia (Puerco) <puerco@chainguard.dev>