### PR TITLE
use merge option to speed up apkindex generation when build

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -1388,9 +1388,19 @@ func (ctx *Context) BuildPackage() error {
 		packageDir := filepath.Join(pctx.Context.OutDir, pctx.Context.Arch.ToAPK())
 		ctx.Logger.Printf("generating apk index from packages in %s", packageDir)
 
+		var apkFiles []string
+		pkgFileName := fmt.Sprintf("%s-%s-r%d.apk", ctx.Configuration.Package.Name, ctx.Configuration.Package.Version, ctx.Configuration.Package.Epoch)
+		apkFiles = append(apkFiles, filepath.Join(packageDir, pkgFileName))
+
+		for _, subpkg := range ctx.Configuration.Subpackages {
+			subpkgFileName := fmt.Sprintf("%s-%s-r%d.apk", subpkg.Name, ctx.Configuration.Package.Version, ctx.Configuration.Package.Epoch)
+			apkFiles = append(apkFiles, filepath.Join(packageDir, subpkgFileName))
+		}
+
 		opts := []index.Option{
-			index.WithPackageDir(packageDir),
+			index.WithPackageFiles(apkFiles),
 			index.WithSigningKey(ctx.SigningKey),
+			index.WithMergeIndexFileFlag(true),
 			index.WithIndexFile(filepath.Join(packageDir, "APKINDEX.tar.gz")),
 		}
 

--- a/pkg/index/index.go
+++ b/pkg/index/index.go
@@ -30,13 +30,21 @@ import (
 )
 
 type Context struct {
-	PackageFiles []string
-	IndexFile    string
-	SigningKey   string
-	Logger       *log.Logger
+	PackageFiles       []string
+	IndexFile          string
+	MergeIndexFileFlag bool
+	SigningKey         string
+	Logger             *log.Logger
 }
 
 type Option func(*Context) error
+
+func WithMergeIndexFileFlag(mergeFlag bool) Option {
+	return func(ctx *Context) error {
+		ctx.MergeIndexFileFlag = mergeFlag
+		return nil
+	}
+}
 
 func WithIndexFile(indexFile string) Option {
 	return func(ctx *Context) error {
@@ -131,9 +139,40 @@ func (ctx *Context) GenerateIndex() error {
 		return err
 	}
 
-	index := &apkrepo.ApkIndex{
-		Packages: packages,
+	var index *apkrepo.ApkIndex
+
+	if ctx.MergeIndexFileFlag {
+		originApkIndex, err := os.Open(ctx.IndexFile)
+		if err == nil {
+			index, err = apkrepo.IndexFromArchive(originApkIndex)
+			if err != nil {
+				return fmt.Errorf("failed to read apkindex from archive file: %w", err)
+			}
+
+			for _, pkg := range packages {
+				found := false
+				for _, p := range index.Packages {
+					if pkg.Name == p.Name {
+						found = true
+						p = pkg
+					}
+				}
+				if !found {
+					index.Packages = append(index.Packages, pkg)
+				}
+			}
+		} else {
+			// indexFile not exists, we just create a new one
+			index = &apkrepo.ApkIndex{
+				Packages: packages,
+			}
+		}
+	} else {
+		index = &apkrepo.ApkIndex{
+			Packages: packages,
+		}
 	}
+
 	ctx.Logger.Printf("generating index at %s", ctx.IndexFile)
 	archive, err := apkrepo.ArchiveFromIndex(index)
 	if err != nil {


### PR DESCRIPTION
I'm new to melange codebase so bear with me here :)

This PR will help to speed up apkindex generation when we build a new package by merging apkindex if exists.

Fixes: #279 (hopefully :)))

Signed-off-by: Tuan Anh Tran <me@tuananh.org>