### PR TITLE
build: set some default environment variables

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -609,6 +609,10 @@ func (cfg *Configuration) Load(ctx Context) error {
 	}
 
 	// Set up some useful environment variables.
+	if cfg.Environment.Environment == nil {
+		cfg.Environment.Environment = make(map[string]string)
+	}
+
 	cfg.Environment.Environment["HOME"] = "/home/build"
 	cfg.Environment.Environment["GOPATH"] = "/home/build/.cache/go"
 

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -608,6 +608,10 @@ func (cfg *Configuration) Load(ctx Context) error {
 		}
 	}
 
+	// Set up some useful environment variables.
+	cfg.Environment.Environment["HOME"] = "/home/build"
+	cfg.Environment.Environment["GOPATH"] = "/home/build/.cache/go"
+
 	return nil
 }
 


### PR DESCRIPTION
Now that we explicitly do builds with a blank environment, we must set up some defaults.