### PR TITLE
pipeline: only run mkdir -p if absolutely needed

### DIFF
--- a/pkg/build/pipeline.go
+++ b/pkg/build/pipeline.go
@@ -250,7 +250,13 @@ func (p *Pipeline) evalRun(ctx *PipelineContext) error {
 
 	fragment := mutateStringFromMap(p.With, p.Runs)
 	sys_path := "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
-	script := fmt.Sprintf("#!/bin/sh\nset -e\nexport PATH=%s\nmkdir -p '%s'\ncd '%s'\n%s\nexit 0\n", sys_path, workdir, workdir, fragment)
+	script := fmt.Sprintf(`#!/bin/sh
+set -e
+export PATH='%s'
+[ -d '%s' ] || mkdir -p '%s'
+cd '%s'
+%s
+exit 0`, sys_path, workdir, workdir, workdir, fragment)
 	command := []string{"/bin/sh", "-c", script}
 	config := ctx.Context.WorkspaceConfig()
 


### PR DESCRIPTION
in some cases, mkdir -p will fail if a directory already exists, if the permissions wouldnt have allowed it to be created to begin with.