### PR TITLE
New pipeline go/install

### DIFF
--- a/pkg/build/pipelines/go/build.yaml
+++ b/pkg/build/pipelines/go/build.yaml
@@ -10,7 +10,8 @@ inputs:
   packages:
     description: |
       List of space-separated packages to compile. Files con also be specified.
-      This value is passed as an argument to go build.
+      This value is passed as an argument to go build. All paths are relative
+      to inputs.modroot.
     required: true
 
   tags:
@@ -22,6 +23,13 @@ inputs:
       Filename to use when writing the binary. The final install location inside 
       the apk will be in prefix / install-dir / output
     required: true
+
+  modroot:
+    default: "."
+    required: false
+    description: |
+      Top directory of the go module, this is where go.mod lives. Before buiding
+      the go pipeline wil cd into this directory.
 
   prefix:
     description: |
@@ -51,6 +59,6 @@ pipeline:
       fi
 
       DEST_PATH="-o ${{targets.destdir}}/${{inputs.prefix}}/${{inputs.install-dir}}/${{inputs.output}}"
-      
+      cd "${{inputs.modroot}}"
       go build ${DEST_PATH} -tags "${TAGS}" -ldflags "${LDFLAGS}" ${{inputs.packages}}
       

--- a/pkg/build/pipelines/go/install.yaml
+++ b/pkg/build/pipelines/go/install.yaml
@@ -1,0 +1,68 @@
+name: Run a build using the go compiler
+
+needs:
+  packages:
+    - go
+    - busybox
+    - ca-certificates-bundle
+
+inputs:
+  package:
+    description: |
+      Import path to the package 
+    required: true
+
+  version: 
+    description: |
+      Package version to install. This can be a version tag (v1.0.0), a 
+      commit hash or another ref (eg latest or HEAD).
+
+  prefix:
+    description: |
+      Prefix to relocate binaries
+    default: usr
+
+  install-dir:
+    description: |
+      Directory where binaries will be installed
+    default: bin
+
+  ldflags:
+    description:
+      List of [pattern=]arg to pass to the go compiler with -ldflags
+
+  tags:
+    description: |
+      A comma-separated list of build tags to pass to the go compiler
+
+pipeline:
+  - runs: |
+      TAGS=""
+      LDFLAGS=""
+      VERSION=""
+
+      # Installed binaries will be stored in a tmp dir
+      export GOBIN=$(mktemp -d)
+
+      if [ ! "${{inputs.tags}}" == "" ]; then
+        TAGS="${{inputs.tags}}"
+      fi
+
+      if [ ! "${{inputs.ldflags}}" == "" ]; then
+        LDFLAGS="${{inputs.ldflags}}"
+      fi
+
+      if [ ! "${{inputs.version}}" == "" ]; then
+        VERSION="@${{inputs.version}}"
+      fi
+
+      # Run go install
+      go install ${DEST_PATH} -tags "${TAGS}" -ldflags "${LDFLAGS}" ${{inputs.package}}${VERSION}
+      mkdir -p ${{targets.destdir}}/${{inputs.prefix}}/${{inputs.install-dir}}
+
+      # Move all resulting files to the target dir
+      echo "go/install: Installing built binaries"
+      for f in $(ls ${GOBIN})
+      do
+        mv -v ${GOBIN}/${f} ${{targets.destdir}}/${{inputs.prefix}}/${{inputs.install-dir}}/${f}
+      done


### PR DESCRIPTION
This PR adds a small improvement to the `go/build` pipeline to allow running a build in a different directory than the current $CWD. More importantly, it introduces a new `go/install` pipeline [as suggested by @imjasonh](https://github.com/chainguard-dev/melange/pull/180#pullrequestreview-1192458615)  that runs a go build using `go install ...`.

Here's a sample from my tests:

```yaml
pipeline:
  - uses: go/install
    with:
      package: github.com/uservers/miniprow/actions/broker
      version: HEAD
```
Using go install lets us rely on the go binary to download all packages and avoid having to clone repos or `fetch` manually.