### PR TITLE
pipeline: loadUse: refactor pipeline loading

### DIFF
--- a/pkg/build/pipeline.go
+++ b/pkg/build/pipeline.go
@@ -16,7 +16,6 @@ package build
 
 import (
 	"embed"
-	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -152,16 +151,24 @@ func validateWith(data map[string]string, inputs map[string]Input) (map[string]s
 	return data, nil
 }
 
+func loadPipelineData(dir string, uses string) ([]byte, error) {
+	if dir == "" {
+		return []byte{}, fmt.Errorf("pipeline directory not specified")
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, uses+".yaml"))
+	if err != nil {
+		return []byte{}, err
+	}
+
+	return data, nil
+}
+
 func (p *Pipeline) loadUse(ctx *PipelineContext, uses string, with map[string]string) error {
-	data, err := os.ReadFile(filepath.Join(ctx.Context.PipelineDir, uses+".yaml"))
-	if errors.Is(err, os.ErrNotExist) {
-		// fallback to the builtin pipeline directory search if the given file doesn't exist in the given pipeline directory
-
-		// search the given pipeline within the built-in pipeline directory which is `/usr/share/melange/pipelines` in this case
-		data, err = os.ReadFile(filepath.Join(ctx.Context.BuiltinPipelineDir, uses+".yaml"))
-		if errors.Is(err, os.ErrNotExist) {
-			// fallback to the embedded pipelines compiled into the binary.
-
+	data, err := loadPipelineData(ctx.Context.PipelineDir, uses)
+	if err != nil {
+		data, err = loadPipelineData(ctx.Context.BuiltinPipelineDir, uses)
+		if err != nil {
 			data, err = f.ReadFile("pipelines/" + uses + ".yaml")
 			if err != nil {
 				return fmt.Errorf("unable to load pipeline: %w", err)


### PR DESCRIPTION
- factor out on-disk pipeline loading into loadPipelineData
- require on-disk pipeline locations to actually be explicitly configured

Signed-off-by: Ariadne Conill <ariadne@dereferenced.org>