### PR TITLE
fix file descriptor exhaustion when hashing files for SBOMs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	chainguard.dev/apko v0.5.1-0.20221129023637-7aa15e85ee99
 	github.com/dprotaso/go-yit v0.0.0-20220510233725-9ba8df137936
 	github.com/google/go-cmp v0.5.9
+	github.com/korovkin/limiter v0.0.0-20221015170604-22eb1ceceddc
 	github.com/oec/goparsify v0.2.1
 	github.com/psanford/memfs v0.0.0-20210214183328-a001468d78ef
 	github.com/spf13/cobra v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -291,6 +291,8 @@ github.com/klauspost/compress v1.15.11 h1:Lcadnb3RKGin4FYM/orgq0qde+nc15E5Cbqg4B
 github.com/klauspost/compress v1.15.11/go.mod h1:QPwzmACJjUTFsnSHH934V6woptycfrDDJnH7hvFVbGM=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
+github.com/korovkin/limiter v0.0.0-20221015170604-22eb1ceceddc h1:30n5Eq2aBsT+cmDxl8F4PcfptcBxW5J22lbVErc/X9c=
+github.com/korovkin/limiter v0.0.0-20221015170604-22eb1ceceddc/go.mod h1:mM0lzivCxB6c8msz/LOP9lJgZxy92GXwGcNG1A7UZEE=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=

--- a/pkg/sbom/implementation.go
+++ b/pkg/sbom/implementation.go
@@ -125,6 +125,10 @@ func (di *defaultGeneratorImplementation) ScanFiles(spec *Spec, dirPackage *pkg)
 		})
 	}
 
+	if err := g.WaitAndClose(); err != nil {
+		return fmt.Errorf("waiting for limiter to finish: %w", err)
+	}
+
 	if err := g.FirstErrorGet(); err != nil {
 		return err
 	}

--- a/pkg/sbom/implementation.go
+++ b/pkg/sbom/implementation.go
@@ -98,6 +98,8 @@ func (di *defaultGeneratorImplementation) ScanFiles(spec *Spec, dirPackage *pkg)
 	files := sync.Map{}
 	for _, path := range fileList {
 		path := path
+
+		// nolint:errcheck
 		g.Execute(func() {
 			f := file{
 				Name:          path,
@@ -113,6 +115,7 @@ func (di *defaultGeneratorImplementation) ScanFiles(spec *Spec, dirPackage *pkg)
 			} {
 				csum, err := fn(filepath.Join(dirPath, path))
 				if err != nil {
+					// nolint:errcheck
 					g.FirstErrorStore(fmt.Errorf("hashing %s file %s: %w", algo, path, err))
 				}
 				f.Checksums[algo] = csum


### PR DESCRIPTION
Previously, if there were more files than `RLIMIT_NOFILE`, Melange would fail to generate the package-level SBOM due to exhausting the file descriptors.  Accordingly, limit the number of hashing jobs that can run at the same time to avoid FD exhaustion.