### PR TITLE
Use cond package to do variable substitution

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -802,6 +802,14 @@ func buildConfigMap(cfg *Configuration) map[string]string {
 	return out
 }
 
+func replacerFromMap(with map[string]string) *strings.Replacer {
+	replacements := []string{}
+	for k, v := range with {
+		replacements = append(replacements, k, v)
+	}
+	return strings.NewReplacer(replacements...)
+}
+
 // ParseConfiguration returns a decoded build Configuration using the parsing options provided.
 func ParseConfiguration(configurationFilePath string, opts ...ConfigurationParsingOption) (*Configuration, error) {
 	options := &configOptions{}

--- a/pkg/build/pipeline_test.go
+++ b/pkg/build/pipeline_test.go
@@ -27,8 +27,9 @@ func Test_mutateStringFromMap(t *testing.T) {
 	}
 
 	input1 := "${{inputs.foo}} ${{inputs.baz-bah-boom}}"
-	output1 := mutateStringFromMap(keys, input1)
+	output1, err := mutateStringFromMap(keys, input1)
 
+	require.NoError(t, err)
 	require.Equal(t, output1, "foo ", "bogus variable substitution not deleted")
 }
 

--- a/pkg/cond/parser_test.go
+++ b/pkg/cond/parser_test.go
@@ -71,3 +71,13 @@ func TestVariableLookup(t *testing.T) {
 	require.NoErrorf(t, err, "got error: %v", err)
 	require.Equal(t, true, result, "${{foo.bar}} definitely equals baz")
 }
+
+func TestVariableLookupWhitespace(t *testing.T) {
+	result, err := Evaluate("${{ foo.bar }} == 'baz'", placeholderLookup)
+	require.NoErrorf(t, err, "got error: %v", err)
+	require.Equal(t, true, result, "${{ foo.bar }} definitely equals baz")
+
+	result, err = Evaluate("'baz' == ${{ foo.bar }}", placeholderLookup)
+	require.NoErrorf(t, err, "got error: %v", err)
+	require.Equal(t, true, result, "${{ foo.bar }} definitely equals baz")
+}

--- a/pkg/cond/subst.go
+++ b/pkg/cond/subst.go
@@ -1,0 +1,60 @@
+// Copyright 2023 Chainguard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cond
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/ijt/goparsify"
+)
+
+func Subst(inputExpr string, lookupFns ...VariableLookupFunction) (string, error) {
+	lookupFn := NullLookup
+
+	if len(lookupFns) > 0 {
+		lookupFn = lookupFns[0]
+	}
+
+	whiteSpace := goparsify.Many(goparsify.Exact(" "))
+	variableName := goparsify.Chars("a-z0-9.")
+	variable := goparsify.Seq("${{", whiteSpace, variableName, whiteSpace, "}}").Map(func(n *goparsify.Result) {
+		if resolved, err := lookupFn(n.Child[2].Token); err == nil {
+			n.Token = resolved
+			n.Result = resolved
+		}
+	})
+
+	text := goparsify.Until("${{")
+	node := goparsify.Any(text, variable)
+	document := goparsify.Many(node).Map(func(n *goparsify.Result) {
+		tokens := []string{}
+		for _, tok := range n.Child {
+			tokens = append(tokens, tok.Token)
+		}
+		n.Result = strings.Join(tokens, "")
+	})
+
+	result, _, err := goparsify.Run(document, inputExpr, goparsify.NoWhitespace)
+	if err != nil {
+		return "", fmt.Errorf("parser error: %w", err)
+	}
+
+	if rstr, ok := result.(string); ok {
+		return rstr, nil
+	}
+
+	return "", fmt.Errorf("got non-string result from parser")
+}

--- a/pkg/cond/subst.go
+++ b/pkg/cond/subst.go
@@ -29,11 +29,14 @@ func Subst(inputExpr string, lookupFns ...VariableLookupFunction) (string, error
 	}
 
 	whiteSpace := goparsify.Many(goparsify.Exact(" "))
-	variableName := goparsify.Chars("a-z0-9.")
+	variableName := goparsify.Chars("a-z0-9.\\-")
 	variable := goparsify.Seq("${{", whiteSpace, variableName, whiteSpace, "}}").Map(func(n *goparsify.Result) {
 		if resolved, err := lookupFn(n.Child[2].Token); err == nil {
 			n.Token = resolved
 			n.Result = resolved
+		} else {
+			n.Token = ""
+			n.Result = ""
 		}
 	})
 

--- a/pkg/cond/subst_test.go
+++ b/pkg/cond/subst_test.go
@@ -62,6 +62,10 @@ baz
 	require.Equal(t, expected, result, "result does not match expected result")
 }
 
+func fakeLookup(key string) (string, error) {
+	return "a", nil
+}
+
 func TestSubstVarWhitespaceExactWhitespace(t *testing.T) {
 	doc := `Hello
   ${{ foo.bar }}
@@ -75,4 +79,14 @@ func TestSubstVarWhitespaceExactWhitespace(t *testing.T) {
 
 	require.NoErrorf(t, err, "got error: %v", err)
 	require.Equal(t, expected, result, "result does not match expected result")
+}
+
+func TestSubstVarShellFragment(t *testing.T) {
+	doc := `if [ "${{inputs.expected-sha256}}" == "" ] && [ "${{inputs.expected-sha512}}" == "" ]; then
+  printf "One of expected-sha256 or expected-sha512 is required"
+  exit 1
+fi`
+	_, err := Subst(doc, fakeLookup)
+
+	require.NoErrorf(t, err, "got error: %v", err)
 }

--- a/pkg/cond/subst_test.go
+++ b/pkg/cond/subst_test.go
@@ -1,0 +1,78 @@
+// Copyright 2023 Chainguard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cond
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSubstSimple(t *testing.T) {
+	doc := "Hello ${{foo.bar}}!"
+	expected := "Hello baz!"
+	result, err := Subst(doc, placeholderLookup)
+
+	require.NoErrorf(t, err, "got error: %v", err)
+	require.Equal(t, expected, result, "result does not match expected result")
+}
+
+func TestSubstMulti(t *testing.T) {
+	doc := "Hello ${{foo.bar}} ${{foo.bar}}!"
+	expected := "Hello baz baz!"
+	result, err := Subst(doc, placeholderLookup)
+
+	require.NoErrorf(t, err, "got error: %v", err)
+	require.Equal(t, expected, result, "result does not match expected result")
+}
+
+func TestSubstVarWhitespace(t *testing.T) {
+	doc := "Hello ${{ foo.bar }} ${{foo.bar}}!"
+	expected := "Hello baz baz!"
+	result, err := Subst(doc, placeholderLookup)
+
+	require.NoErrorf(t, err, "got error: %v", err)
+	require.Equal(t, expected, result, "result does not match expected result")
+}
+
+func TestSubstVarWhitespaceNewline(t *testing.T) {
+	doc := `Hello
+${{ foo.bar }}
+${{foo.bar}}
+!`
+	expected := `Hello
+baz
+baz
+!`
+	result, err := Subst(doc, placeholderLookup)
+
+	require.NoErrorf(t, err, "got error: %v", err)
+	require.Equal(t, expected, result, "result does not match expected result")
+}
+
+func TestSubstVarWhitespaceExactWhitespace(t *testing.T) {
+	doc := `Hello
+  ${{ foo.bar }}
+    ${{foo.bar}}
+!`
+	expected := `Hello
+  baz
+    baz
+!`
+	result, err := Subst(doc, placeholderLookup)
+
+	require.NoErrorf(t, err, "got error: %v", err)
+	require.Equal(t, expected, result, "result does not match expected result")
+}


### PR DESCRIPTION
The `cond` package was introduced for `if` expressions.  It allows whitespace in variables such as `${{ foo }}`, instead of `${{foo}}`.

By using `cond` package for substitutions, we can have whitespace in variable substitutions.

Needs more extensive tests, but is promising.

Closes #176.