### PR TITLE
Close lingering file descriptor at index generation

### DIFF
--- a/pkg/index/index.go
+++ b/pkg/index/index.go
@@ -104,6 +104,7 @@ func (ctx *Context) GenerateIndex() error {
 			if err != nil {
 				return fmt.Errorf("failed to open package %s: %w", apkFile, err)
 			}
+			defer f.Close()
 			pkg, err := apkrepo.ParsePackage(f)
 			if err != nil {
 				return fmt.Errorf("failed to parse package %s: %w", apkFile, err)


### PR DESCRIPTION
This commit fixes a bug that caused melange to leak file descriptors when generating the apk index, possibly hitting the max open files limit.


Signed-off-by: Adolfo García Veytia (Puerco) <puerco@chainguard.dev>