### PR TITLE
Basic SBOM generation in apks

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+env: 
+  SOURCE_DATE_EPOCH: 1669683910
+
 jobs:
   examples:
     name: build examples

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -858,12 +858,22 @@ func (ctx *Context) BuildPackage() error {
 	for i := range ctx.Configuration.Pipeline {
 		langs = append(langs, ctx.Configuration.Pipeline[i].SBOM.Language)
 	}
-
+	licenseExpression := ""
+	copyright := ""
+	for _, cp := range ctx.Configuration.Package.Copyright {
+		if licenseExpression != "" {
+			licenseExpression += " OR "
+		}
+		licenseExpression += cp.License
+		copyright += cp.Attestation + "\n"
+	}
 	if err := generator.GenerateSBOM(&sbom.Spec{
 		Path:           filepath.Join(ctx.WorkspaceDir, "melange-out", ctx.Configuration.Package.Name),
 		PackageName:    ctx.Configuration.Package.Name,
 		PackageVersion: ctx.Configuration.Package.Version,
 		Languages:      langs,
+		License:        licenseExpression,
+		Copyright:      copyright,
 	}); err != nil {
 		return fmt.Errorf("writing SBOMs: %w", err)
 	}

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -97,6 +97,7 @@ type Pipeline struct {
 	Assertions PipelineAssertions `yaml:"assertions,omitempty"`
 	logger     *log.Logger
 	steps      int
+	SBOM       SBOM `yaml:"sbom,omitempty"`
 }
 
 type Subpackage struct {
@@ -107,6 +108,10 @@ type Subpackage struct {
 	Options      PackageOption `yaml:"packageOption,omitempty"`
 	Scriptlets   Scriptlets    `yaml:"scriptlets,omitempty"`
 	Description  string        `yaml:"description,omitempty"`
+}
+
+type SBOM struct {
+	Language string `yaml:"language"`
 }
 
 type Input struct {

--- a/pkg/sbom/bom.go
+++ b/pkg/sbom/bom.go
@@ -24,6 +24,7 @@ type element interface {
 }
 
 type pkg struct {
+	FilesAnalyzed bool
 	Name          string
 	Version       string
 	Relationships []relationship
@@ -32,11 +33,12 @@ type pkg struct {
 type file struct {
 	Name          string
 	Version       string
+	Checksum      []map[string]string
 	Relationships []relationship
 }
 
 type relationship struct {
-	Source *element
-	Target *element
+	Source element
+	Target element
 	Type   string
 }

--- a/pkg/sbom/bom.go
+++ b/pkg/sbom/bom.go
@@ -21,20 +21,42 @@ type bom struct {
 }
 
 type element interface {
+	ID() string
 }
 
 type pkg struct {
 	FilesAnalyzed bool
+	id            string
 	Name          string
 	Version       string
+	HomePage      string
+	Supplier      string
+	Originator    string
+	Copyright     string
+	Checksums     map[string]string
 	Relationships []relationship
 }
 
+func (p *pkg) ID() string {
+	if p.id != "" {
+		return p.id
+	}
+	return "SPDXRef-Package-" + p.Name
+}
+
 type file struct {
+	id            string
 	Name          string
 	Version       string
-	Checksum      []map[string]string
+	Checksums     map[string]string
 	Relationships []relationship
+}
+
+func (f *file) ID() string {
+	if f.id != "" {
+		return f.id
+	}
+	return "SPDXRef-File-" + f.Name
 }
 
 type relationship struct {

--- a/pkg/sbom/bom.go
+++ b/pkg/sbom/bom.go
@@ -1,0 +1,42 @@
+// Copyright 2022 Chainguard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// bom captures the internal data model of the SBOMs melange produces
+package sbom
+
+type bom struct {
+	Packages []pkg
+	Files    []file
+}
+
+type element interface {
+}
+
+type pkg struct {
+	Name          string
+	Version       string
+	Relationships []relationship
+}
+
+type file struct {
+	Name          string
+	Version       string
+	Relationships []relationship
+}
+
+type relationship struct {
+	Source *element
+	Target *element
+	Type   string
+}

--- a/pkg/sbom/bom.go
+++ b/pkg/sbom/bom.go
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 // bom captures the internal data model of the SBOMs melange produces
+// into a private, generalized bill of materials model (with relationship
+// data) designed to be transcoded to specific formats.
 package sbom
 
 type bom struct {
@@ -25,16 +27,18 @@ type element interface {
 }
 
 type pkg struct {
-	FilesAnalyzed bool
-	id            string
-	Name          string
-	Version       string
-	HomePage      string
-	Supplier      string
-	Originator    string
-	Copyright     string
-	Checksums     map[string]string
-	Relationships []relationship
+	FilesAnalyzed    bool
+	id               string
+	Name             string
+	Version          string
+	HomePage         string
+	Supplier         string
+	Originator       string
+	Copyright        string
+	LicenseDeclared  string
+	LicenseConcluded string
+	Checksums        map[string]string
+	Relationships    []relationship
 }
 
 func (p *pkg) ID() string {

--- a/pkg/sbom/generator.go
+++ b/pkg/sbom/generator.go
@@ -37,6 +37,8 @@ type Spec struct {
 	Path           string
 	PackageName    string
 	PackageVersion string
+	License        string // Full SPDX license expression
+	Copyright      string
 	Languages      []string
 }
 

--- a/pkg/sbom/generator.go
+++ b/pkg/sbom/generator.go
@@ -18,8 +18,19 @@ import "fmt"
 
 func NewGenerator() (*Generator, error) {
 	return &Generator{
-		impl: &defaultGeneratorImplementation{},
+		impl:    &defaultGeneratorImplementation{},
+		Options: defaultOptions,
 	}, nil
+}
+
+var defaultOptions = Options{
+	ScanLicenses: true,
+	ScanFiles:    true,
+}
+
+type Options struct {
+	ScanLicenses bool
+	ScanFiles    bool
 }
 
 type Spec struct {
@@ -27,11 +38,6 @@ type Spec struct {
 	PackageName    string
 	PackageVersion string
 	Languages      []string
-}
-
-type Options struct {
-	ScanLicenses bool
-	ScanFiles    bool
 }
 
 type Generator struct {

--- a/pkg/sbom/generator.go
+++ b/pkg/sbom/generator.go
@@ -17,7 +17,9 @@ package sbom
 import "fmt"
 
 func NewGenerator() (*Generator, error) {
-	return &Generator{}, nil
+	return &Generator{
+		impl: &defaultGeneratorImplementation{},
+	}, nil
 }
 
 type Spec struct {

--- a/pkg/sbom/generator.go
+++ b/pkg/sbom/generator.go
@@ -46,12 +46,19 @@ func (g *Generator) GenerateSBOM(spec *Spec) error {
 		return fmt.Errorf("initializing new SBOM: %w", err)
 	}
 
+	pkg, err := g.impl.GenerateAPKPackage(spec)
+	if err != nil {
+		return fmt.Errorf("generating main package: %w", err)
+	}
+
 	// Add file inventory to packages
 	if g.Options.ScanFiles {
-		if err := g.impl.ScanFiles(spec, sbomDoc); err != nil {
+		if err := g.impl.ScanFiles(spec, &pkg); err != nil {
 			return fmt.Errorf("reading SBOM file inventory: %w", err)
 		}
 	}
+
+	sbomDoc.Packages = append(sbomDoc.Packages, pkg)
 
 	// Scan files for licensing data
 	if g.Options.ScanLicenses {

--- a/pkg/sbom/generator.go
+++ b/pkg/sbom/generator.go
@@ -1,0 +1,74 @@
+// Copyright 2022 Chainguard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sbom
+
+import "fmt"
+
+func NewGenerator() (*Generator, error) {
+	return &Generator{}, nil
+}
+
+type Spec struct {
+	Path           string
+	PackageName    string
+	PackageVersion string
+	Languages      []string
+}
+
+type Options struct {
+	ScanLicenses bool
+	ScanFiles    bool
+}
+
+type Generator struct {
+	Options Options
+	impl    generatorImplementation
+}
+
+// GenerateSBOM runs the main SBOM generation process
+func (g *Generator) GenerateSBOM(spec *Spec) error {
+	sbomDoc, err := g.impl.GenerateDocument(spec)
+	if err != nil {
+		return fmt.Errorf("initializing new SBOM: %w", err)
+	}
+
+	// Add file inventory to packages
+	if g.Options.ScanFiles {
+		if err := g.impl.ScanFiles(spec, sbomDoc); err != nil {
+			return fmt.Errorf("reading SBOM file inventory: %w", err)
+		}
+	}
+
+	// Scan files for licensing data
+	if g.Options.ScanLicenses {
+		if err := g.impl.ScanLicenses(spec, sbomDoc); err != nil {
+			return fmt.Errorf("reading SBOM file inventory: %w", err)
+		}
+	}
+
+	// Generate dependency data from each language specified in the opts
+	for _, lang := range spec.Languages {
+		if err := g.impl.ReadDependencyData(spec, sbomDoc, lang); err != nil {
+			return fmt.Errorf("reading %s dependecy data: %w", lang, err)
+		}
+	}
+
+	// Finally, write the SBOM data to disk
+	if err := g.impl.WriteSBOM(spec, sbomDoc); err != nil {
+		return fmt.Errorf("writing sbom to disk: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/sbom/implementation.go
+++ b/pkg/sbom/implementation.go
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Some of this code is based on the bom tool scan code originally
+// found at https://github.com/kubernetes-sigs/bom/blob/main/pkg/spdx/implementation.go
+
 package sbom
 
 import (

--- a/pkg/sbom/implementation.go
+++ b/pkg/sbom/implementation.go
@@ -162,7 +162,6 @@ func computeVerificationCode(hashList []string) string {
 	sort.Strings(hashList)
 	h := sha1.New()
 	if _, err := h.Write([]byte(strings.Join(hashList, ""))); err != nil {
-		// logrus.Error("getting SHA1 verification of files: %w", err)
 		return ""
 	}
 	return fmt.Sprintf("%x", h.Sum(nil))
@@ -241,12 +240,9 @@ func addPackage(doc *spdx.Document, p *pkg) {
 
 func addFile(doc *spdx.Document, f *file) {
 	spdxFile := spdx.File{
-		ID:   f.ID(),
-		Name: f.Name,
-		//CopyrightText:     f.Copyright,
-		// NoticeText:        "",
-		LicenseConcluded: spdx.NOASSERTION,
-		//Description:       "",
+		ID:                f.ID(),
+		Name:              f.Name,
+		LicenseConcluded:  spdx.NOASSERTION,
 		FileTypes:         []string{},
 		LicenseInfoInFile: []string{},
 		Checksums:         []spdx.Checksum{},

--- a/pkg/sbom/implementation.go
+++ b/pkg/sbom/implementation.go
@@ -388,7 +388,7 @@ func getDirectoryTree(dirPath string) ([]string, error) {
 			return nil
 		}
 
-		fileList = append(fileList, path)
+		fileList = append(fileList, filepath.Join(string(filepath.Separator), path))
 		return nil
 	}); err != nil {
 		return nil, fmt.Errorf("buiding directory tree: %w", err)

--- a/pkg/sbom/implementation.go
+++ b/pkg/sbom/implementation.go
@@ -58,10 +58,12 @@ func (di *defaultGeneratorImplementation) GenerateAPKPackage(spec *Spec) (pkg, e
 		return pkg{}, errors.New("unable to generate package, name not specified")
 	}
 	newPackage := pkg{
-		FilesAnalyzed: false,
-		Name:          spec.PackageName,
-		Version:       spec.PackageVersion,
-		Relationships: []relationship{},
+		FilesAnalyzed:   false,
+		Name:            spec.PackageName,
+		Version:         spec.PackageVersion,
+		Relationships:   []relationship{},
+		LicenseDeclared: spec.License,
+		Copyright:       spec.Copyright,
 	}
 
 	return newPackage, nil
@@ -154,8 +156,8 @@ func addPackage(doc *spdx.Document, p *pkg) {
 		FilesAnalyzed: false,
 		HasFiles:      []string{},
 		// LicenseInfoFromFiles: []string{},
-		// LicenseConcluded:     "",
-		// LicenseDeclared:      "",
+		LicenseConcluded: p.LicenseConcluded,
+		LicenseDeclared:  p.LicenseDeclared,
 		// Description:          "",
 		// DownloadLocation:     "",
 		// Originator:           "",

--- a/pkg/sbom/implementation.go
+++ b/pkg/sbom/implementation.go
@@ -171,23 +171,18 @@ func computeVerificationCode(hashList []string) string {
 // addPackage adds a package to the document
 func addPackage(doc *spdx.Document, p *pkg) {
 	spdxPkg := spdx.Package{
-		ID:            p.ID(),
-		Name:          p.Name,
-		Version:       p.Version,
-		FilesAnalyzed: false,
-		HasFiles:      []string{},
-		// LicenseInfoFromFiles: []string{},
-		LicenseConcluded: p.LicenseConcluded,
-		LicenseDeclared:  p.LicenseDeclared,
-		// Description:          "",
-		// DownloadLocation:     "",
-		// Originator:           "",
-		// SourceInfo:           "",
-		CopyrightText: p.Copyright,
-		// PrimaryPurpose:       "",
-		Checksums:    []spdx.Checksum{},
-		ExternalRefs: []spdx.ExternalRef{},
-		// VerificationCode: spdx.PackageVerificationCode{},
+		ID:                   p.ID(),
+		Name:                 p.Name,
+		Version:              p.Version,
+		FilesAnalyzed:        false,
+		HasFiles:             []string{},
+		LicenseConcluded:     p.LicenseConcluded,
+		LicenseDeclared:      p.LicenseDeclared,
+		DownloadLocation:     spdx.NOASSERTION,
+		LicenseInfoFromFiles: []string{},
+		CopyrightText:        p.Copyright,
+		Checksums:            []spdx.Checksum{},
+		ExternalRefs:         []spdx.ExternalRef{},
 	}
 
 	for algo, c := range p.Checksums {
@@ -217,6 +212,7 @@ func addPackage(doc *spdx.Document, p *pkg) {
 	verificationCode := computeVerificationCode(hashList)
 	if verificationCode != "" {
 		spdxPkg.VerificationCode.Value = verificationCode
+		spdxPkg.FilesAnalyzed = true
 		if len(excluded) > 0 {
 			spdxPkg.VerificationCode.ExcludedFiles = excluded
 		}
@@ -249,7 +245,7 @@ func addFile(doc *spdx.Document, f *file) {
 		Name: f.Name,
 		//CopyrightText:     f.Copyright,
 		// NoticeText:        "",
-		//LicenseConcluded:  "",
+		LicenseConcluded: spdx.NOASSERTION,
 		//Description:       "",
 		FileTypes:         []string{},
 		LicenseInfoInFile: []string{},

--- a/pkg/sbom/implementation.go
+++ b/pkg/sbom/implementation.go
@@ -14,10 +14,131 @@
 
 package sbom
 
+import (
+	"context"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"golang.org/x/sync/errgroup"
+	"sigs.k8s.io/release-utils/hash"
+)
+
 type generatorImplementation interface {
 	GenerateDocument(*Spec) (*bom, error)
 	ScanFiles(*Spec, *bom) error
 	ScanLicenses(*Spec, *bom) error
 	ReadDependencyData(*Spec, *bom, string) error
 	WriteSBOM(*Spec, *bom) error
+}
+
+type defaultGeneratorImplementation struct{}
+
+func (di *defaultGeneratorImplementation) GenerateDocument(spec *Spec) (*bom, error) {
+	return &bom{
+		Packages: []pkg{},
+		Files:    []file{},
+	}, nil
+}
+
+// ScanFiles reads the files to be packaged in the apk and
+// extracts the required data for the SBOM.
+func (di *defaultGeneratorImplementation) ScanFiles(spec *Spec, doc *bom) error {
+	dirPath, err := filepath.Abs(spec.Path)
+	if err != nil {
+		return fmt.Errorf("getting absolute directory path: %w", err)
+	}
+	fileList, err := getDirectoryTree(dirPath)
+	if err != nil {
+		return fmt.Errorf("building directory tree: %w", err)
+	}
+
+	// logrus.Debugf("Scanning %d files and adding them to the SPDX package", len(fileList))
+
+	dirPackage := pkg{
+		FilesAnalyzed: true,
+	}
+
+	g, _ := errgroup.WithContext(context.Background())
+	files := sync.Map{}
+	for _, path := range fileList {
+		path := path
+		g.Go(func() error {
+			f := file{
+				Name:          path,
+				Checksum:      []map[string]string{},
+				Relationships: []relationship{},
+			}
+
+			// Hash the file contents
+			for algo, fn := range map[string]func(string) (string, error){
+				"SHA1":   hash.SHA1ForFile,
+				"SHA256": hash.SHA256ForFile,
+				"SHA512": hash.SHA512ForFile,
+			} {
+				csum, err := fn(path)
+				if err != nil {
+					return fmt.Errorf("hashing %s file %s: %w", algo, path, err)
+				}
+				f.Checksum = append(f.Checksum, map[string]string{algo: csum})
+			}
+
+			files.Store(path, f)
+			return nil
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		return err
+	}
+
+	// Add files into the package
+	files.Range(func(key, f any) bool {
+		dirPackage.Relationships = append(dirPackage.Relationships, relationship{
+			Source: &dirPackage,
+			Target: &f,
+			Type:   "CONTAINS",
+		})
+		return true
+	})
+	doc.Packages = append(doc.Packages, dirPackage)
+	return nil
+}
+
+func (di *defaultGeneratorImplementation) ScanLicenses(spec *Spec, doc *bom) error {
+	return nil
+}
+
+func (di *defaultGeneratorImplementation) ReadDependencyData(spec *Spec, doc *bom, language string) error {
+	return nil
+}
+
+func (di *defaultGeneratorImplementation) WriteSBOM(spec *Spec, doc *bom) error {
+	return nil
+}
+
+// getDirectoryTree reads a directory and returns a list of strings of all files init
+func getDirectoryTree(dirPath string) ([]string, error) {
+	fileList := []string{}
+
+	if err := fs.WalkDir(os.DirFS(dirPath), ".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+
+		if d.Type() == os.ModeSymlink {
+			return nil
+		}
+
+		fileList = append(fileList, path)
+		return nil
+	}); err != nil {
+		return nil, fmt.Errorf("buiding directory tree: %w", err)
+	}
+	return fileList, nil
 }

--- a/pkg/sbom/implementation.go
+++ b/pkg/sbom/implementation.go
@@ -197,6 +197,11 @@ func addPackage(doc *spdx.Document, p *pkg) {
 		case *pkg:
 			addPackage(doc, v)
 		}
+		doc.Relationships = append(doc.Relationships, spdx.Relationship{
+			Element: rel.Source.ID(),
+			Type:    rel.Type,
+			Related: rel.Target.ID(),
+		})
 	}
 }
 

--- a/pkg/sbom/implementation.go
+++ b/pkg/sbom/implementation.go
@@ -1,0 +1,23 @@
+// Copyright 2022 Chainguard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sbom
+
+type generatorImplementation interface {
+	GenerateDocument(*Spec) (*bom, error)
+	ScanFiles(*Spec, *bom) error
+	ScanLicenses(*Spec, *bom) error
+	ReadDependencyData(*Spec, *bom, string) error
+	WriteSBOM(*Spec, *bom) error
+}

--- a/pkg/sbom/implementation_test.go
+++ b/pkg/sbom/implementation_test.go
@@ -1,0 +1,45 @@
+// Copyright 2022 Chainguard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Some of this code is based on the bom tool scan code originally
+// found at https://github.com/kubernetes-sigs/bom/blob/main/pkg/spdx/implementation.go
+
+package sbom
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetDirectoryTree(t *testing.T) {
+	d := t.TempDir()
+	original := []string{
+		"/README.go",
+		"/http/agent.go",
+		"/http/httpfakes/fake_agent_implementation.go",
+		"/http.go",
+		"/http_test.go",
+	}
+	for _, tf := range original {
+		dir := filepath.Dir(tf)
+		require.NoError(t, os.MkdirAll(filepath.Join(d, dir), os.FileMode(0o755)))
+		require.NoError(t, os.WriteFile(filepath.Join(d, tf), []byte("dummy"), os.FileMode(0o644)))
+	}
+	readList, err := getDirectoryTree(d)
+	require.NoError(t, err)
+	require.Equal(t, original, readList)
+}

--- a/pkg/sbom/implementation_test.go
+++ b/pkg/sbom/implementation_test.go
@@ -29,9 +29,9 @@ func TestGetDirectoryTree(t *testing.T) {
 	d := t.TempDir()
 	original := []string{
 		"/README.go",
+		"/http.go",
 		"/http/agent.go",
 		"/http/httpfakes/fake_agent_implementation.go",
-		"/http.go",
 		"/http_test.go",
 	}
 	for _, tf := range original {


### PR DESCRIPTION
This PR wires SBOM generation into the melange build process.

It creates basic SBOMs for all apks built by melange. The SBOMs themselves only inventory the apk contents and write them to the SBOM. In the next iterations we will start adding features to the SBOMs like language and build deps, vcs references, smarter licensing, etc.

Closes https://github.com/chainguard-dev/melange/issues/141 