### PR TITLE
Work on guest interface for supporting multiple ways to build the guest.

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -861,50 +861,8 @@ func (cfg Configuration) PackageURLs(distro string) []string {
 
 // BuildGuest invokes apko to build the guest environment.
 func (ctx *Context) BuildGuest() error {
-	// Prepare workspace directory
-	if err := os.MkdirAll(ctx.WorkspaceDir, 0755); err != nil {
-		return fmt.Errorf("mkdir -p %s: %w", ctx.WorkspaceDir, err)
-	}
-
-	// Prepare guest directory
-	if err := os.MkdirAll(ctx.GuestDir, 0755); err != nil {
-		return fmt.Errorf("mkdir -p %s: %w", ctx.GuestDir, err)
-	}
-
-	ctx.Logger.Printf("building workspace in '%s' with apko", ctx.GuestDir)
-
-	bc, err := apko_build.New(ctx.GuestDir,
-		apko_build.WithImageConfiguration(ctx.Configuration.Environment),
-		apko_build.WithProot(ctx.UseProot),
-		apko_build.WithArch(ctx.Arch),
-		apko_build.WithExtraKeys(ctx.ExtraKeys),
-		apko_build.WithExtraRepos(ctx.ExtraRepos),
-		apko_build.WithDebugLogging(true),
-		apko_build.WithLocal(true),
-	)
-	if err != nil {
-		return fmt.Errorf("unable to create build context: %w", err)
-	}
-
-	if err := bc.Refresh(); err != nil {
-		return fmt.Errorf("unable to refresh build context: %w", err)
-	}
-
-	bc.Summarize()
-
-	if !ctx.Runner.NeedsImage() {
-		if err := bc.BuildImage(); err != nil {
-			return fmt.Errorf("unable to generate image: %w", err)
-		}
-	} else {
-		if err := ctx.BuildAndPushLocalImage(bc); err != nil {
-			return fmt.Errorf("unable to generate image: %w", err)
-		}
-	}
-
-	ctx.Logger.Printf("successfully built workspace with apko")
-
-	return nil
+	guest := ctx.Runner.Guest()
+	return guest.Build(ctx)
 }
 
 // BuildAndPushLocalImage uses apko to build and push the image to the local

--- a/pkg/container/apko_guest.go
+++ b/pkg/container/apko_guest.go
@@ -1,0 +1,80 @@
+// Copyright 2023 Chainguard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package container
+
+import (
+	apko_build "chainguard.dev/apko/pkg/build"
+	"chainguard.dev/melange/pkg/build"
+	"fmt"
+	"os"
+)
+
+type AKOGuest struct {
+	Guest
+}
+
+// Build builds the base system inside the runner.
+// For apko, it will install the requested environment from the
+// configuration.
+func (receiver *AKOGuest) Build(ctx *build.Context) error {
+	// Prepare workspace directory
+	if err := os.MkdirAll(ctx.WorkspaceDir, 0755); err != nil {
+		return fmt.Errorf("mkdir -p %s: %w", ctx.WorkspaceDir, err)
+	}
+
+	// Prepare guest directory
+	if err := os.MkdirAll(ctx.GuestDir, 0755); err != nil {
+		return fmt.Errorf("mkdir -p %s: %w", ctx.GuestDir, err)
+	}
+
+	ctx.Logger.Printf("building workspace in '%s' with apko", ctx.GuestDir)
+
+	bc, err := apko_build.New(ctx.GuestDir,
+		apko_build.WithImageConfiguration(ctx.Configuration.Environment),
+		apko_build.WithProot(ctx.UseProot),
+		apko_build.WithArch(ctx.Arch),
+		apko_build.WithExtraKeys(ctx.ExtraKeys),
+		apko_build.WithExtraRepos(ctx.ExtraRepos),
+		apko_build.WithDebugLogging(true),
+		apko_build.WithLocal(true),
+	)
+	if err != nil {
+		return fmt.Errorf("unable to create build context: %w", err)
+	}
+
+	if err := bc.Refresh(); err != nil {
+		return fmt.Errorf("unable to refresh build context: %w", err)
+	}
+
+	bc.Summarize()
+
+	if !ctx.Runner.NeedsImage() {
+		if err := bc.BuildImage(); err != nil {
+			return fmt.Errorf("unable to generate image: %w", err)
+		}
+	} else {
+		if err := ctx.BuildAndPushLocalImage(bc); err != nil {
+			return fmt.Errorf("unable to generate image: %w", err)
+		}
+	}
+
+	ctx.Logger.Printf("successfully built workspace with apko")
+	return nil
+}
+
+// ApkoGuest returns an apko Guest implementation.
+func ApkoGuest() Guest {
+	return &AKOGuest{}
+}

--- a/pkg/container/bubblewrap_runner.go
+++ b/pkg/container/bubblewrap_runner.go
@@ -74,6 +74,12 @@ func (bw *BWRunner) NeedsImage() bool {
 	return false
 }
 
+// Guest returns a Guest implementation for this runner.
+// For Bubblewrap, this is ApkoGuest.
+func (bw *BWRunner) Guest() Guest {
+	return ApkoGuest()
+}
+
 // StartPod starts a pod if necessary.  Not implemented for
 // Bubblewrap runners.
 func (bw *BWRunner) StartPod(cfg *Config) error {

--- a/pkg/container/docker_runner.go
+++ b/pkg/container/docker_runner.go
@@ -186,6 +186,12 @@ func (dk *DKRunner) NeedsImage() bool {
 	return true
 }
 
+// Guest returns a Guest implementation for this runner.
+// For Docker, this is ApkoGuest.
+func (dk *DKRunner) Guest() Guest {
+	return ApkoGuest()
+}
+
 // waitForCommand waits for a command to complete in the pod.
 func (dk *DKRunner) waitForCommand(cfg *Config, ctx context.Context, attachResp types.HijackedResponse, taskIDResp types.IDResponse) error {
 	stdoutPipeR, stdoutPipeW, err := os.Pipe()

--- a/pkg/container/guest.go
+++ b/pkg/container/guest.go
@@ -1,0 +1,21 @@
+// Copyright 2023 Chainguard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package container
+
+import "chainguard.dev/melange/pkg/build"
+
+type Guest interface {
+	Build(ctx *build.Context) error
+}

--- a/pkg/container/runner.go
+++ b/pkg/container/runner.go
@@ -21,6 +21,7 @@ import (
 
 type Runner interface {
 	TestUsability() bool
+	Guest() Guest
 	NeedsImage() bool
 	StartPod(cfg *Config) error
 	Run(cfg *Config, cmd ...string) error


### PR DESCRIPTION
As part of my effort for supporting melange builds on macOS for macOS, I require the use of something other than apko. This PR makes the first steps at decoupling apko directly from the build and turns it into a pluggable interface. Each runner is responsible for specifying what guest it wants to use. This gives the option for an external runner to return a different guest building implementation to fulfill the environment request of a melange file.