### PR TITLE
Fix parse configuration's use of abstract filesystems

### DIFF
--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -57,11 +57,12 @@ func Build() *cobra.Command {
 	var debug bool
 
 	cmd := &cobra.Command{
-		Use:     "build",
-		Short:   "Build a package from a YAML configuration file",
-		Long:    `Build a package from a YAML configuration file.`,
-		Example: `  melange build [config.yaml]`,
-		Args:    cobra.MinimumNArgs(0),
+		Use:           "build",
+		Short:         "Build a package from a YAML configuration file",
+		Long:          `Build a package from a YAML configuration file.`,
+		Example:       `  melange build [config.yaml]`,
+		SilenceErrors: true,
+		Args:          cobra.MinimumNArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			archs := apko_types.ParseArchitectures(archstrs)
 			options := []build.Option{

--- a/pkg/renovate/bump/bump_test.go
+++ b/pkg/renovate/bump/bump_test.go
@@ -2,6 +2,8 @@ package bump
 
 import (
 	"chainguard.dev/melange/pkg/build"
+	"github.com/stretchr/testify/require"
+
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -95,7 +97,7 @@ func TestBump_withExpectedCommit(t *testing.T) {
 			assert.NoError(t, err)
 
 			rs, err := build.ParseConfiguration(filepath.Join(dir, tt.name))
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Contains(t, rs.Package.Version, tt.newVersion)
 			assert.Contains(t, rs.Pipeline[0].With["expected-commit"], tt.expectedCommit)
 


### PR DESCRIPTION
This PR fixes two issues:

1. A test for the bump logic was using `assert.NoError` instead of `require.NoError`, so it panicked when the test proceeded to use a nil object after an error case.

2. `ParseConfiguration` wasn't correctly handling abstract filesystems. In general, when using an `fs.FS`, the code should be able to trust that the config file path is meant for that filesystem, but it was using `filepath.Base` in anticipation of receiving an absolute filepath for the actual OS filesystem. This PR detects if the caller is setting their own `fs.FS` and uses the given path "as-is" if so. In the future, we should adjust `ParseConfiguration` to always use a provided `fs.FS` and thus always trust that the given config path is correct as-is.

These issues were caught via tests in `wolfictl`.