### PR TITLE
Fix go pipeline LDFLAGS variable interpolation

### DIFF
--- a/pkg/build/pipelines/go/build.yaml
+++ b/pkg/build/pipelines/go/build.yaml
@@ -47,7 +47,7 @@ pipeline:
       fi
 
       if [ ! "${{inputs.ldflags}}" == "" ]; then
-        LDFLAGS="{{inputs.ldflags}}"
+        LDFLAGS="${{inputs.ldflags}}"
       fi
 
       DEST_PATH="-o ${{targets.destdir}}/${{inputs.prefix}}/${{inputs.install-dir}}/${{inputs.output}}"


### PR DESCRIPTION
Fixes the error:
`invalid value "{{inputs.ldflags}}" for flag -ldflags: missing =<value> in <pattern>=<value>`