### PR TITLE
Refactor --cache-dir and separate preloading concerns into --cache-source

### DIFF
--- a/docs/md/melange_build.md
+++ b/docs/md/melange_build.md
@@ -32,7 +32,8 @@ melange build [flags]
       --breakpoint-label string     stop build execution at the specified label
       --build-date string           date used for the timestamps of the files inside the image
       --build-option strings        build options to enable
-      --cache-dir string            directory used for cached inputs (default "/var/cache/melange")
+      --cache-dir string            directory used for cached inputs (default "./melange-cache/")
+      --cache-source string         directory or bucket used for preloading the cache
       --continue-label string       continue build execution at the specified label
       --create-build-log            creates a package.log file containing a list of packages that were built by the command
       --debug                       enables debug logging of build pipelines

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/psanford/memfs v0.0.0-20210214183328-a001468d78ef
 	github.com/spf13/cobra v1.6.1
 	github.com/stretchr/testify v1.8.2
+	github.com/yookoala/realpath v1.0.0
 	github.com/zealic/xignore v0.3.3
 	gitlab.alpinelinux.org/alpine/go v0.6.0
 	golang.org/x/exp v0.0.0-20220827204233-334a2380cb91

--- a/go.sum
+++ b/go.sum
@@ -555,6 +555,8 @@ github.com/xdg-go/scram v1.0.2/go.mod h1:1WAq6h33pAW+iRreB34OORO2Nf7qel3VV3fjBj+
 github.com/xdg-go/scram v1.1.1/go.mod h1:RaEWvsqvNKKvBPvcKeFjrG2cJqOkHTiyTpzz23ni57g=
 github.com/xdg-go/stringprep v1.0.2/go.mod h1:8F9zXuvzgwmyT5DUm4GUfZGDdT3W+LCvS6+da4O5kxM=
 github.com/xdg-go/stringprep v1.0.3/go.mod h1:W3f5j4i+9rC0kuIEJL0ky1VpHXQU3ocBgklLGvcBnW8=
+github.com/yookoala/realpath v1.0.0 h1:7OA9pj4FZd+oZDsyvXWQvjn5oBdcHRTV44PpdMSuImQ=
+github.com/yookoala/realpath v1.0.0/go.mod h1:gJJMA9wuX7AcqLy1+ffPatSCySA1FQ2S8Ya9AIoYBpE=
 github.com/youmark/pkcs8 v0.0.0-20181117223130-1be2e3e5546d/go.mod h1:rHwXgn7JulP+udvsHwJoVG1YGAP6VLg4y9I5dyZdqmA=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -366,7 +366,7 @@ func New(opts ...Option) (*Context, error) {
 		WorkspaceIgnore: ".melangeignore",
 		SourceDir:       ".",
 		OutDir:          ".",
-		CacheDir:        "/var/cache/melange",
+		CacheDir:        "./melange-cache/",
 		Logger:          log.New(log.Writer(), "melange: ", log.LstdFlags|log.Lmsgprefix),
 		Arch:            apko_types.ParseArchitecture(runtime.GOARCH),
 	}

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -38,6 +38,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/joho/godotenv"
 	"github.com/openvex/go-vex/pkg/vex"
+	"github.com/yookoala/realpath"
 	"github.com/zealic/xignore"
 	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
@@ -1648,7 +1649,12 @@ func (ctx *Context) buildWorkspaceConfig() *container.Config {
 
 	if ctx.CacheDir != "" {
 		if fi, err := os.Stat(ctx.CacheDir); err == nil && fi.IsDir() {
-			mounts = append(mounts, container.BindMount{Source: ctx.CacheDir, Destination: "/var/cache/melange"})
+			mountSource, err := realpath.Realpath(ctx.CacheDir)
+			if err != nil {
+				ctx.Logger.Printf("could not resolve path for --cache-dir: %s", err)
+			}
+
+			mounts = append(mounts, container.BindMount{Source: mountSource, Destination: "/var/cache/melange"})
 		} else {
 			ctx.Logger.Printf("--cache-dir %s not a dir; skipping", ctx.CacheDir)
 		}

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -1218,7 +1218,7 @@ func (ctx *Context) fetchBucket(cmm CacheMembershipMap) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	bucket, prefix, _ := strings.Cut(strings.TrimPrefix(ctx.CacheDir, "gs://"), "/")
+	bucket, prefix, _ := strings.Cut(strings.TrimPrefix(ctx.CacheSource, "gs://"), "/")
 
 	client, err := storage.NewClient(cctx)
 	if err != nil {
@@ -1269,11 +1269,11 @@ func (ctx *Context) PopulateCache() error {
 		return fmt.Errorf("while determining which objects to fetch: %w", err)
 	}
 
-	ctx.Logger.Printf("populating cache from %s", ctx.CacheDir)
+	ctx.Logger.Printf("populating cache from %s", ctx.CacheSource)
 
 	// --cache-dir=gs://bucket/path/to/cache first pulls all found objects to a
 	// tmp dir which is subsequently used as the cache.
-	if strings.HasPrefix(ctx.CacheDir, "gs://") {
+	if strings.HasPrefix(ctx.CacheSource, "gs://") {
 		tmp, err := ctx.fetchBucket(cmm)
 		if err != nil {
 			return err

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -338,6 +338,7 @@ type Context struct {
 	CreateBuildLog     bool
 	ignorePatterns     []*xignore.Pattern
 	CacheDir           string
+	CacheSource        string
 	BreakpointLabel    string
 	ContinueLabel      string
 	foundContinuation  bool
@@ -561,6 +562,15 @@ func WithSourceDir(sourceDir string) Option {
 func WithCacheDir(cacheDir string) Option {
 	return func(ctx *Context) error {
 		ctx.CacheDir = cacheDir
+		return nil
+	}
+}
+
+// WithCacheSource sets the cache source directory to use.  The cache will be
+// pre-populated from this source directory.
+func WithCacheSource(sourceDir string) Option {
+	return func(ctx *Context) error {
+		ctx.CacheSource = sourceDir
 		return nil
 	}
 }

--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -107,7 +107,7 @@ func Build() *cobra.Command {
 	cmd.Flags().StringVar(&workspaceDir, "workspace-dir", "", "directory used for the workspace at /home/build")
 	cmd.Flags().StringVar(&pipelineDir, "pipeline-dir", "", "directory used to extend defined built-in pipelines")
 	cmd.Flags().StringVar(&sourceDir, "source-dir", "", "directory used for included sources")
-	cmd.Flags().StringVar(&cacheDir, "cache-dir", "/var/cache/melange", "directory used for cached inputs")
+	cmd.Flags().StringVar(&cacheDir, "cache-dir", "./melange-cache/", "directory used for cached inputs")
 	cmd.Flags().StringVar(&guestDir, "guest-dir", "", "directory used for the build environment guest")
 	cmd.Flags().StringVar(&signingKey, "signing-key", "", "key to use for signing")
 	cmd.Flags().StringVar(&envFile, "env-file", "", "file to use for preloaded environment variables")

--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -34,6 +34,7 @@ func Build() *cobra.Command {
 	var pipelineDir string
 	var sourceDir string
 	var cacheDir string
+	var cacheSource string
 	var guestDir string
 	var signingKey string
 	var generateIndex bool
@@ -67,6 +68,7 @@ func Build() *cobra.Command {
 				build.WithWorkspaceDir(workspaceDir),
 				build.WithPipelineDir(pipelineDir),
 				build.WithCacheDir(cacheDir),
+				build.WithCacheSource(cacheSource),
 				build.WithGuestDir(guestDir),
 				build.WithSigningKey(signingKey),
 				build.WithGenerateIndex(generateIndex),
@@ -108,6 +110,7 @@ func Build() *cobra.Command {
 	cmd.Flags().StringVar(&pipelineDir, "pipeline-dir", "", "directory used to extend defined built-in pipelines")
 	cmd.Flags().StringVar(&sourceDir, "source-dir", "", "directory used for included sources")
 	cmd.Flags().StringVar(&cacheDir, "cache-dir", "./melange-cache/", "directory used for cached inputs")
+	cmd.Flags().StringVar(&cacheSource, "cache-source", "", "directory or bucket used for preloading the cache")
 	cmd.Flags().StringVar(&guestDir, "guest-dir", "", "directory used for the build environment guest")
 	cmd.Flags().StringVar(&signingKey, "signing-key", "", "key to use for signing")
 	cmd.Flags().StringVar(&envFile, "env-file", "", "file to use for preloaded environment variables")


### PR DESCRIPTION
Previously `--cache-dir` was assumed to be both a GCS bucket and a destination directory.  This made the feature unusable on Darwin hosts, which rejected the GCS bucket name as a valid filename on disk.

Fixes #329.