### PR TITLE
Ensure valid SPDX identifier strings

### DIFF
--- a/pkg/sbom/bom.go
+++ b/pkg/sbom/bom.go
@@ -17,6 +17,8 @@
 // data) designed to be transcoded to specific formats.
 package sbom
 
+import "fmt"
+
 type bom struct {
 	Packages []pkg
 	Files    []file
@@ -45,7 +47,7 @@ type pkg struct {
 
 func (p *pkg) ID() string {
 	if p.id != "" {
-		return p.id
+		return fmt.Sprintf("SPDXRef-Package-%s", p.id)
 	}
 	return "SPDXRef-Package-" + p.Name
 }
@@ -60,7 +62,7 @@ type file struct {
 
 func (f *file) ID() string {
 	if f.id != "" {
-		return f.id
+		return fmt.Sprintf("SPDXRef-File-%s", f.id)
 	}
 	return "SPDXRef-File-" + f.Name
 }


### PR DESCRIPTION
This PR introduces a change to make sure all packages and files in the SBOM have valid SPDX identifier strings 

Signed-off-by: Adolfo García Veytia (Puerco) <puerco@chainguard.dev>