### PR TITLE
Include epoch in SBOM package version

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -1086,7 +1086,7 @@ func (ctx *Context) BuildPackage() error {
 	if err := generator.GenerateSBOM(&sbom.Spec{
 		Path:           filepath.Join(ctx.WorkspaceDir, "melange-out", ctx.Configuration.Package.Name),
 		PackageName:    ctx.Configuration.Package.Name,
-		PackageVersion: ctx.Configuration.Package.Version,
+		PackageVersion: fmt.Sprintf("%s-r%d", ctx.Configuration.Package.Version, ctx.Configuration.Package.Epoch),
 		Languages:      langs,
 		License:        ctx.Configuration.Package.LicenseExpression(),
 		Copyright:      ctx.Configuration.Package.FullCopyright(),


### PR DESCRIPTION
This is a follow-up to #202, which fixed the SBOM package version for subpackages. This PR applies the same fix to main packages as well.