### PR TITLE
package: only use base soname when generating runtime dependencies across symlinks

### DIFF
--- a/pkg/build/package.go
+++ b/pkg/build/package.go
@@ -394,16 +394,7 @@ func generateSharedObjectNameDeps(pc *PackageContext, generated *Dependencies) e
 				}
 
 				for _, soname := range sonames {
-					parts := strings.Split(soname, ".so.")
-
-					var libver string
-					if len(parts) > 1 {
-						libver = parts[1]
-					} else {
-						libver = "0"
-					}
-
-					generated.Runtime = append(generated.Runtime, fmt.Sprintf("so:%s=%s", soname, libver))
+					generated.Runtime = append(generated.Runtime, fmt.Sprintf("so:%s", soname))
 				}
 			}
 


### PR DESCRIPTION
the logic for generating provides entries was copied too closely.

this resulted in some dependencies being generated, e.g. `so:libc.so.6=6`.  while this is a valid APK dependency, we should avoid this type of dependency, as we may change the provide in the future to be the package version.