### PR TITLE
pipelines: add working-directory modifier

### DIFF
--- a/examples/working-directory.yaml
+++ b/examples/working-directory.yaml
@@ -1,0 +1,36 @@
+package:
+  name: hello
+  version: 2.12
+  epoch: 0
+  description: "an example of how conditionals influence build behavior"
+  target-architecture:
+    - all
+  copyright:
+    - paths:
+      - "*"
+      license: Not-Applicable
+  dependencies:
+    runtime:
+
+environment:
+  contents:
+    repositories:
+      - https://dl-cdn.alpinelinux.org/alpine/edge/main
+    packages:
+      - alpine-baselayout-data
+      - busybox
+      - ca-certificates-bundle
+
+pipeline:
+  - working-directory: /home/build/foo
+    runs: |
+      echo "current working directory: $(pwd)"
+  - working-directory: /home/build/bar
+    pipeline:
+      - runs: |
+          echo "current working directory: $(pwd)"
+      - working-directory: /home/build/baz
+        runs: |
+          echo "current working directory: $(pwd)"
+  - runs: |
+      mkdir -p "${{targets.destdir}}"

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -148,6 +148,7 @@ type Pipeline struct {
 	Label      string             `yaml:"label,omitempty"`
 	If         string             `yaml:"if,omitempty"`
 	Assertions PipelineAssertions `yaml:"assertions,omitempty"`
+	WorkDir    string             `yaml:"working-directory,omitempty"`
 	logger     *log.Logger
 	steps      int
 	SBOM       SBOM `yaml:"sbom,omitempty"`

--- a/pkg/build/pipeline.go
+++ b/pkg/build/pipeline.go
@@ -227,9 +227,14 @@ func (p *Pipeline) evalRun(ctx *PipelineContext) error {
 	p.With = mutateWith(ctx, p.With)
 	p.dumpWith()
 
+	workdir := "/home/build"
+	if p.WorkDir != "" {
+		workdir = mutateStringFromMap(p.With, p.WorkDir)
+	}
+
 	fragment := mutateStringFromMap(p.With, p.Runs)
 	sys_path := "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
-	script := fmt.Sprintf("#!/bin/sh\nset -e\nexport PATH=%s\n%s\nexit 0\n", sys_path, fragment)
+	script := fmt.Sprintf("#!/bin/sh\nset -e\nexport PATH=%s\ncd %s\n%s\nexit 0\n", sys_path, workdir, fragment)
 	command := []string{"/bin/sh", "-c", script}
 	config := ctx.Context.WorkspaceConfig()
 

--- a/pkg/build/pipeline.go
+++ b/pkg/build/pipeline.go
@@ -203,6 +203,7 @@ func (p *Pipeline) evalUse(ctx *PipelineContext) error {
 	if err != nil {
 		return err
 	}
+	sp.WorkDir = p.WorkDir
 
 	if err := sp.loadUse(ctx, p.Uses, p.With); err != nil {
 		return err
@@ -332,6 +333,10 @@ func (p *Pipeline) Run(ctx *PipelineContext) (bool, error) {
 	}
 
 	for _, sp := range p.Pipeline {
+		if sp.WorkDir == "" {
+			sp.WorkDir = p.WorkDir
+		}
+
 		ran, err := sp.Run(ctx)
 
 		if err != nil {

--- a/pkg/build/pipeline.go
+++ b/pkg/build/pipeline.go
@@ -235,7 +235,7 @@ func (p *Pipeline) evalRun(ctx *PipelineContext) error {
 
 	fragment := mutateStringFromMap(p.With, p.Runs)
 	sys_path := "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
-	script := fmt.Sprintf("#!/bin/sh\nset -e\nexport PATH=%s\ncd %s\n%s\nexit 0\n", sys_path, workdir, fragment)
+	script := fmt.Sprintf("#!/bin/sh\nset -e\nexport PATH=%s\nmkdir -p '%s'\ncd '%s'\n%s\nexit 0\n", sys_path, workdir, workdir, fragment)
 	command := []string{"/bin/sh", "-c", script}
 	config := ctx.Context.WorkspaceConfig()
 


### PR DESCRIPTION
This allows pipelines like:

```yaml
pipeline:
  - working-directory: /home/build/foo
    runs: |
      echo "current working directory: $(pwd)"
  - working-directory: /home/build/bar
    pipeline:
      - runs: |
          echo "current working directory: $(pwd)"
      - working-directory: /home/build/baz
        runs: |
          echo "current working directory: $(pwd)"
```

This will output:

```
current working directory: /home/build/foo
current working directory: /home/build/bar
current working directory: /home/build/baz
```

`working-directory` can also be used with `uses`, e.g.

```yaml
pipeline:
  - working-directory: /home/build/srcA
    uses: fetch
    with:
      ...
```

In that example, the fetched source will be populated in `/home/build/srcA`, rather than the default `/home/build`.

cc @luhring