### PR TITLE
Go pipeline

### DIFF
--- a/examples/go-hello.yaml
+++ b/examples/go-hello.yaml
@@ -1,0 +1,28 @@
+package:
+  name: hello-go
+  version: v0.0.1
+  epoch: 0
+  description: "simple hello go project"
+  target-architecture:
+    - all
+
+environment:
+  contents:
+    repositories:
+      - https://packages.wolfi.dev/os
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://github.com/puerco/hello/archive/refs/tags/${{package.version}}.tar.gz
+      expected-sha512: 8b6a997ef52711cfe29ede1510cd4b2181e2397eb89e0114feb6b6829dc01e400154e8021fe8be58ae8cad1c97152721a61c3ab88f68009d1bb7b2263aac6a18
+  - uses: go/build
+    with:
+      packages: main.go
+      output: hello
+      
+      # Example to pass tags to compiler:
+      # tags: hello,bye
+
+      # Example to pass ldflags to compiler 
+      # ldflags: -buildid= sigs.k8s.io/release-utils/version.gitCommit=406d901bef12a92957f47f8a539d6bc6e6e13ca5

--- a/pkg/build/pipelines/go/build.yaml
+++ b/pkg/build/pipelines/go/build.yaml
@@ -1,0 +1,56 @@
+name: Run a build using the go compiler
+
+needs:
+  packages:
+    - go
+    - busybox
+    - ca-certificates-bundle
+
+inputs:
+  packages:
+    description: |
+      List of space-separated packages to compile. Files con also be specified.
+      This value is passed as an argument to go build.
+    required: true
+
+  tags:
+    description: |
+      A comma-separated list of build tags to pass to the go compiler
+  
+  output:
+    description: |
+      Filename to use when writing the binary. The final install location inside 
+      the apk will be in prefix / install-dir / output
+    required: true
+
+  prefix:
+    description: |
+      Prefix to relocate binaries
+    default: usr
+
+  ldflags:
+    description:
+      List of [pattern=]arg to pass to the go compiler with -ldflags
+
+  install-dir:
+    description: |
+      Directory where binaries will be installed
+    default: bin
+
+pipeline:
+  - runs: |
+      TAGS=""
+      LDFLAGS=""
+
+      if [ ! "${{inputs.tags}}" == "" ]; then
+        TAGS="${{inputs.tags}}"
+      fi
+
+      if [ ! "${{inputs.ldflags}}" == "" ]; then
+        LDFLAGS="{{inputs.ldflags}}"
+      fi
+
+      DEST_PATH="-o ${{targets.destdir}}/${{inputs.prefix}}/${{inputs.install-dir}}/${{inputs.output}}"
+      
+      go build ${DEST_PATH} -tags "${TAGS}" -ldflags "${LDFLAGS}" ${{inputs.packages}}
+      


### PR DESCRIPTION
This PR adds a new built-in pipeline to melange run go builds.

It supports a few options to pass to the compiler like tags, ldflags
and support to relocate the binary using a prefix and target directory.

Example usage:

```yaml
pipeline:
  - uses: fetch
    with:
      uri: https://github.com/puerco/hello/archive/refs/tags/v0.0.1.tar.gz
      expected-sha512: 8b6a997ef52711cfe29ede1510cd4b2.....
  - uses: go/build
    with:
      package: main.go
      output: hello
```

A simple example is included.

Signed-off-by: Adolfo García Veytia (Puerco) <puerco@chainguard.dev>