### PR TITLE
build: package: add support for defining "replaces" relationships

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -317,6 +317,7 @@ type Context struct {
 type Dependencies struct {
 	Runtime  []string `yaml:"runtime,omitempty"`
 	Provides []string `yaml:"provides,omitempty"`
+	Replaces []string `yaml:"replaces,omitempty"`
 
 	ProviderPriority int `yaml:"provider-priority,omitempty"`
 }

--- a/pkg/build/package.go
+++ b/pkg/build/package.go
@@ -123,6 +123,9 @@ depend = {{ $dep }}
 {{- range $dep := .Dependencies.Provides }}
 provides = {{ $dep }}
 {{- end }}
+{{- range $dep := .Dependencies.Replaces }}
+replaces = {{ $dep }}
+{{- end }}
 {{- if .Dependencies.ProviderPriority }}
 provider_priority = {{ .Dependencies.ProviderPriority }}
 {{- end }}


### PR DESCRIPTION
a "replaces" relationship is used to define that a package may overwrite files belonging to the package declared in the "replaces" relationship.