### PR TITLE
Rename internal SBOM to use full version

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -936,7 +936,7 @@ func (ctx *Context) BuildPackage() error {
 		if err := generator.GenerateSBOM(&sbom.Spec{
 			Path:           filepath.Join(ctx.WorkspaceDir, "melange-out", sp.Name),
 			PackageName:    sp.Name,
-			PackageVersion: ctx.Configuration.Package.Version,
+			PackageVersion: fmt.Sprintf("%s-r%d", ctx.Configuration.Package.Version, ctx.Configuration.Package.Epoch),
 			Languages:      langs,
 			License:        ctx.Configuration.Package.LicenseExpression(),
 			Copyright:      ctx.Configuration.Package.FullCopyright(),


### PR DESCRIPTION
This commit changes the interna SBOM path inside the apk to use the full
version string, including the epoch.

Signed-off-by: Adolfo García Veytia (Puerco) <puerco@chainguard.dev>