### PR TITLE
Export functionality for config parsing

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -554,29 +554,109 @@ func WithEnvFile(envFile string) Option {
 	}
 }
 
-// Load the configuration data from the build context configuration file.
-func (cfg *Configuration) Load(ctx Context) error {
-	data, err := os.ReadFile(ctx.ConfigFile)
-	if err != nil {
-		return fmt.Errorf("unable to load configuration file: %w", err)
+type ConfigurationParsingOption func(*configOptions)
+
+type configOptions struct {
+	abstractFS     fs.FS
+	configFilePath string
+	envFilePath    string
+	logger         Logger
+}
+
+// include reconciles all given opts into the receiver variable, such that it is
+// ready to use for config parsing.
+func (options *configOptions) include(opts ...ConfigurationParsingOption) {
+	for _, fn := range opts {
+		fn(options)
+	}
+	if options.logger == nil {
+		options.logger = nopLogger{}
+	}
+}
+
+// open handles opening of a file with the given name, in such a way that
+// automatically chooses to use an abstract or concrete OS filesystem.
+func (options *configOptions) open(filepath string) (fs.File, error) {
+	if filesystem := options.abstractFS; filesystem != nil {
+		return filesystem.Open(filepath)
 	}
 
-	if err := yaml.Unmarshal(data, cfg); err != nil {
-		return fmt.Errorf("unable to parse configuration file: %w", err)
-	}
+	return os.Open(filepath)
+}
 
+// WithAbstractFS adjusts the behavior of configuration parsing to expect all
+// file paths to be relative to the abstract fs.FS. This approach isn't supported
+// yet except for when opening the config file.
+func WithAbstractFS(filesystem fs.FS) ConfigurationParsingOption {
+	return func(options *configOptions) {
+		options.abstractFS = filesystem
+	}
+}
+
+// WithConfigFile sets the path from which to read the configuration file.
+func WithConfigFile(path string) ConfigurationParsingOption {
+	return func(options *configOptions) {
+		options.configFilePath = path
+	}
+}
+
+// WithEnvFileForParsing set the paths from whcih to read an environment file.
+func WithEnvFileForParsing(path string) ConfigurationParsingOption {
+	return func(options *configOptions) {
+		options.envFilePath = path
+	}
+}
+
+// WithLogger sets the logger to use during configuration parsing. This is
+// optional, and if not supplied, a no-op logger will be used.
+func WithLogger(logger Logger) ConfigurationParsingOption {
+	return func(options *configOptions) {
+		options.logger = logger
+	}
+}
+
+func detectCommit(options *configOptions) string {
 	// Best-effort detection of current commit, to be used when not specified in the config file
-	detectedCommit := ""
-	repo, err := git.PlainOpen(path.Dir(ctx.ConfigFile))
+
+	// TODO: figure out how to use an abstract FS
+	repo, err := git.PlainOpen(path.Dir(options.configFilePath))
 	if err != nil {
-		ctx.Logger.Printf("unable to detect git commit for build configuration: %v", err)
-	} else {
-		head, err := repo.Head()
-		if err == nil {
-			detectedCommit = head.Hash().String()
-			ctx.Logger.Printf("detected git commit for build configuration: %s", detectedCommit)
-		}
+		options.logger.Printf("unable to detect git commit for build configuration: %v", err)
+		return ""
 	}
+
+	head, err := repo.Head()
+	if err != nil {
+		return ""
+	}
+
+	commit := head.Hash().String()
+	options.logger.Printf("detected git commit for build configuration: %s", commit)
+	return commit
+}
+
+// ParseConfiguration returns a decoded build Configuration using the parsing options provided.
+func ParseConfiguration(opts ...ConfigurationParsingOption) (*Configuration, error) {
+	options := &configOptions{}
+	options.include(opts...)
+
+	if options.configFilePath == "" {
+		return nil, errors.New("no configuration file path provided")
+	}
+
+	f, err := options.open(options.configFilePath)
+	if err != nil {
+		return nil, err
+	}
+
+	cfg := Configuration{}
+
+	err = yaml.NewDecoder(f).Decode(&cfg)
+	if err != nil {
+		return nil, fmt.Errorf("unable to decode configuration file: %w", err)
+	}
+
+	detectedCommit := detectCommit(options)
 
 	if cfg.Package.Commit == "" {
 		cfg.Package.Commit = detectedCommit
@@ -598,7 +678,7 @@ func (cfg *Configuration) Load(ctx Context) error {
 		}
 		items, ok := datas[sp.Range]
 		if !ok {
-			return fmt.Errorf("subpackage specified undefined range: %q", sp.Range)
+			return nil, fmt.Errorf("subpackage specified undefined range: %q", sp.Range)
 		}
 
 		for _, it := range items {
@@ -646,10 +726,10 @@ func (cfg *Configuration) Load(ctx Context) error {
 	cfg.Environment.Accounts.Users = []apko_types.User{usr}
 
 	// Merge environment file if needed.
-	if ctx.EnvFile != "" {
-		envMap, err := godotenv.Read(ctx.EnvFile)
+	if envFile := options.envFilePath; envFile != "" {
+		envMap, err := godotenv.Read(envFile)
 		if err != nil {
-			return fmt.Errorf("loading environment file: %w", err)
+			return nil, fmt.Errorf("loading environment file: %w", err)
 		}
 
 		curEnv := cfg.Environment.Environment
@@ -669,6 +749,21 @@ func (cfg *Configuration) Load(ctx Context) error {
 	cfg.Environment.Environment["HOME"] = "/home/build"
 	cfg.Environment.Environment["GOPATH"] = "/home/build/.cache/go"
 
+	return &cfg, nil
+}
+
+// Load the configuration data from the build context configuration file.
+func (cfg *Configuration) Load(ctx Context) error {
+	parsedCfg, err := ParseConfiguration(
+		WithConfigFile(ctx.ConfigFile),
+		WithEnvFileForParsing(ctx.EnvFile),
+		WithLogger(ctx.Logger),
+	)
+	if err != nil {
+		return err
+	}
+
+	*cfg = *parsedCfg
 	return nil
 }
 

--- a/pkg/build/logger.go
+++ b/pkg/build/logger.go
@@ -1,0 +1,16 @@
+package build
+
+type Logger interface {
+	Printf(format string, v ...any)
+	SetPrefix(prefix string)
+}
+
+type nopLogger struct{}
+
+func (n nopLogger) Printf(_ string, _ ...any) {
+	return
+}
+
+func (n nopLogger) SetPrefix(_ string) {
+	return
+}

--- a/pkg/build/logger.go
+++ b/pkg/build/logger.go
@@ -7,10 +7,6 @@ type Logger interface {
 
 type nopLogger struct{}
 
-func (n nopLogger) Printf(_ string, _ ...any) {
-	return
-}
+func (n nopLogger) Printf(_ string, _ ...any) {}
 
-func (n nopLogger) SetPrefix(_ string) {
-	return
-}
+func (n nopLogger) SetPrefix(_ string) {}

--- a/pkg/build/logger.go
+++ b/pkg/build/logger.go
@@ -7,6 +7,6 @@ type Logger interface {
 
 type nopLogger struct{}
 
-func (n nopLogger) Printf(_ string, _ ...any) {}
+func (n nopLogger) Printf(string, ...any) {}
 
-func (n nopLogger) SetPrefix(_ string) {}
+func (n nopLogger) SetPrefix(string) {}


### PR DESCRIPTION
### Background

Previously, the best method available for parsing a Melange config was to call `Load`, which required creating a `build.Context` first.

As our ecosystem consolidates its Melange config parsing logic into Melange itself (which is a good thing), it needs to be as easy as possible to get a decoded configuration to meet a given consumer's needs.

### What's changed

This PR introduces a new `ParseConfiguration` function, along with options for adjusting configuration parsing behavior.

This PR also introduces a `Logger` interface so that it's easier to use the stdlib `log.Logger`, _or not_, depending on one's needs.