### PR TITLE
upgrade apko to 20230421 snapshot

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module chainguard.dev/melange
 go 1.20
 
 require (
-	chainguard.dev/apko v0.7.4-0.20230420220735-1385cde8932d
+	chainguard.dev/apko v0.7.4-0.20230421200506-66070a941bd0
 	cloud.google.com/go/storage v1.30.1
 	github.com/chainguard-dev/yam v0.0.0-20230411155911-ba3a3357c32e
 	github.com/docker/docker v23.0.3+incompatible

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-chainguard.dev/apko v0.7.4-0.20230420220735-1385cde8932d h1:23/b75KTvOrFO3Jq37UWTWXL2sfN5D8snEKkleakOBU=
-chainguard.dev/apko v0.7.4-0.20230420220735-1385cde8932d/go.mod h1:+/nr2VHPIDEJqsUpY/WvYDrkzCe7WoL5RBW28NQVKUs=
+chainguard.dev/apko v0.7.4-0.20230421200506-66070a941bd0 h1:UpFkquDnEIZ1V4+S/UrHGxFp11smFWRGTaWgqLMEGek=
+chainguard.dev/apko v0.7.4-0.20230421200506-66070a941bd0/go.mod h1:+/nr2VHPIDEJqsUpY/WvYDrkzCe7WoL5RBW28NQVKUs=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSRU=


### PR DESCRIPTION
To pick up the `~` version matching fixes.  Thanks @deitch!