### PR TITLE
Add name method to build config

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -209,6 +209,11 @@ type Configuration struct {
 	Options map[string]BuildOption `yaml:"options,omitempty"`
 }
 
+// Name returns a name for the configuration, using the package name.
+func (cfg Configuration) Name() string {
+	return cfg.Package.Name
+}
+
 type VarTransforms struct {
 	From    string `yaml:"from"`
 	Match   string `yaml:"match"`


### PR DESCRIPTION
This is useful in `wolfictl`, and implements a `Configuration` interface used as a generic type constraint.

See related: https://github.com/wolfi-dev/wolfictl/pull/198