### PR TITLE
add query and package-version commands

### DIFF
--- a/pkg/cli/commands.go
+++ b/pkg/cli/commands.go
@@ -34,6 +34,8 @@ func New() *cobra.Command {
 	cmd.AddCommand(SignIndex())
 	cmd.AddCommand(UpdateCache())
 	cmd.AddCommand(Convert())
+	cmd.AddCommand(PackageVersion())
+	cmd.AddCommand(Query())
 	cmd.AddCommand(version.Version())
 	return cmd
 }

--- a/pkg/cli/packageversion.go
+++ b/pkg/cli/packageversion.go
@@ -1,0 +1,39 @@
+// Copyright 2023 Chainguard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"chainguard.dev/melange/pkg/build"
+	"github.com/spf13/cobra"
+)
+
+func PackageVersion() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "package-version",
+		Short: "Report the target package for a YAML configuration file",
+		Long: `Report the target package for a YAML configuration file.
+		Shortcut for equivlaent of running:
+		
+			melange query config.yaml '{{ .Package.Name }}-{{ .Package.Version }}-r{{ .Package.Epoch }}'
+		`,
+		Example: `  melange package-version [config.yaml]`,
+		Args:    cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return QueryCmd(cmd.Context(), "{{ .Package.Name }}-{{ .Package.Version }}-r{{ .Package.Epoch }}", build.WithConfig(args[0]))
+		},
+	}
+
+	return cmd
+}

--- a/pkg/cli/query.go
+++ b/pkg/cli/query.go
@@ -1,0 +1,59 @@
+// Copyright 2023 Chainguard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"text/template"
+
+	"chainguard.dev/melange/pkg/build"
+	"github.com/spf13/cobra"
+)
+
+func Query() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "query",
+		Short: "Query a Melange YAML file for information",
+		Long: `Query a Melange YAML file for information.
+		Uses templates with go templates syntax to query the YAML file.`,
+		Example: `  melange query config.yaml "{{ .Package.Name }}-{{ .Package.Version }}-{{ .Package.Epoch }}"`,
+		Args:    cobra.MinimumNArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return QueryCmd(cmd.Context(), args[1], build.WithConfig(args[0]))
+		},
+	}
+
+	return cmd
+}
+
+func QueryCmd(ctx context.Context, pattern string, opts ...build.Option) error {
+
+	bc, err := build.New(opts...)
+	if err != nil {
+		return err
+	}
+	tmpl, err := template.New("query").Parse(pattern)
+	if err != nil {
+		return fmt.Errorf("invalid template: %w", err)
+	}
+	err = tmpl.Execute(os.Stdout, bc.Configuration)
+	if err != nil {
+		return fmt.Errorf("error executing template: %w", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
Since melange already is parsing yaml files, might as well use it to report on information.