### PR TITLE
container: BubblewrapRunner: fix leaking of host environment

### DIFF
--- a/pkg/container/bubblewrap_runner.go
+++ b/pkg/container/bubblewrap_runner.go
@@ -38,7 +38,8 @@ func (bw *BWRunner) Run(cfg Config, args ...string) error {
 	baseargs = append(baseargs, "--unshare-pid",
 		"--dev", "/dev",
 		"--proc", "/proc",
-		"--chdir", "/home/build")
+		"--chdir", "/home/build",
+		"--clearenv")
 
 	if !cfg.Capabilities.Networking {
 		baseargs = append(baseargs, "--unshare-net")


### PR DESCRIPTION
Builds of Wolfi packages were found to be not reproducible with Melange git outside of the SDK environment (which clears the environment itself).

https://twitter.com/kpcyrd/status/1598712375305289731

Clear the host environment explicitly in Melange to ensure that host CFLAGS do not leak into the build container environment.