### PR TITLE
add configurable package building options and if-conditionals for subpackages

### DIFF
--- a/examples/options.yaml
+++ b/examples/options.yaml
@@ -1,0 +1,128 @@
+package:
+  name: curl
+  version: 7.87.0
+  epoch: 3
+  description: "URL retrieval utility and library"
+  target-architecture:
+    - all
+  copyright:
+    - paths:
+        - "*"
+      attestation: TODO
+      license: MIT
+secfixes:
+  7.87.0-r0:
+    - CVE-2022-43551
+    - CVE-2022-43552
+  7.86.0-r0:
+    - CVE-2022-42916
+    - CVE-2022-32221
+
+environment:
+  contents:
+    repositories:
+      - https://packages.wolfi.dev/os
+    keyring:
+      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    packages:
+      - wolfi-base
+      - busybox
+      - ca-certificates-bundle
+      - build-base
+      - nghttp2-dev
+      - openssl-dev
+      - zlib-dev
+      - brotli-dev
+
+vars:
+  with-openssl: --with-openssl
+  with-rustls: --without-rustls
+
+options:
+  rustls:
+    vars:
+      with-openssl: --without-openssl
+      with-rustls: --with-rustls
+    environment:
+      contents:
+        packages:
+          add:
+            - rustls-ffi
+          remove:
+            - openssl-dev
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://curl.se/download/curl-${{package.version}}.tar.xz
+      expected-sha256: ee5f1a1955b0ed413435ef79db28b834ea5f0fb7c8cfb1ce47175cc3bee08fff
+  - if: ${{options.rustls.enabled}} == 'true'
+    runs: |
+      echo "Building with RUSTLS backend"
+  - uses: autoconf/configure
+    with:
+      opts: |
+        --enable-ipv6 \
+        --enable-unix-sockets \
+        ${{vars.with-openssl}} \
+        ${{vars.with-rustls}} \
+        --with-nghttp2 \
+        --with-pic \
+        --disable-ldap \
+        --without-libssh2
+  - uses: autoconf/make
+  - uses: autoconf/make-install
+  - uses: strip
+
+subpackages:
+  - name: "curl-dev"
+    description: "headers for libcurl"
+    pipeline:
+      - uses: split/dev
+    dependencies:
+      runtime:
+        - libcurl4
+  - name: "curl-doc"
+    description: "documentation for curl"
+    pipeline:
+      - uses: split/manpages
+  - if: ${{options.rustls.enabled}} == 'false'
+    name: "libcurl-openssl4"
+    description: "curl library (openssl backend)"
+    dependencies:
+      provides:
+        - libcurl4=7.87.1
+      provider-priority: 5
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/lib
+          mv "${{targets.destdir}}"/usr/lib/libcurl.so.* "${{targets.subpkgdir}}"/usr/lib/
+  - if: ${{options.rustls.enabled}} == 'true'
+    name: "libcurl-rustls4"
+    description: "curl library (rustls backend)"
+    dependencies:
+      provides:
+        - libcurl4=7.87.1
+      provider-priority: 10
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"/usr/lib
+          mv "${{targets.destdir}}"/usr/lib/libcurl.so.* "${{targets.subpkgdir}}"/usr/lib/
+
+advisories:
+  CVE-2022-32221:
+    - timestamp: 2022-12-09T12:10:34-05:00
+      status: fixed
+      fixed-version: 7.86.0-r0
+  CVE-2022-42916:
+    - timestamp: 2022-11-19T10:37:17-05:00
+      status: fixed
+      fixed-version: 7.86.0-r0
+  CVE-2022-43551:
+    - timestamp: 2022-12-21T13:16:36+00:00
+      status: fixed
+      fixed-version: 7.87.0-r0
+  CVE-2022-43552:
+    - timestamp: 2022-12-21T13:16:36+00:00
+      status: fixed
+      fixed-version: 7.87.0-r0

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -199,6 +199,8 @@ type Configuration struct {
 	Advisories  Advisories   `yaml:"advisories,omitempty"`
 
 	Vars map[string]string `yaml:"vars,omitempty"`
+
+	Options map[string]BuildOption `yaml:"options,omitempty"`
 }
 
 // TODO: ensure that there's no net effect to secdb!

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -314,6 +314,8 @@ type Context struct {
 	Runner             container.Runner
 	imgDigest          name.Digest
 	containerConfig    *container.Config
+
+	EnabledBuildOptions []string
 }
 
 type Dependencies struct {
@@ -647,6 +649,17 @@ func WithVarsFile(varsFile string) Option {
 func WithNamespace(namespace string) Option {
 	return func(ctx *Context) error {
 		ctx.Namespace = namespace
+		return nil
+	}
+}
+
+// WithEnabledBuildOptions takes an array of strings representing enabled build
+// options.  These options are referenced in the options block of the Configuration,
+// and represent patches to the configured build process which are optionally
+// applied.
+func WithEnabledBuildOptions(enabledBuildOptions []string) Option {
+	return func(ctx *Context) error {
+		ctx.EnabledBuildOptions = enabledBuildOptions
 		return nil
 	}
 }

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -421,6 +421,17 @@ func New(opts ...Option) (*Context, error) {
 	}
 	ctx.Runner = runner
 
+	// Apply build options to the context.
+	for _, optName := range ctx.EnabledBuildOptions {
+		ctx.Logger.Printf("applying configuration patches for build option %s", optName)
+
+		if opt, ok := ctx.Configuration.Options[optName]; ok {
+			if err := opt.Apply(&ctx); err != nil {
+				return nil, err
+			}
+		}
+	}
+
 	return &ctx, nil
 }
 

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -1460,6 +1460,16 @@ func (ctx *Context) BuildPackage() error {
 		apkFiles = append(apkFiles, filepath.Join(packageDir, pkgFileName))
 
 		for _, subpkg := range ctx.Configuration.Subpackages {
+			pctx.Subpackage = &subpkg
+
+			result, err := subpkg.ShouldRun(&pctx)
+			if err != nil {
+				return err
+			}
+			if !result {
+				continue
+			}
+
 			subpkgFileName := fmt.Sprintf("%s-%s-r%d.apk", subpkg.Name, ctx.Configuration.Package.Version, ctx.Configuration.Package.Epoch)
 			apkFiles = append(apkFiles, filepath.Join(packageDir, subpkgFileName))
 		}

--- a/pkg/build/build_option.go
+++ b/pkg/build/build_option.go
@@ -1,0 +1,39 @@
+// Copyright 2022 Chainguard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build
+
+// ListOption describes an optional deviation to a list, for example, a
+// list of packages.
+type ListOption struct {
+	Add    []string `yaml:"add,omitempty"`
+	Remove []string `yaml:"remove,omitempty"`
+}
+
+// ContentsOption describes an optional deviation to an apko environment's
+// contents block.
+type ContentsOption struct {
+	Packages ListOption `yaml:"packages,omitempty"`
+}
+
+// EnvironmentOption describes an optional deviation to an apko environment.
+type EnvironmentOption struct {
+	Contents ContentsOption `yaml:"contents,omitempty"`
+}
+
+// BuildOption describes an optional deviation to a package build.
+type BuildOption struct {
+	Vars        map[string]string `yaml:"vars,omitempty"`
+	Environment EnvironmentOption `yaml:"environment,omitempty"`
+}

--- a/pkg/build/build_option.go
+++ b/pkg/build/build_option.go
@@ -51,9 +51,7 @@ func (bo BuildOption) Apply(ctx *Context) error {
 
 	// Patch the build environment configuration.
 	lo := bo.Environment.Contents.Packages
-	for _, pkg := range lo.Add {
-		ctx.Configuration.Environment.Contents.Packages = append(ctx.Configuration.Environment.Contents.Packages, pkg)
-	}
+	ctx.Configuration.Environment.Contents.Packages = append(ctx.Configuration.Environment.Contents.Packages, lo.Add...)
 
 	for _, pkg := range lo.Remove {
 		pkgList := ctx.Configuration.Environment.Contents.Packages

--- a/pkg/build/build_option.go
+++ b/pkg/build/build_option.go
@@ -37,3 +37,8 @@ type BuildOption struct {
 	Vars        map[string]string `yaml:"vars,omitempty"`
 	Environment EnvironmentOption `yaml:"environment,omitempty"`
 }
+
+// Apply applies a patch described by a BuildOption to a package build.
+func (bo BuildOption) Apply(ctx *Context) error {
+	return nil
+}

--- a/pkg/build/pipeline.go
+++ b/pkg/build/pipeline.go
@@ -109,6 +109,16 @@ func substitutionMap(ctx *PipelineContext) map[string]string {
 		nw[nk] = mutateStringFromMap(nw, v)
 	}
 
+	for k, _ := range ctx.Context.Configuration.Options {
+		nk := fmt.Sprintf("${{options.%s.enabled}}", k)
+		nw[nk] = "false"
+	}
+
+	for _, opt := range ctx.Context.EnabledBuildOptions {
+		nk := fmt.Sprintf("${{options.%s.enabled}}", opt)
+		nw[nk] = "true"
+	}
+
 	return nw
 }
 

--- a/pkg/build/pipeline.go
+++ b/pkg/build/pipeline.go
@@ -109,7 +109,7 @@ func substitutionMap(ctx *PipelineContext) map[string]string {
 		nw[nk] = mutateStringFromMap(nw, v)
 	}
 
-	for k, _ := range ctx.Context.Configuration.Options {
+	for k := range ctx.Context.Configuration.Options {
 		nk := fmt.Sprintf("${{options.%s.enabled}}", k)
 		nw[nk] = "false"
 	}

--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -52,6 +52,7 @@ func Build() *cobra.Command {
 	var envFile string
 	var varsFile string
 	var purlNamespace string
+	var buildOption []string
 
 	cmd := &cobra.Command{
 		Use:     "build",
@@ -82,6 +83,7 @@ func Build() *cobra.Command {
 				build.WithEnvFile(envFile),
 				build.WithVarsFile(varsFile),
 				build.WithNamespace(purlNamespace),
+				build.WithEnabledBuildOptions(buildOption),
 			}
 
 			if len(args) > 0 {
@@ -125,6 +127,7 @@ func Build() *cobra.Command {
 	cmd.Flags().StringVar(&continueLabel, "continue-label", "", "continue build execution at the specified label")
 	cmd.Flags().StringVar(&purlNamespace, "namespace", "unknown", "namespace to use in package URLs in SBOM (eg wolfi, alpine)")
 	cmd.Flags().StringSliceVar(&archstrs, "arch", nil, "architectures to build for (e.g., x86_64,ppc64le,arm64) -- default is all, unless specified in config")
+	cmd.Flags().StringSliceVar(&buildOption, "build-option", []string{}, "build options to enable")
 	cmd.Flags().StringSliceVarP(&extraKeys, "keyring-append", "k", []string{}, "path to extra keys to include in the build environment keyring")
 	cmd.Flags().StringSliceVarP(&extraRepos, "repository-append", "r", []string{}, "path to extra repositories to include in the build environment")
 


### PR DESCRIPTION
Adds two new features:

**Build options**

These allow patching the build configuration with configurable build variants.  Packages can be added, or removed from the build dependencies, and build variables can be changed.  Additional variables reflecting the build option name are reflected in conditionals.

**Subpackage conditionals**

These control whether or not specific subpackages get built.  They are intended to be used with the `${{options.foo.enabled}}` variables, for example:

```yaml
subpackages:
  - if: ${{options.foo.enabled}} == 'true'
    name: 'foo'
    pipeline:
       ...
```