### PR TITLE
Try to fix a strange index generation bug.

### DIFF
--- a/pkg/index/index.go
+++ b/pkg/index/index.go
@@ -152,7 +152,7 @@ func (ctx *Context) GenerateIndex() error {
 			for _, pkg := range packages {
 				found := false
 				for _, p := range index.Packages {
-					if pkg.Name == p.Name {
+					if pkg.Name == p.Name && pkg.Version == p.Version {
 						found = true
 						p = pkg
 					}
@@ -173,7 +173,7 @@ func (ctx *Context) GenerateIndex() error {
 		}
 	}
 
-	ctx.Logger.Printf("generating index at %s", ctx.IndexFile)
+	ctx.Logger.Printf("generating index at %s with new packages: %v", ctx.IndexFile, packages)
 	archive, err := apkrepo.ArchiveFromIndex(index)
 	if err != nil {
 		return fmt.Errorf("failed to create archive from index object: %w", err)


### PR DESCRIPTION
I've seen this occur a few times in prod, and it's just a guess, but I think new package versions aren't making it into the index when run in merge index mode.

I attributed it to a race condition (which I think happens too), but I think this is also an issue.