### PR TITLE
autoconf: always define the GNU host and build triplets in configure step

### DIFF
--- a/pkg/build/pipelines/autoconf/configure.yaml
+++ b/pkg/build/pipelines/autoconf/configure.yaml
@@ -6,10 +6,22 @@ inputs:
       The directory containing the configure script.
     default: .
 
+  host:
+    description: |
+      The GNU triplet which describes the host system.
+    default: ${{host.triplet.gnu}}
+
+  build:
+    description: |
+      The GNU triplet which describes the build system.
+    default: ${{host.triplet.gnu}}
+
 pipeline:
   - runs: |
       cd ${{inputs.dir}}
       ./configure \
+        --host=${{inputs.host}} \
+        --build=${{inputs.build}} \
         --prefix=/usr \
         --sysconfdir=/etc \
         --libdir=/usr/lib \


### PR DESCRIPTION
Needed for packages like dhcping which have very old `config.guess` files.