### PR TITLE
Drop dependency on chainguard/vex 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.18
 
 require (
 	chainguard.dev/apko v0.6.1-0.20230112190132-a65677fe7e84
-	chainguard.dev/vex v0.0.3-0.20221224011205-1d4b8701e0dd
 	cloud.google.com/go/storage v1.28.1
 	github.com/docker/docker v20.10.22+incompatible
 	github.com/dprotaso/go-yit v0.0.0-20220510233725-9ba8df137936
@@ -14,6 +13,7 @@ require (
 	github.com/joho/godotenv v1.4.0
 	github.com/korovkin/limiter v0.0.0-20221015170604-22eb1ceceddc
 	github.com/oec/goparsify v0.2.1
+	github.com/openvex/go-vex v0.1.1-0.20230117203711-211394f7f8dd
 	github.com/package-url/packageurl-go v0.1.1-0.20220203205134-d70459300c8a
 	github.com/psanford/memfs v0.0.0-20210214183328-a001468d78ef
 	github.com/spf13/cobra v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
 chainguard.dev/apko v0.6.1-0.20230112190132-a65677fe7e84 h1:NC9Xd08+pO9jJk+G4H3AS/O8CWgKRr1QXtfCfnw8Z1w=
 chainguard.dev/apko v0.6.1-0.20230112190132-a65677fe7e84/go.mod h1:QCjOD8kSJzzZNX+hoAzFLcMSQqjK5Whc0OyIe8oti8Y=
-chainguard.dev/vex v0.0.3-0.20221224011205-1d4b8701e0dd h1:KurNZ1Mq6RK90P+z2H7clPw2Lpn5uFmfgJgYr/J0jJc=
-chainguard.dev/vex v0.0.3-0.20221224011205-1d4b8701e0dd/go.mod h1:uNzgmAtDI3UkKkzJrVetp5bq6bpJ5vvYU4JybJxaF6I=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSRU=
@@ -459,6 +457,8 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.0-rc2 h1:2zx/Stx4Wc5pIPDvIxHXvXtQFW/7XWJGmnM7r3wg034=
 github.com/opencontainers/image-spec v1.1.0-rc2/go.mod h1:3OVijpioIKYWTqjiG0zfF6wvoJ4fAXGbjdZuI2NgsRQ=
+github.com/openvex/go-vex v0.1.1-0.20230117203711-211394f7f8dd h1:ah2q0K3DchGUh7vDvnF4Dd+QHv/hNLXwiGALR3DrYfs=
+github.com/openvex/go-vex v0.1.1-0.20230117203711-211394f7f8dd/go.mod h1:jYmYbhQAO/0hquryXND/jMVDBcob8/KkVgzUEUAHsFI=
 github.com/package-url/packageurl-go v0.1.1-0.20220203205134-d70459300c8a h1:tkTSd1nhioPqi5Whu3CQ79UjPtaGOytqyNnSCVOqzHM=
 github.com/package-url/packageurl-go v0.1.1-0.20220203205134-d70459300c8a/go.mod h1:uQd4a7Rh3ZsVg5j0lNyAfyxIeGde9yrlhjF78GzeW0c=
 github.com/pelletier/go-toml v1.7.0/go.mod h1:vwGMzjaWMwyfHwgIBhI2YUM4fB6nL6lVAvS1LBMMhTE=

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -33,18 +33,20 @@ import (
 	apko_oci "chainguard.dev/apko/pkg/build/oci"
 	apko_types "chainguard.dev/apko/pkg/build/types"
 	apkofs "chainguard.dev/apko/pkg/fs"
-	"chainguard.dev/melange/pkg/container"
-	"chainguard.dev/melange/pkg/index"
-	"chainguard.dev/melange/pkg/sbom"
-	"chainguard.dev/vex/pkg/vex"
+
 	"cloud.google.com/go/storage"
 	"github.com/go-git/go-git/v5"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/joho/godotenv"
+	"github.com/openvex/go-vex/pkg/vex"
 	"github.com/zealic/xignore"
 	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
 	"gopkg.in/yaml.v3"
+
+	"chainguard.dev/melange/pkg/container"
+	"chainguard.dev/melange/pkg/index"
+	"chainguard.dev/melange/pkg/sbom"
 )
 
 type Scriptlets struct {


### PR DESCRIPTION
This commit drops the dependency on the old chainguard/vex module in the melange builder.



Signed-off-by: Adolfo García Veytia (Puerco) <puerco@chainguard.dev>