### PR TITLE
Add --arch to melange index to skip packages with the wrong arch

### DIFF
--- a/pkg/cli/index.go
+++ b/pkg/cli/index.go
@@ -23,6 +23,7 @@ import (
 
 func Index() *cobra.Command {
 	var apkIndexFilename string
+	var expectedArch string
 	cmd := &cobra.Command{
 		Use:     "index",
 		Short:   "Creates a repository index from a list of package files",
@@ -32,6 +33,7 @@ func Index() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			options := []index.Option{
 				index.WithIndexFile(apkIndexFilename),
+				index.WithExpectedArch(expectedArch),
 				index.WithPackageFiles(args),
 			}
 
@@ -39,6 +41,7 @@ func Index() *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVarP(&apkIndexFilename, "output", "o", "APKINDEX.tar.gz", "Output generated index to FILE")
+	cmd.Flags().StringVarP(&expectedArch, "arch", "a", "", "Index only packages which match the expected architecture")
 	return cmd
 }
 

--- a/pkg/index/index.go
+++ b/pkg/index/index.go
@@ -35,6 +35,7 @@ type Context struct {
 	MergeIndexFileFlag bool
 	SigningKey         string
 	Logger             *log.Logger
+	ExpectedArch       string
 }
 
 type Option func(*Context) error
@@ -82,6 +83,15 @@ func WithPackageDir(packageDir string) Option {
 func WithSigningKey(signingKey string) Option {
 	return func(ctx *Context) error {
 		ctx.SigningKey = signingKey
+		return nil
+	}
+}
+
+// WithExpectedArch sets the expected package architecture.  Any packages with
+// an unexpected architecture will not be indexed.
+func WithExpectedArch(expectedArch string) Option {
+	return func(ctx *Context) error {
+		ctx.ExpectedArch = expectedArch
 		return nil
 	}
 }

--- a/pkg/index/index.go
+++ b/pkg/index/index.go
@@ -161,6 +161,13 @@ func (ctx *Context) GenerateIndex() error {
 
 			for _, pkg := range packages {
 				found := false
+
+				if ctx.ExpectedArch != "" && pkg.Arch != ctx.ExpectedArch {
+					ctx.Logger.Printf("WARNING: %s-%s: found unexpected architecture %s, expecting %s",
+						pkg.Name, pkg.Version, pkg.Arch, ctx.ExpectedArch)
+					continue
+				}
+
 				for _, p := range index.Packages {
 					if pkg.Name == p.Name && pkg.Version == p.Version {
 						found = true


### PR DESCRIPTION
Packages which have the wrong arch result in a warning like:

```
WARNING: foo-1.2.3-r0: found unexpected architecture aarch64, expecting x86_64
```