### PR TITLE
package: findInterpreter: chop trailing nul from interpBuf

### DIFF
--- a/pkg/build/package.go
+++ b/pkg/build/package.go
@@ -309,6 +309,7 @@ func findInterpreter(bin *elf.File) (string, error) {
 			return "", err
 		}
 
+		interpBuf = bytes.Trim(interpBuf, "\x00")
 		return string(interpBuf), nil
 	}
 


### PR DESCRIPTION
ELF specification requires the PT_INTERP program header to be nul-terminated.  Since go does not make use of nul-terminated strings, this meant that the nul was captured into the string.

Strip the nul at the end to deal with it.