### PR TITLE
Do not depend on concrete logger

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -152,7 +152,7 @@ type Pipeline struct {
 	If         string             `yaml:"if,omitempty"`
 	Assertions PipelineAssertions `yaml:"assertions,omitempty"`
 	WorkDir    string             `yaml:"working-directory,omitempty"`
-	logger     *logrus.Entry
+	logger     Logger
 	steps      int
 	SBOM       SBOM `yaml:"sbom,omitempty"`
 }
@@ -1741,4 +1741,3 @@ func (ctx *Context) WorkspaceConfig() *container.Config {
 	ctx.containerConfig = ctx.buildWorkspaceConfig()
 	return ctx.containerConfig
 }
-

--- a/pkg/build/logger.go
+++ b/pkg/build/logger.go
@@ -2,8 +2,11 @@ package build
 
 type Logger interface {
 	Printf(format string, v ...any)
+	Debugf(format string, v ...any)
 }
 
 type nopLogger struct{}
+
+func (n nopLogger) Debugf(format string, v ...any) {}
 
 func (n nopLogger) Printf(string, ...any) {}

--- a/pkg/build/pipeline.go
+++ b/pkg/build/pipeline.go
@@ -17,12 +17,13 @@ package build
 import (
 	"embed"
 	"fmt"
-	"github.com/pkg/errors"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
+
+	"github.com/pkg/errors"
 
 	"gopkg.in/yaml.v3"
 
@@ -429,7 +430,11 @@ func (p *Pipeline) Run(ctx *PipelineContext) (bool, error) {
 }
 
 func (p *Pipeline) initializeFromContext(ctx *PipelineContext) error {
-	p.logger = ctx.Context.Logger
+	if l := ctx.Context.Logger; l != nil {
+		p.logger = ctx.Context.Logger
+	} else {
+		p.logger = nopLogger{}
+	}
 
 	return nil
 }


### PR DESCRIPTION
The Melange `Pipeline` type shouldn't rely on a concrete type like `*logrus.Entry`, because this requires users to have a concrete type or `nil`, and `nil` causes panics in the logger implementation.

Using an abstraction instead allows consumers to use other loggers (including a `nopLogger`) when logging isn't needed or wanted.

This caused a panic in `wolfictl`, and a forthcoming wolfictl PR will take advantage of this change (with tests!).