### PR TITLE
Add trimpath to the go pipeline.

### DIFF
--- a/pkg/build/pipelines/go/build.yaml
+++ b/pkg/build/pipelines/go/build.yaml
@@ -60,5 +60,5 @@ pipeline:
 
       DEST_PATH="-o ${{targets.destdir}}/${{inputs.prefix}}/${{inputs.install-dir}}/${{inputs.output}}"
       cd "${{inputs.modroot}}"
-      go build ${DEST_PATH} -tags "${TAGS}" -ldflags "${LDFLAGS}" ${{inputs.packages}}
+      go build ${DEST_PATH} -tags "${TAGS}" -ldflags "${LDFLAGS}" -trimpath ${{inputs.packages}}
       


### PR DESCRIPTION
This seems like a best practice. I've been working to convert some non-pipeline go build yamls over to use the pipeline, and this would help.