### PR TITLE
build: package: skip SONAME analysis when ELF interpreter setting is present

### DIFF
--- a/pkg/build/package.go
+++ b/pkg/build/package.go
@@ -464,7 +464,10 @@ func generateSharedObjectNameDeps(pc *PackageContext, generated *Dependencies) e
 				}
 			}
 
-			if !pc.Options.NoProvides {
+			// An executable program should never have a SONAME, but apparently binaries built
+			// with some versions of jlink do.  Thus, if an interpreter is set (meaning it is an
+			// executable program), we do not scan the object for SONAMEs.
+			if !pc.Options.NoProvides && interp == "" {
 				sonames, err := ef.DynString(elf.DT_SONAME)
 				// most likely SONAME is not set on this object
 				if err != nil {


### PR DESCRIPTION
End-user programs are the only type of ELF object where it would make sense for an ELF interpreter to be set on the on the ELF object.  Accordingly, treat any object which has an ELF interpreter set on it as an end-user program and skip SONAME analysis for them.

Certain end-user programs such as the ones included with OpenJDK 8 have a bogus SONAME (`lib.so`) set on them, which otherwise should not be there.