### PR TITLE
Skip SBOM generation for empty apks

### DIFF
--- a/pkg/sbom/generator.go
+++ b/pkg/sbom/generator.go
@@ -49,6 +49,16 @@ type Generator struct {
 
 // GenerateSBOM runs the main SBOM generation process
 func (g *Generator) GenerateSBOM(spec *Spec) error {
+	shouldRun, err := g.impl.CheckEnvironment(spec)
+	if err != nil {
+		return fmt.Errorf("checking SBOM environment: %w", err)
+	}
+
+	if !shouldRun {
+		// log "Not generating SBOM"
+		return nil
+	}
+
 	sbomDoc, err := g.impl.GenerateDocument(spec)
 	if err != nil {
 		return fmt.Errorf("initializing new SBOM: %w", err)

--- a/pkg/sbom/implementation.go
+++ b/pkg/sbom/implementation.go
@@ -38,6 +38,7 @@ import (
 )
 
 type generatorImplementation interface {
+	CheckEnvironment(*Spec) (bool, error)
 	GenerateDocument(*Spec) (*bom, error)
 	GenerateAPKPackage(*Spec) (pkg, error)
 	ScanFiles(*Spec, *pkg) error
@@ -47,6 +48,24 @@ type generatorImplementation interface {
 }
 
 type defaultGeneratorImplementation struct{}
+
+func (di *defaultGeneratorImplementation) CheckEnvironment(spec *Spec) (bool, error) {
+	dirPath, err := filepath.Abs(spec.Path)
+	if err != nil {
+		return false, fmt.Errorf("getting absolute directory path: %w", err)
+	}
+
+	// Check if directory exists
+	if _, err := os.Stat(dirPath); err != nil {
+		if os.IsNotExist(err) {
+			// log "Working directory not found, probably apk is empty"
+			return false, nil
+		}
+		return false, fmt.Errorf("checking if workind directory exists: %w", err)
+	}
+
+	return true, nil
+}
 
 func (di *defaultGeneratorImplementation) GenerateDocument(spec *Spec) (*bom, error) {
 	return &bom{


### PR DESCRIPTION
This PR adds a new stage in SBOM generation, melange will now check the working directory of the apk and if it does not exist, it will skip SBOM generation altogether assuming the apk is empty.

Note log hooks are commented while we wire a logger into the generator

Signed-off-by: Adolfo García Veytia (Puerco) <puerco@chainguard.dev>