### PR TITLE
add --strip-origin-name option for bootstrapping

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -220,6 +220,7 @@ type Context struct {
 	BreakpointLabel    string
 	ContinueLabel      string
 	foundContinuation  bool
+	StripOriginName    bool
 }
 
 type Dependencies struct {
@@ -492,6 +493,18 @@ func WithBreakpointLabel(breakpointLabel string) Option {
 func WithContinueLabel(continueLabel string) Option {
 	return func(ctx *Context) error {
 		ctx.ContinueLabel = continueLabel
+		return nil
+	}
+}
+
+// WithStripOriginName determines whether the origin name should be stripped
+// from generated packages.  The APK solver uses origin names to flatten
+// possible dependency nodes when solving for a DAG, which means that they
+// should be stripped when building "bootstrap" repositories, as the
+// cross-sysroot packages will be preferred over the native ones otherwise.
+func WithStripOriginName(stripOriginName bool) Option {
+	return func(ctx *Context) error {
+		ctx.StripOriginName = stripOriginName
 		return nil
 	}
 }

--- a/pkg/build/package.go
+++ b/pkg/build/package.go
@@ -42,6 +42,7 @@ type PackageContext struct {
 	Context       *Context
 	Origin        *Package
 	PackageName   string
+	OriginName    string
 	InstalledSize int64
 	DataHash      string
 	OutDir        string
@@ -67,8 +68,9 @@ func (pkg *Package) Emit(ctx *PipelineContext) error {
 func (spkg *Subpackage) Emit(ctx *PipelineContext) error {
 	pc := PackageContext{
 		Context:      ctx.Context,
-		Origin:       &ctx.Context.Configuration.Package,
 		PackageName:  spkg.Name,
+		OriginName:   spkg.Name,
+		Origin:       &ctx.Context.Configuration.Package,
 		OutDir:       filepath.Join(ctx.Context.OutDir, ctx.Context.Arch.ToAPK()),
 		Logger:       log.New(log.Writer(), fmt.Sprintf("melange (%s/%s): ", spkg.Name, ctx.Context.Arch.ToAPK()), log.LstdFlags|log.Lmsgprefix),
 		Dependencies: spkg.Dependencies,
@@ -77,6 +79,11 @@ func (spkg *Subpackage) Emit(ctx *PipelineContext) error {
 		Scriptlets:   spkg.Scriptlets,
 		Description:  spkg.Description,
 	}
+
+	if !ctx.Context.StripOriginName {
+		pc.OriginName = pc.Origin.Name
+	}
+
 	return pc.EmitPackage()
 }
 
@@ -97,7 +104,7 @@ pkgname = {{.PackageName}}
 pkgver = {{.Origin.Version}}-r{{.Origin.Epoch}}
 arch = {{.Arch}}
 size = {{.InstalledSize}}
-origin = {{.Origin.Name}}
+origin = {{.OriginName}}
 pkgdesc = {{.Description}}
 {{- range $copyright := .Origin.Copyright }}
 license = {{ $copyright.License }}

--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -40,6 +40,7 @@ func Build() *cobra.Command {
 	var generateIndex bool
 	var useProot bool
 	var emptyWorkspace bool
+	var stripOriginName bool
 	var outDir string
 	var archstrs []string
 	var extraKeys []string
@@ -74,6 +75,7 @@ func Build() *cobra.Command {
 				build.WithBinShOverlay(overlayBinSh),
 				build.WithBreakpointLabel(breakpointLabel),
 				build.WithContinueLabel(continueLabel),
+				build.WithStripOriginName(stripOriginName),
 			}
 
 			if len(args) > 0 {
@@ -107,6 +109,7 @@ func Build() *cobra.Command {
 	cmd.Flags().BoolVar(&generateIndex, "generate-index", true, "whether to generate APKINDEX.tar.gz")
 	cmd.Flags().BoolVar(&useProot, "use-proot", false, "whether to use proot for fakeroot")
 	cmd.Flags().BoolVar(&emptyWorkspace, "empty-workspace", false, "whether the build workspace should be empty")
+	cmd.Flags().BoolVar(&stripOriginName, "strip-origin-name", false, "whether origin names should be stripped (for bootstrap)")
 	cmd.Flags().StringVar(&outDir, "out-dir", filepath.Join(cwd, "packages"), "directory where packages will be output")
 	cmd.Flags().StringVar(&dependencyLog, "dependency-log", "", "log dependencies to a specified file")
 	cmd.Flags().StringVar(&overlayBinSh, "overlay-binsh", "", "use specified file as /bin/sh overlay in build environment")


### PR DESCRIPTION
Bootstrap packages cannot use origin names safely, the APK solver uses them to collapse dependency nodes.