### PR TITLE
Add purl generation and --namespace option to melange build

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/joho/godotenv v1.4.0
 	github.com/korovkin/limiter v0.0.0-20221015170604-22eb1ceceddc
 	github.com/oec/goparsify v0.2.1
+	github.com/package-url/packageurl-go v0.1.1-0.20220203205134-d70459300c8a
 	github.com/psanford/memfs v0.0.0-20210214183328-a001468d78ef
 	github.com/spf13/cobra v1.6.1
 	github.com/stretchr/testify v1.8.1
@@ -115,7 +116,6 @@ require (
 	github.com/onsi/gomega v1.23.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.0-rc2 // indirect
-	github.com/package-url/packageurl-go v0.1.1-0.20220203205134-d70459300c8a // indirect
 	github.com/pjbgf/sha1cd v0.2.3 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -86,14 +86,12 @@ type Package struct {
 func (p Package) PackageURL(distro string) string {
 	const typ = "apk"
 	version := fmt.Sprintf("%s-r%d", p.Version, p.Epoch)
-	namespace := distro
 
-	return fmt.Sprintf("pkg:%s/%s/%s@%s?distro=%s",
+	return fmt.Sprintf("pkg:%s/%s/%s@%s",
 		typ,
-		namespace,
+		distro,
 		p.Name,
 		version,
-		distro,
 	)
 }
 
@@ -169,14 +167,12 @@ type Subpackage struct {
 // information, see https://github.com/package-url/purl-spec#purl.
 func (spkg Subpackage) PackageURL(distro, packageVersionWithRelease string) string {
 	const typ = "apk"
-	namespace := distro
 
-	return fmt.Sprintf("pkg:%s/%s/%s@%s?distro=%s",
+	return fmt.Sprintf("pkg:%s/%s/%s@%s",
 		typ,
-		namespace,
+		distro,
 		spkg.Name,
 		packageVersionWithRelease,
-		distro,
 	)
 }
 

--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -50,6 +50,7 @@ func Build() *cobra.Command {
 	var breakpointLabel string
 	var continueLabel string
 	var envFile string
+	var purlNamespace string
 
 	cmd := &cobra.Command{
 		Use:     "build",
@@ -78,6 +79,7 @@ func Build() *cobra.Command {
 				build.WithContinueLabel(continueLabel),
 				build.WithStripOriginName(stripOriginName),
 				build.WithEnvFile(envFile),
+				build.WithNamespace(purlNamespace),
 			}
 
 			if len(args) > 0 {
@@ -118,7 +120,8 @@ func Build() *cobra.Command {
 	cmd.Flags().StringVar(&overlayBinSh, "overlay-binsh", "", "use specified file as /bin/sh overlay in build environment")
 	cmd.Flags().StringVar(&breakpointLabel, "breakpoint-label", "", "stop build execution at the specified label")
 	cmd.Flags().StringVar(&continueLabel, "continue-label", "", "continue build execution at the specified label")
-	cmd.Flags().StringSliceVar(&archstrs, "arch", nil, "architectures to build for (e.g., x86_64,ppc64le,arm64) -- default is all, unless specified in config.")
+	cmd.Flags().StringVar(&purlNamespace, "namespace", "unknown", "namespace to use in package URLs in SBOM (eg wolfi, alpine)")
+	cmd.Flags().StringSliceVar(&archstrs, "arch", nil, "architectures to build for (e.g., x86_64,ppc64le,arm64) -- default is all, unless specified in config")
 	cmd.Flags().StringSliceVarP(&extraKeys, "keyring-append", "k", []string{}, "path to extra keys to include in the build environment keyring")
 	cmd.Flags().StringSliceVarP(&extraRepos, "repository-append", "r", []string{}, "path to extra repositories to include in the build environment")
 

--- a/pkg/sbom/bom.go
+++ b/pkg/sbom/bom.go
@@ -37,6 +37,8 @@ type pkg struct {
 	Copyright        string
 	LicenseDeclared  string
 	LicenseConcluded string
+	Namespace        string
+	Arch             string
 	Checksums        map[string]string
 	Relationships    []relationship
 }

--- a/pkg/sbom/generator.go
+++ b/pkg/sbom/generator.go
@@ -39,6 +39,8 @@ type Spec struct {
 	PackageVersion string
 	License        string // Full SPDX license expression
 	Copyright      string
+	Namespace      string
+	Arch           string
 	Languages      []string
 }
 


### PR DESCRIPTION
This PR adds package URLs to entries in the SBOMs describing the packages built by melange. In order to configure the purl we now expose a `--namespace` flag that sets the string which will be used as the namespace value in the purl.

@luhring : This PR also removes the aliased `distro=` qualifier that used the same value as the namespace. As wolfi is a rolling (un)distro, we don't need to define it now (we only have one flavor at the moment). If we need a distro qualifier we can add it later.

Here's an example:

### Invocation:
```
melange build --namespace=wolfi --arch=x86_64 openssh.yaml
```

### Output (fragment from the produced openssh-server apk SBOM):
```json

"packages": [
    {
      "SPDXID": "SPDXRef-Package-openssh-server",
      "name": "openssh-server",
      "versionInfo": "9.0_p1-r0",
      "filesAnalyzed": true,
      "hasFiles": [
        "SPDXRef-File-/etc/ssh/sshd_config",
        "SPDXRef-File-/usr/sbin/sshd"
      ],
      "licenseConcluded": "NOASSERTION",
      "licenseDeclared": "ISC",
      "downloadLocation": "NOASSERTION",
      "copyrightText": "TODO\n",
      "checksums": [],
      "externalRefs": [
        {
          "referenceCategory": "PACKAGE_MANAGER",
          "referenceLocator": "pkg:apk/wolfi/openssh-server@9.0_p1-r0?arch=x86_64",
          "referenceType": "purl"
        }
      ],
      "packageVerificationCode": {
        "packageVerificationCodeValue": "01b354575a7938f3f64cdf7458059d85d46c6a68"
      }
    }
  ],
```