### PR TITLE
pipelines: autoconf/make-install: delete all GNU libtool metadata files

### DIFF
--- a/pkg/build/pipelines/autoconf/make-install.yaml
+++ b/pkg/build/pipelines/autoconf/make-install.yaml
@@ -13,3 +13,9 @@ needs:
 pipeline:
   - runs: |
       make -C "${{inputs.dir}}" install DESTDIR="${{targets.destdir}}" V=1
+
+  # Delete all GNU libtool metadata files.  These things are the bane of a
+  # packager's existence: they contain useless metadata, cause overlinking and
+  # provide no real-world value in a modern UNIX environment.
+  - runs: |
+      find ${{targets.destdir}} -name '*.la' -print -exec rm \{} \;


### PR DESCRIPTION
Otherwise these `.la` files stick around and cause all sorts of problems, such as overlinking, and wasting developer time chasing things that aren't really problems.