### PR TITLE
Generate build environment SBOM

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -1274,6 +1274,7 @@ func (ctx *Context) BuildPackage() error {
 		License:        ctx.Configuration.Package.LicenseExpression(),
 		Copyright:      ctx.Configuration.Package.FullCopyright(),
 		Namespace:      namespace,
+		GuestPath:      ctx.GuestDir,
 		Arch:           ctx.Arch.ToAPK(),
 	}
 

--- a/pkg/sbom/bom.go
+++ b/pkg/sbom/bom.go
@@ -33,12 +33,14 @@ type pkg struct {
 	Version          string
 	HomePage         string
 	Supplier         string
+	DownloadLocation string
 	Originator       string
 	Copyright        string
 	LicenseDeclared  string
 	LicenseConcluded string
 	Namespace        string
 	Arch             string
+	Purl             string
 	Checksums        map[string]string
 	Relationships    []relationship
 }

--- a/pkg/sbom/generator.go
+++ b/pkg/sbom/generator.go
@@ -78,7 +78,9 @@ func (g *Generator) GenerateBuildEnvSBOM(spec *Spec) error {
 	doc.Packages = append(doc.Packages, pkg)
 
 	for _, name := range append([]string{spec.PackageName}, spec.Subpackages...) {
-		if err := g.impl.WriteSBOM(spec, doc, name, "%s-build-%s.spdx.json"); err != nil {
+		if err := g.impl.WriteSBOM(
+			spec, doc, name, fmt.Sprintf("%s-build-%s.spdx.json", spec.PackageName, spec.PackageVersion),
+		); err != nil {
 			return fmt.Errorf("writing sbom to disk: %w", err)
 		}
 	}
@@ -132,7 +134,8 @@ func (g *Generator) GenerateSBOM(spec *Spec) error {
 
 	// Finally, write the SBOM data to disk
 	if err := g.impl.WriteSBOM(
-		spec, sbomDoc, spec.PackageName, "%s-%s.spdx.json",
+		spec, sbomDoc, spec.PackageName,
+		fmt.Sprintf("%s-%s.spdx.json", spec.PackageName, spec.PackageVersion),
 	); err != nil {
 		return fmt.Errorf("writing sbom to disk: %w", err)
 	}

--- a/pkg/sbom/generator.go
+++ b/pkg/sbom/generator.go
@@ -41,7 +41,9 @@ type Spec struct {
 	Copyright      string
 	Namespace      string
 	Arch           string
-	GuestPath      string // Path to the apko build environment fs
+	GuestDir       string // Path to the apko build environment fs
+	WorkspaceDir   string
+	Subpackages    []string
 	Languages      []string
 }
 
@@ -69,6 +71,12 @@ func (g *Generator) GenerateBuildEnvSBOM(spec *Spec) error {
 	}
 
 	doc.Packages = append(doc.Packages, pkg)
+
+	for _, name := range append([]string{spec.PackageName}, spec.Subpackages...) {
+		if err := g.impl.WriteSBOM(spec, doc, name, "%s-%s-build.spdx.json"); err != nil {
+			return fmt.Errorf("writing sbom to disk: %w", err)
+		}
+	}
 	return nil
 }
 
@@ -118,7 +126,9 @@ func (g *Generator) GenerateSBOM(spec *Spec) error {
 	}
 
 	// Finally, write the SBOM data to disk
-	if err := g.impl.WriteSBOM(spec, sbomDoc); err != nil {
+	if err := g.impl.WriteSBOM(
+		spec, sbomDoc, spec.PackageName, "%s-%s.spdx.json",
+	); err != nil {
 		return fmt.Errorf("writing sbom to disk: %w", err)
 	}
 

--- a/pkg/sbom/generator.go
+++ b/pkg/sbom/generator.go
@@ -14,7 +14,10 @@
 
 package sbom
 
-import "fmt"
+import (
+	"fmt"
+	"os"
+)
 
 func NewGenerator() (*Generator, error) {
 	return &Generator{
@@ -60,6 +63,8 @@ func (g *Generator) GenerateBuildEnvSBOM(spec *Spec) error {
 		return fmt.Errorf("while reading apk index: %w", err)
 	}
 
+	fmt.Fprintf(os.Stderr, "There are %d packages in the build SBOM", len(pkgs))
+
 	pkg, err := g.impl.GenerateBuildPackage(spec, pkgs)
 	if err != nil {
 		return fmt.Errorf("generating build environment package: %w", err)
@@ -73,7 +78,7 @@ func (g *Generator) GenerateBuildEnvSBOM(spec *Spec) error {
 	doc.Packages = append(doc.Packages, pkg)
 
 	for _, name := range append([]string{spec.PackageName}, spec.Subpackages...) {
-		if err := g.impl.WriteSBOM(spec, doc, name, "%s-%s-build.spdx.json"); err != nil {
+		if err := g.impl.WriteSBOM(spec, doc, name, "%s-build-%s.spdx.json"); err != nil {
 			return fmt.Errorf("writing sbom to disk: %w", err)
 		}
 	}

--- a/pkg/sbom/implementation.go
+++ b/pkg/sbom/implementation.go
@@ -216,6 +216,9 @@ func (di *defaultGeneratorImplementation) ReadDependencyData(spec *Spec, doc *bo
 }
 
 func computeVerificationCode(hashList []string) string {
+	if len(hashList) == 0 {
+		return ""
+	}
 	// Sort the strings:
 	sort.Strings(hashList)
 	h := sha1.New()

--- a/pkg/sbom/implementation.go
+++ b/pkg/sbom/implementation.go
@@ -446,8 +446,7 @@ func (di *defaultGeneratorImplementation) WriteSBOM(spec *Spec, doc *bom, packag
 		return fmt.Errorf("creating SBOM directory in apk filesystem: %w", err)
 	}
 
-	apkSBOMpath := filepath.Join(dirPath, apkSBOMdir, fmt.Sprintf(fileName, packageName, spec.PackageVersion))
-	f, err := os.Create(apkSBOMpath)
+	f, err := os.Create(filepath.Join(dirPath, apkSBOMdir, fileName))
 	if err != nil {
 		return fmt.Errorf("opening SBOM file for writing: %w", err)
 	}
@@ -593,7 +592,7 @@ func (di *defaultGeneratorImplementation) GenerateBuildPackage(spec *Spec, packa
 				id:               "",
 				Name:             n,
 				DownloadLocation: downloadURL,
-				Version:          spec.PackageName,
+				Version:          spec.PackageVersion,
 				Originator:       "",
 				Copyright:        spec.Copyright,
 				LicenseDeclared:  spec.License,


### PR DESCRIPTION
This PR modifies melange to generate an SBOM describing the build environment assembled to build the apks in a build. The new SBOM lists all the SBOMs installed into the build environment in a package describing them as a bundle.

### Structure

The build environment package links to the produced apks identifying itself as a `BUILD_TOOL_OF` of the package. It looks like this:

```
 📂 SPDX Document apk-hello-2.12-r0
  │ 
  │ 📦 DESCRIBES 1 Packages
  │ 
  ├ hello-build@2.12-r0
  │  │ 🔗 29 Relationships
  │  ├ DEPENDS_ON PACKAGE glibc-locale-posix@2.36-r4
  │  ├ DEPENDS_ON PACKAGE wolfi-baselayout@20221118-r0
  │  ├ DEPENDS_ON PACKAGE glibc@2.36-r4
  │  ├ DEPENDS_ON PACKAGE binutils@2.39-r4
  │  ├ DEPENDS_ON PACKAGE libstdc++-dev@12.2.0-r6
  │  ├ DEPENDS_ON PACKAGE libgcc@12.2.0-r6
  │  ├ DEPENDS_ON PACKAGE libstdc++@12.2.0-r6
  │  ├ DEPENDS_ON PACKAGE gmp@6.2.1-r4
  │  ├ DEPENDS_ON PACKAGE isl@0.24-r2
  │  ├ DEPENDS_ON PACKAGE mpfr@4.2.0-r0
  │  ├ DEPENDS_ON PACKAGE mpc@1.2.1-r2
  │  ├ DEPENDS_ON PACKAGE zlib@1.2.13-r1
  │  ├ DEPENDS_ON PACKAGE gcc@12.2.0-r6
  │  ├ DEPENDS_ON PACKAGE linux-headers@5.19.17-r0
  │  ├ DEPENDS_ON PACKAGE glibc-dev@2.36-r4
  │  ├ DEPENDS_ON PACKAGE make@4.3-r1
  │  ├ DEPENDS_ON PACKAGE pkgconf@1.9.3-r3
  │  ├ DEPENDS_ON PACKAGE build-base@1-r3
  │  ├ DEPENDS_ON PACKAGE scanelf@1.3.4-r2
  │  ├ DEPENDS_ON PACKAGE libcrypto3@3.0.7-r1
  │  ├ DEPENDS_ON PACKAGE libssl3@3.0.7-r1
  │  ├ DEPENDS_ON PACKAGE wget@1.21.3-r2
  │  ├ DEPENDS_ON PACKAGE ca-certificates-bundle@20220614-r2
  │  ├ DEPENDS_ON PACKAGE apk-tools@2.12.10-r0
  │  ├ DEPENDS_ON PACKAGE busybox@1.35.0-r4
  │  ├ DEPENDS_ON PACKAGE wolfi-keys@1-r3
  │  ├ DEPENDS_ON PACKAGE wolfi-base@1-r1
  │  ├ BUILD_TOOL_OF PACKAGE hello@hello
  │  └ BUILD_TOOL_OF PACKAGE hello-doc@hello

```

### Included in all apks

The SBOM is copied into each of the apks emitted by the build and is written in the same directory as the SBOM describing the package itself:
```
tar --list -f /melage/packages/x86_64/hello-doc-2.12-r0.apk
.PKGINFO
usr/share/man/man1/hello.1
var/lib/db/sbom/hello-2.12-r0.spdx.json
var/lib/db/sbom/hello-doc-build-2.12-r0.spdx.json
```

### Wolfi URLs are now auto added

When the namespace is defined as `wolfi`, melange will now correctly construct the DownloadLocation in the SBOM:

```
      "downloadLocation": "https://packages.wolfi.dev/os/x86_64/hello-2.12-r0.apk",
```
