### PR TITLE
Implement support for environment files

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	chainguard.dev/apko v0.5.1-0.20221129023637-7aa15e85ee99
 	github.com/dprotaso/go-yit v0.0.0-20220510233725-9ba8df137936
 	github.com/google/go-cmp v0.5.9
+	github.com/joho/godotenv v1.3.0
 	github.com/korovkin/limiter v0.0.0-20221015170604-22eb1ceceddc
 	github.com/oec/goparsify v0.2.1
 	github.com/psanford/memfs v0.0.0-20210214183328-a001468d78ef

--- a/go.sum
+++ b/go.sum
@@ -275,6 +275,7 @@ github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i
 github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
 github.com/jinzhu/copier v0.3.5 h1:GlvfUwHk62RokgqVNvYsku0TATCF7bAHVwEXoBh3iJg=
 github.com/jinzhu/copier v0.3.5/go.mod h1:DfbEm0FYsaqBcKcFuvmOZb218JkPGtvSHsKg8S8hyyg=
+github.com/joho/godotenv v1.3.0 h1:Zjp+RcGpHhGlrMbJzXTrZZPrWj+1vfm90La1wgB6Bhc=
 github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -282,7 +282,7 @@ func New(opts ...Option) (*Context, error) {
 		return nil, fmt.Errorf("melange.yaml is missing")
 	}
 
-	if err := ctx.Configuration.Load(ctx.ConfigFile); err != nil {
+	if err := ctx.Configuration.Load(ctx); err != nil {
 		return nil, fmt.Errorf("failed to load configuration: %w", err)
 	}
 
@@ -522,8 +522,8 @@ func WithEnvFile(envFile string) Option {
 }
 
 // Load the configuration data from the build context configuration file.
-func (cfg *Configuration) Load(configFile string) error {
-	data, err := os.ReadFile(configFile)
+func (cfg *Configuration) Load(ctx Context) error {
+	data, err := os.ReadFile(ctx.ConfigFile)
 	if err != nil {
 		return fmt.Errorf("unable to load configuration file: %w", err)
 	}

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -221,6 +221,7 @@ type Context struct {
 	ContinueLabel      string
 	foundContinuation  bool
 	StripOriginName    bool
+	EnvFile            string
 }
 
 type Dependencies struct {
@@ -505,6 +506,17 @@ func WithContinueLabel(continueLabel string) Option {
 func WithStripOriginName(stripOriginName bool) Option {
 	return func(ctx *Context) error {
 		ctx.StripOriginName = stripOriginName
+		return nil
+	}
+}
+
+// WithEnvFile specifies an environment file to use to preload the build
+// environment.  It should contain the CFLAGS and LDFLAGS used by the C
+// toolchain as well as any other desired environment settings for the
+// build environment.
+func WithEnvFile(envFile string) Option {
+	return func(ctx *Context) error {
+		ctx.EnvFile = envFile
 		return nil
 	}
 }

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -31,6 +31,7 @@ import (
 	apko_build "chainguard.dev/apko/pkg/build"
 	apko_types "chainguard.dev/apko/pkg/build/types"
 	apkofs "chainguard.dev/apko/pkg/fs"
+	"github.com/joho/godotenv"
 	"github.com/zealic/xignore"
 	"gopkg.in/yaml.v3"
 
@@ -590,6 +591,22 @@ func (cfg *Configuration) Load(ctx Context) error {
 		GID:      1000,
 	}
 	cfg.Environment.Accounts.Users = []apko_types.User{usr}
+
+	// Merge environment file if needed.
+	if ctx.EnvFile != "" {
+		envMap, err := godotenv.Read(ctx.EnvFile)
+		if err != nil {
+			return fmt.Errorf("loading environment file: %w", err)
+		}
+
+		curEnv := cfg.Environment.Environment
+		cfg.Environment.Environment = envMap
+
+		// Overlay the environment in the YAML on top as override.
+		for k, v := range curEnv {
+			cfg.Environment.Environment[k] = v
+		}
+	}
 
 	return nil
 }

--- a/pkg/build/build_test.go
+++ b/pkg/build/build_test.go
@@ -54,8 +54,9 @@ package:
 		t.Fatal(err)
 	}
 
+	ctx := Context{ConfigFile: f}
 	cfg := &Configuration{}
-	if err := cfg.Load(f); err != nil {
+	if err := cfg.Load(ctx); err != nil {
 		t.Fatal(err)
 	}
 	if d := cmp.Diff(expected, cfg); d != "" {
@@ -139,8 +140,9 @@ subpackages:
 		t.Fatal(err)
 	}
 
+	ctx := Context{ConfigFile: f}
 	cfg := &Configuration{}
-	if err := cfg.Load(f); err != nil {
+	if err := cfg.Load(ctx); err != nil {
 		t.Fatal(err)
 	}
 	if d := cmp.Diff(expected, cfg.Subpackages, cmpopts.IgnoreUnexported(Pipeline{})); d != "" {

--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -49,6 +49,7 @@ func Build() *cobra.Command {
 	var overlayBinSh string
 	var breakpointLabel string
 	var continueLabel string
+	var envFile string
 
 	cmd := &cobra.Command{
 		Use:     "build",
@@ -76,6 +77,7 @@ func Build() *cobra.Command {
 				build.WithBreakpointLabel(breakpointLabel),
 				build.WithContinueLabel(continueLabel),
 				build.WithStripOriginName(stripOriginName),
+				build.WithEnvFile(envFile),
 			}
 
 			if len(args) > 0 {
@@ -106,6 +108,7 @@ func Build() *cobra.Command {
 	cmd.Flags().StringVar(&cacheDir, "cache-dir", "/var/cache/melange", "directory used for cached inputs")
 	cmd.Flags().StringVar(&guestDir, "guest-dir", "", "directory used for the build environment guest")
 	cmd.Flags().StringVar(&signingKey, "signing-key", "", "key to use for signing")
+	cmd.Flags().StringVar(&envFile, "env-file", "", "file to use for preloaded environment variables")
 	cmd.Flags().BoolVar(&generateIndex, "generate-index", true, "whether to generate APKINDEX.tar.gz")
 	cmd.Flags().BoolVar(&useProot, "use-proot", false, "whether to use proot for fakeroot")
 	cmd.Flags().BoolVar(&emptyWorkspace, "empty-workspace", false, "whether the build workspace should be empty")


### PR DESCRIPTION
Previously, we inherited the build environment variables from the SDK image environment.  This causes Melange builds to have problems with reproducibility outside of the SDK image environment.  Accordingly, we add `--env-file` to make the build environment configuration explicit via an environment file.