### PR TITLE
Fix `ruby/clean` pipeline to remove files from the right directory

### DIFF
--- a/pkg/build/pipelines/ruby/build.yaml
+++ b/pkg/build/pipelines/ruby/build.yaml
@@ -11,12 +11,28 @@ inputs:
       Gem name
     required: true
 
+  output:
+    description: |
+      Gem output filename
+    required: false
+
+  opts:
+    description: |
+      Options to pass to gem build
+    required: false
+
 pipeline:
   - runs: |
       if ! [ -x "$(command -v ruby)" ]; then
         echo 'Error: Ruby is not installed.'
         exit 1
       fi
+
   - runs: |
-      
-      gem build ${{inputs.gem}}.gemspec
+      output_flag=''
+      [ -n '${{inputs.output}}' ] && output_flag='--output ${{inputs.output}}'
+
+      gem build \
+        ${{inputs.gem}}.gemspec \
+        ${output_flag} \
+        ${{inputs.opts}}

--- a/pkg/build/pipelines/ruby/clean.yaml
+++ b/pkg/build/pipelines/ruby/clean.yaml
@@ -12,5 +12,8 @@ pipeline:
         exit 1
       fi
   - runs: |
-      cd ${{targets.destdir}}
-      rm -rf build_info cache extensions plugins
+      INSTALL_DIR=${{targets.destdir}}/$(ruby -e 'puts Gem.default_dir')
+      rm -rf ${INSTALL_DIR}/build_info \
+             ${INSTALL_DIR}/cache \
+             ${INSTALL_DIR}/extensions \
+             ${INSTALL_DIR}/plugins

--- a/pkg/build/pipelines/ruby/install.yaml
+++ b/pkg/build/pipelines/ruby/install.yaml
@@ -9,32 +9,53 @@ inputs:
   gem:
     description: |
       Gem name
-    required: true
+    required: false
+
+  gem-file:
+    description: |
+      The full filename of the gem to build
+    required: false
 
   version:
     description: |
-      Gem version to install. This can be a version tag (v1.0.0)
+      Gem version to install. This can be a version tag (1.0.0)
     required: true
 
+  opts:
+    description: |
+      Options to pass to the gem install command
+    default: ''
+    required: false
+
 pipeline:
-  - runs: |
+  - name: Check ruby
+    runs: |
       if ! [ -x "$(command -v ruby)" ]; then
-        echo 'Error: Ruby is not installed.'
+        echo 'ERROR: Ruby is not installed.'
         exit 1
       fi
-  - runs: |
+  - name: Ruby install
+    runs: |
+      if [ -z "${{inputs.gem}}" ] && [ -z "${{inputs.gem-file}}" ]; then
+        echo "ERROR: You need to specify gem or gem-file"
+        exit 1
+      fi
+
+      [ -n '${{inputs.gem-file}}' ] && GEM=${{inputs.gem-file}}
+      [ -n '${{inputs.gem}}' ] && GEM=${{inputs.gem}}-${{inputs.version}}.gem
+
       TARGET_DIR_BIN="${{targets.destdir}}/usr/bin"
       TARGET_DIR_INSTALL="${{targets.destdir}}$(ruby -e 'puts Gem.default_dir')/"
 
       mkdir -p "${TARGET_DIR_BIN}"
       mkdir -p "${TARGET_DIR_INSTALL}"
-      
-      gem install \
-      --install-dir ${TARGET_DIR_INSTALL}  \
-      --bindir ${TARGET_DIR_BIN} \
-      --no-document \
-      --ignore-dependencies \
-      --local \
-      --verbose \
-      -v ${{inputs.version}} \
-      ${{inputs.gem}}-${{inputs.version}}.gem
+
+      gem install ${GEM} \
+        --install-dir ${TARGET_DIR_INSTALL}  \
+        --bindir ${TARGET_DIR_BIN} \
+        --version ${{inputs.version}} \
+        --ignore-dependencies \
+        --no-document \
+        --verbose \
+        --local \
+        ${{inputs.opts}}


### PR DESCRIPTION
The `ruby/clean` pipeline was removing files from the wrong directory causing bloat in gems. I also added some more options to the other gem pipelines to make them a little more flexible