### PR TITLE
fix: issue with bump where !!float appears the config file

### DIFF
--- a/pkg/renovate/bump/bump.go
+++ b/pkg/renovate/bump/bump.go
@@ -77,6 +77,7 @@ func New(opts ...Option) renovate.Renovator {
 			return err
 		}
 		versionNode.Value = bcfg.TargetVersion
+		versionNode.Style = yaml.LiteralStyle
 
 		epochNode, err := renovate.NodeFromMapping(packageNode, "epoch")
 		if err != nil {


### PR DESCRIPTION
For example, when an existing package version is only `major`.`minor` say texinfo.yaml which is currently 6.8, the go yaml library reads the version as a float.  When writing the file back is is including the `!!float` text in the version value.

Here's an example of a file where this problem exists https://github.com/wolfi-dev/os/pull/148/files/9fa0cc8cc597f5626a1fbffa458e6122a28cb201#r1036805295

Signed-off-by: James Rawlings <jrawlings@chainguard.dev>