### PR TITLE
build: fix YAML annotation for subpackage.options

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -131,7 +131,7 @@ type Subpackage struct {
 	Name         string        `yaml:"name"`
 	Pipeline     []Pipeline    `yaml:"pipeline,omitempty"`
 	Dependencies Dependencies  `yaml:"dependencies,omitempty"`
-	Options      PackageOption `yaml:"packageOption,omitempty"`
+	Options      PackageOption `yaml:"options,omitempty"`
 	Scriptlets   Scriptlets    `yaml:"scriptlets,omitempty"`
 	Description  string        `yaml:"description,omitempty"`
 }


### PR DESCRIPTION
options was typoed as packageOption in e9e20df4, fix the annotation so that it matches what bootstrap packages are actually using

Signed-off-by: Ariadne Conill <ariadne@dereferenced.org>