### PR TITLE
directly parse configuration for query

### DIFF
--- a/pkg/cli/packageversion.go
+++ b/pkg/cli/packageversion.go
@@ -15,7 +15,6 @@
 package cli
 
 import (
-	"chainguard.dev/melange/pkg/build"
 	"github.com/spf13/cobra"
 )
 
@@ -31,7 +30,7 @@ func PackageVersion() *cobra.Command {
 		Example: `  melange package-version [config.yaml]`,
 		Args:    cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return QueryCmd(cmd.Context(), "{{ .Package.Name }}-{{ .Package.Version }}-r{{ .Package.Epoch }}", build.WithConfig(args[0]))
+			return QueryCmd(cmd.Context(), args[0], "{{ .Package.Name }}-{{ .Package.Version }}-r{{ .Package.Epoch }}")
 		},
 	}
 

--- a/pkg/cli/query.go
+++ b/pkg/cli/query.go
@@ -33,16 +33,15 @@ func Query() *cobra.Command {
 		Example: `  melange query config.yaml "{{ .Package.Name }}-{{ .Package.Version }}-{{ .Package.Epoch }}"`,
 		Args:    cobra.MinimumNArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return QueryCmd(cmd.Context(), args[1], build.WithConfig(args[0]))
+			return QueryCmd(cmd.Context(), args[0], args[1])
 		},
 	}
 
 	return cmd
 }
 
-func QueryCmd(ctx context.Context, pattern string, opts ...build.Option) error {
-
-	bc, err := build.New(opts...)
+func QueryCmd(ctx context.Context, configFile, pattern string) error {
+	config, err := build.ParseConfiguration(configFile)
 	if err != nil {
 		return err
 	}
@@ -50,7 +49,7 @@ func QueryCmd(ctx context.Context, pattern string, opts ...build.Option) error {
 	if err != nil {
 		return fmt.Errorf("invalid template: %w", err)
 	}
-	err = tmpl.Execute(os.Stdout, bc.Configuration)
+	err = tmpl.Execute(os.Stdout, config)
 	if err != nil {
 		return fmt.Errorf("error executing template: %w", err)
 	}


### PR DESCRIPTION
Previously we relied on `build.New()` to get a `BuildContext`, which has `bc.Configuration`, which we passed to the template.

But that assumed a lot of things about the build environment, since it is a build context. Those things sometimes break. In any case `build.ParseConfiguration()` is exported.

This changes it to just call `ParseConfiguration` directly.