### PR TITLE
feat: respect target-architecture to filter archs

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,6 @@ package:
   version: 2.12
   epoch: 0
   description: "the GNU hello world program"
-  target-architecture:
-    - all
   copyright:
     - paths:
       - "*"

--- a/docs/BUILD-PROCESS.md
+++ b/docs/BUILD-PROCESS.md
@@ -7,7 +7,7 @@ This document describes the Melange build process.
 The melange yaml file consists of the following components that are key to the build process. Note that this is not
 the official or a comprehensive `melange.yaml` reference.
 
-* `package.target-architectures`: describes which architectures to build for.
+* `package.target-architectures`: describes which architectures to build for (if empty, build for all available archs).
 * `package.dependences.runtime`: list of apk packages that need to be available in the final apk package, hence `runtime`.
 * `environment.contents`: list of apk packages and their source repositories that need to be available during the build, but not in the final apk package.
 * `pipeline`: list of steps to execute during the build.

--- a/examples/aws-sdk-core.yaml
+++ b/examples/aws-sdk-core.yaml
@@ -4,7 +4,7 @@ package:
   epoch: 0
   description: "Provides API clients for AWS. This gem is part of the official AWS SDK for Ruby."
   target-architecture:
-    - all
+    - x86_64
   copyright:
     - paths:
         - "*"

--- a/examples/build-ruby-webrick.yaml
+++ b/examples/build-ruby-webrick.yaml
@@ -3,8 +3,6 @@ package:
   version: 1.8.1
   epoch: 0
   description: "WEBrick is an HTTP server toolkit that can be configured as an HTTPS server, a proxy server, and a virtual-host server."
-  target-architecture:
-    - all
   copyright:
     - paths:
         - "*"

--- a/examples/conditional.yaml
+++ b/examples/conditional.yaml
@@ -3,8 +3,6 @@ package:
   version: 2.12
   epoch: 0
   description: "an example of how conditionals influence build behavior"
-  target-architecture:
-    - all
   copyright:
     - paths:
       - "*"

--- a/examples/gnu-hello-wolfi.yaml
+++ b/examples/gnu-hello-wolfi.yaml
@@ -3,8 +3,6 @@ package:
   version: 2.12
   epoch: 0
   description: "the GNU hello world program"
-  target-architecture:
-    - all
   copyright:
     - paths:
       - "*"

--- a/examples/gnu-hello.yaml
+++ b/examples/gnu-hello.yaml
@@ -3,8 +3,6 @@ package:
   version: 2.12
   epoch: 0
   description: "the GNU hello world program"
-  target-architecture:
-    - all
   copyright:
     - paths:
       - "*"

--- a/examples/mbedtls.yaml
+++ b/examples/mbedtls.yaml
@@ -3,8 +3,6 @@ package:
   version: 2.16.12
   epoch: 0
   description: "ARM mbed TLS library"
-  target-architecture:
-    - all
   copyright:
     - paths:
       - "*"

--- a/examples/options.yaml
+++ b/examples/options.yaml
@@ -3,8 +3,6 @@ package:
   version: 7.87.0
   epoch: 3
   description: "URL retrieval utility and library"
-  target-architecture:
-    - all
   copyright:
     - paths:
         - "*"

--- a/examples/simple-hello/melange.yaml
+++ b/examples/simple-hello/melange.yaml
@@ -3,8 +3,6 @@ package:
   version: 0
   epoch: 0
   description: "a hello world program"
-  target-architecture:
-    - all
   copyright:
     - paths:
       - "*"

--- a/examples/sshfs.yaml
+++ b/examples/sshfs.yaml
@@ -3,8 +3,6 @@ package:
   version: 3.7.2
   epoch: 0
   description: "FUSE client based on the SSH File Transfer Protocol"
-  target-architecture:
-    - all
   copyright:
     - paths:
       - "*"

--- a/examples/vars.yaml
+++ b/examples/vars.yaml
@@ -3,8 +3,6 @@ package:
   version: 2.12
   epoch: 0
   description: "an example of how conditionals influence build behavior"
-  target-architecture:
-    - all
   copyright:
     - paths:
       - "*"

--- a/examples/working-directory.yaml
+++ b/examples/working-directory.yaml
@@ -3,8 +3,6 @@ package:
   version: 2.12
   epoch: 0
   description: "an example of how conditionals influence build behavior"
-  target-architecture:
-    - all
   copyright:
     - paths:
       - "*"

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	golang.org/x/time v0.3.0
 	google.golang.org/api v0.114.0
 	gopkg.in/yaml.v3 v3.0.1
+	k8s.io/kube-openapi v0.0.0-20221012153701-172d655c2280
 	sigs.k8s.io/release-utils v0.7.3
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1005,6 +1005,8 @@ honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
+k8s.io/kube-openapi v0.0.0-20221012153701-172d655c2280 h1:+70TFaan3hfJzs+7VK2o+OGxg8HsuBr/5f6tVAjDu6E=
+k8s.io/kube-openapi v0.0.0-20221012153701-172d655c2280/go.mod h1:+Axhij7bCpeqhklhUTe3xmOn6bWxolyZEeyaFpjGtl4=
 mvdan.cc/editorconfig v0.2.0/go.mod h1:lvnnD3BNdBYkhq+B4uBuFFKatfp02eB6HixDvEz91C0=
 mvdan.cc/sh/v3 v3.5.1 h1:hmP3UOw4f+EYexsJjFxvU38+kn+V/s2CclXHanIBkmQ=
 mvdan.cc/sh/v3 v3.5.1/go.mod h1:1JcoyAKm1lZw/2bZje/iYKWicU/KMd0rsyJeKHnsK4E=

--- a/melange.yaml
+++ b/melange.yaml
@@ -3,8 +3,6 @@ package:
   version: 0.0.1
   epoch: 0
   description: "a cloud-native packaging build system"
-  target-architecture:
-    - all
   copyright:
     - paths:
       - "*"

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -32,6 +32,7 @@ import (
 	apko_build "chainguard.dev/apko/pkg/build"
 	apko_oci "chainguard.dev/apko/pkg/build/oci"
 	apko_types "chainguard.dev/apko/pkg/build/types"
+	"k8s.io/kube-openapi/pkg/util/sets"
 
 	"cloud.google.com/go/storage"
 	"github.com/go-git/go-git/v5"
@@ -363,6 +364,8 @@ type Dependencies struct {
 	ProviderPriority int `yaml:"provider-priority,omitempty"`
 }
 
+var ErrSkipThisArch = errors.New("error: skip this arch")
+
 func New(opts ...Option) (*Context, error) {
 	ctx := Context{
 		WorkspaceIgnore: ".melangeignore",
@@ -427,6 +430,11 @@ func New(opts ...Option) (*Context, error) {
 
 	if err := ctx.Configuration.Load(ctx); err != nil {
 		return nil, fmt.Errorf("failed to load configuration: %w", err)
+	}
+
+	if len(ctx.Configuration.Package.TargetArchitecture) != 0 &&
+		!sets.NewString(ctx.Configuration.Package.TargetArchitecture...).Has(ctx.Arch.ToAPK()) {
+		return nil, ErrSkipThisArch
 	}
 
 	// SOURCE_DATE_EPOCH will always overwrite the build flag

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -432,7 +432,10 @@ func New(opts ...Option) (*Context, error) {
 		return nil, fmt.Errorf("failed to load configuration: %w", err)
 	}
 
-	if len(ctx.Configuration.Package.TargetArchitecture) != 0 &&
+	if len(ctx.Configuration.Package.TargetArchitecture) == 1 &&
+		ctx.Configuration.Package.TargetArchitecture[0] == "all" {
+		log.Println("WARNING: target-architecture: ['all'] is deprecated and will become an error; remove this field to build for all available archs")
+	} else if len(ctx.Configuration.Package.TargetArchitecture) != 0 &&
 		!sets.NewString(ctx.Configuration.Package.TargetArchitecture...).Has(ctx.Arch.ToAPK()) {
 		return nil, ErrSkipThisArch
 	}


### PR DESCRIPTION
This lets configs describe which archs they want to be built for. If the field is unset, this assumes all architectures. If the field is set to `['all']`, we'll log a warning and interpret it as if it was unset.

I've updated an example to specify it only wants to be built for one arch. These work, and build only for that one configured arch:

```
$ go run ./ build examples/aws-sdk-core.yaml --arch=x86_64
$ go run ./ build examples/aws-sdk-core.yaml
```

This fails:

```
$ go run ./ build examples/aws-sdk-core.yaml --arch=aarch64
Error: target-architecture and --arch do not overlap, nothing to build
```