### PR TITLE
add build variable configuration block, --vars-file build option

### DIFF
--- a/examples/vars.yaml
+++ b/examples/vars.yaml
@@ -1,0 +1,37 @@
+package:
+  name: hello
+  version: 2.12
+  epoch: 0
+  description: "an example of how conditionals influence build behavior"
+  target-architecture:
+    - all
+  copyright:
+    - paths:
+      - "*"
+      license: Not-Applicable
+  dependencies:
+    runtime:
+
+environment:
+  contents:
+    repositories:
+      - https://dl-cdn.alpinelinux.org/alpine/edge/main
+    packages:
+      - alpine-baselayout-data
+      - busybox
+      - ca-certificates-bundle
+
+vars:
+  foo: "Hello"
+  bar: "World"
+  buildLocation: "/home/build/foo"
+
+pipeline:
+  # Variable substitution works for `with`, `working-directory` and
+  # `runs` statements.
+  - working-directory: ${{vars.buildLocation}}
+    runs: |
+      echo "current working directory: $(pwd)"
+  - working-directory: ${{targets.destdir}}
+    runs: |
+      echo "${{vars.foo}} ${{vars.bar}}"

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -197,6 +197,8 @@ type Configuration struct {
 	Data        []RangeData  `yaml:"data,omitempty"`
 	Secfixes    Secfixes     `yaml:"secfixes,omitempty"`
 	Advisories  Advisories   `yaml:"advisories,omitempty"`
+
+	Vars map[string]string `yaml:"vars,omitempty"`
 }
 
 // TODO: ensure that there's no net effect to secdb!

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -308,6 +308,7 @@ type Context struct {
 	foundContinuation  bool
 	StripOriginName    bool
 	EnvFile            string
+	VarsFile           string
 	Runner             container.Runner
 	imgDigest          name.Digest
 	containerConfig    *container.Config
@@ -628,6 +629,15 @@ func WithEnvFile(envFile string) Option {
 	}
 }
 
+// WithVarsFile specifies a variables file to use to populate the build
+// configuration variables block.
+func WithVarsFile(varsFile string) Option {
+	return func(ctx *Context) error {
+		ctx.VarsFile = varsFile
+		return nil
+	}
+}
+
 // WithNamespace takes a string to be used as the namespace in PackageURLs
 // identifying the built apk in the generated SBOM. If no namespace is provided
 // "unknown" will be listed as namespace.
@@ -644,6 +654,8 @@ type configOptions struct {
 	filesystem  fs.FS
 	envFilePath string
 	logger      Logger
+
+	varsFilePath string
 }
 
 // include reconciles all given opts into the receiver variable, such that it is
@@ -681,6 +693,14 @@ func WithEnvFileForParsing(path string) ConfigurationParsingOption {
 func WithLogger(logger Logger) ConfigurationParsingOption {
 	return func(options *configOptions) {
 		options.logger = logger
+	}
+}
+
+// WithVarsFileForParsing sets the path to the vars file to use if the user wishes to
+// populate the variables block from an external file.
+func WithVarsFileForParsing(path string) ConfigurationParsingOption {
+	return func(options *configOptions) {
+		options.varsFilePath = path
 	}
 }
 
@@ -826,6 +846,25 @@ func ParseConfiguration(configurationFilePath string, opts ...ConfigurationParsi
 	cfg.Environment.Environment["HOME"] = "/home/build"
 	cfg.Environment.Environment["GOPATH"] = "/home/build/.cache/go"
 
+	// If a variables file was defined, merge it into the variables block.
+	if varsFile := options.varsFilePath; varsFile != "" {
+		f, err := os.Open(varsFile)
+		if err != nil {
+			return nil, fmt.Errorf("loading variables file: %w", err)
+		}
+		defer f.Close()
+
+		vars := map[string]string{}
+		err = yaml.NewDecoder(f).Decode(&vars)
+		if err != nil {
+			return nil, fmt.Errorf("loading variables file: %w", err)
+		}
+
+		for k, v := range vars {
+			cfg.Vars[k] = v
+		}
+	}
+
 	return &cfg, nil
 }
 
@@ -835,6 +874,7 @@ func (cfg *Configuration) Load(ctx Context) error {
 		ctx.ConfigFile,
 		WithEnvFileForParsing(ctx.EnvFile),
 		WithLogger(ctx.Logger),
+		WithVarsFileForParsing(ctx.VarsFile),
 	)
 	if err != nil {
 		return err

--- a/pkg/build/pipeline.go
+++ b/pkg/build/pipeline.go
@@ -104,6 +104,11 @@ func substitutionMap(ctx *PipelineContext) map[string]string {
 		nw[substitutionSubPkgDir] = fmt.Sprintf("/home/build/melange-out/%s", ctx.Subpackage.Name)
 	}
 
+	for k, v := range ctx.Context.Configuration.Vars {
+		nk := fmt.Sprintf("${{vars.%s}}", k)
+		nw[nk] = mutateStringFromMap(nw, v)
+	}
+
 	return nw
 }
 

--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -50,6 +50,7 @@ func Build() *cobra.Command {
 	var breakpointLabel string
 	var continueLabel string
 	var envFile string
+	var varsFile string
 	var purlNamespace string
 
 	cmd := &cobra.Command{
@@ -79,6 +80,7 @@ func Build() *cobra.Command {
 				build.WithContinueLabel(continueLabel),
 				build.WithStripOriginName(stripOriginName),
 				build.WithEnvFile(envFile),
+				build.WithVarsFile(varsFile),
 				build.WithNamespace(purlNamespace),
 			}
 
@@ -111,6 +113,7 @@ func Build() *cobra.Command {
 	cmd.Flags().StringVar(&guestDir, "guest-dir", "", "directory used for the build environment guest")
 	cmd.Flags().StringVar(&signingKey, "signing-key", "", "key to use for signing")
 	cmd.Flags().StringVar(&envFile, "env-file", "", "file to use for preloaded environment variables")
+	cmd.Flags().StringVar(&varsFile, "vars-file", "", "file to use for preloaded build configuration variables")
 	cmd.Flags().BoolVar(&generateIndex, "generate-index", true, "whether to generate APKINDEX.tar.gz")
 	cmd.Flags().BoolVar(&useProot, "use-proot", false, "whether to use proot for fakeroot")
 	cmd.Flags().BoolVar(&emptyWorkspace, "empty-workspace", false, "whether the build workspace should be empty")


### PR DESCRIPTION
This adds a new section to the melange configuration: a *variable configuration block*.

```yaml
vars:
  uri: https://example.com/foo.tar.gz
  expected-sha256: 2f2846c86932b2b70dcc791e58e8c2c1e11d0ec25ba3df5ed67641d73e763822
  build-directory: /home/build/foobar
  baz: "hello world"
```

These variables can be used as one would expect, e.g.

```yaml
pipeline:
  - working-directory: ${{vars.build-directory}}
    uses: fetch
    with:
      uri: ${{vars.uri}}
      expected-sha256: ${{vars.expected-sha256}}
  - runs: |
      echo "${{vars.baz}}"
```

A yaml file containing an alternative variable configuration block can be specified with `--vars-file`.  The variables defined in that alternative configuration block file will overwrite the variable data defined in the configuration file.