### PR TITLE
add a `update.manual:` key to indicate a package should be manually u…

### DIFF
--- a/docs/UPDATE.md
+++ b/docs/UPDATE.md
@@ -23,6 +23,7 @@ package:
 
 update:
   enabled: true # provide a flag to easily prevent a package from receiving auto update PRs
+  manual: true # indicates that this package should be manually updated, usually taking care over special version numbers which can be hard to automate
   shared: false # indicate that an update to this package requires an epoch bump of downstream dependencies, e.g. golang, java
   release-monitor:
     identifier: 38 # Mandatory, ID number for release monitor
@@ -42,6 +43,7 @@ package:
 
 update:
   enabled: true # provide a flag to easily toggle a package from receiving auto update PRs
+  manual: true # indicates that this package should be manually updated, usually taking care over special version numbers which can be hard to automate
   shared: false # indicate that an update to this package requires an epoch bump of downstream dependencies, e.g. golang, java
   github: # alternative today is `release_monitor:`
     identifier: sigstore/cosign # Mandatory, org/repo for github
@@ -49,4 +51,3 @@ update:
     use-tag: true # Optional, override the default of using a GitHub release to identify related tag to fetch.  Not all projects use GitHub releases but just use tags
     tag-filter: foo # Optional, filter to apply when searching tags on a GitHub repository, some repos maintain a mixture of tags for different major versions for example
 ```
-

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -233,6 +233,7 @@ type AdvisoryContent struct {
 // Update provides information used to describe how to keep the package up to date
 type Update struct {
 	Enabled          bool            `yaml:"enabled"`                     // toggle if updates should occur
+	Manual           bool            `yaml:"manual"`                      // indicates that this package should be manually updated, usually taking care over special version numbers
 	Shared           bool            `yaml:"shared,omitempty"`            // indicate that an update to this package requires an epoch bump of downstream dependencies, e.g. golang, java
 	VersionSeparator string          `yaml:"version-separator,omitempty"` // override the version separator if it is nonstandard
 	ReleaseMonitor   *ReleaseMonitor `yaml:"release-monitor,omitempty"`


### PR DESCRIPTION
…pdated

This can help with automation that is built for automating version updates.  Useful if a package requires extra care when updating it's version, which is risky or hard to automate