### PR TITLE
container: bubblewrap runner: use --new-session to mitigate CVE-2017-5226

### DIFF
--- a/pkg/container/bubblewrap_runner.go
+++ b/pkg/container/bubblewrap_runner.go
@@ -40,7 +40,8 @@ func (bw *BWRunner) Run(cfg *Config, args ...string) error {
 		"--dev", "/dev",
 		"--proc", "/proc",
 		"--chdir", "/home/build",
-		"--clearenv")
+		"--clearenv",
+		"--new-session")
 
 	if !cfg.Capabilities.Networking {
 		baseargs = append(baseargs, "--unshare-net")


### PR DESCRIPTION
Without it, it is possible to escape the sandbox via TIOCSTI ioctls on the session PTY.

Related: https://github.com/containers/bubblewrap/issues/555
Related: https://github.com/containers/bubblewrap/issues/142
Related: https://news.ycombinator.com/item?id=30825088