### PR TITLE
pipelines: git-checkout: mark clone directory as a safe directory for git

### DIFF
--- a/pkg/build/pipelines/git-checkout.yaml
+++ b/pkg/build/pipelines/git-checkout.yaml
@@ -41,9 +41,13 @@ pipeline:
       [ -n '${{inputs.branch}}' ] && clone_target='--branch ${{inputs.branch}}'
       [ -n '${{inputs.tag}}' ] && clone_target='--branch ${{inputs.tag}}'
 
-      git clone $clone_target --depth ${{inputs.depth}} ${{inputs.repository}} ${{inputs.destination}}
+      mkdir -p ${{inputs.destination}}
+      clone_fullpath=$(realpath ${{inputs.destination}})
 
-      cd ${{inputs.destination}}
+      git config --global --add safe.directory $clone_fullpath
+      git clone $clone_target --depth ${{inputs.depth}} ${{inputs.repository}} $clone_fullpath
+
+      cd $clone_fullpath
 
       if [ -z "${{inputs.expected-commit}}" ]; then
         echo "Warning (git-checkout): no expected-commit"

--- a/pkg/build/pipelines/git-checkout.yaml
+++ b/pkg/build/pipelines/git-checkout.yaml
@@ -41,13 +41,19 @@ pipeline:
       [ -n '${{inputs.branch}}' ] && clone_target='--branch ${{inputs.branch}}'
       [ -n '${{inputs.tag}}' ] && clone_target='--branch ${{inputs.tag}}'
 
+      workdir=$(mktemp -d)
       mkdir -p ${{inputs.destination}}
       clone_fullpath=$(realpath ${{inputs.destination}})
 
+      git config --global --add safe.directory $workdir
       git config --global --add safe.directory $clone_fullpath
-      git clone $clone_target --depth ${{inputs.depth}} ${{inputs.repository}} $clone_fullpath
+      git clone $clone_target --depth ${{inputs.depth}} ${{inputs.repository}} $workdir
 
+      cd $workdir
+      tar -c . | (cd $clone_fullpath && tar -x)
+      rm -rf $workdir
       cd $clone_fullpath
+      git config --global --add safe.directory $clone_fullpath
 
       if [ -z "${{inputs.expected-commit}}" ]; then
         echo "Warning (git-checkout): no expected-commit"


### PR DESCRIPTION
This suppresses weird "dubious permissions" errors from Git when Melange is running builds as a Docker controller rather than using Bubblewrap.

cc @dlorenc (who pointed this out in Slack with a testcase)