### PR TITLE
chore: improve mac quick-start guide

### DIFF
--- a/mac/README.md
+++ b/mac/README.md
@@ -35,10 +35,17 @@ helpers work properly with `apko publish`.
 The commands below assume to be run in this
 directory of the repository, and require `limactl`.
 
+### Clone the repository
+
+```
+git clone https://github.com/chainguard-dev/melange.git
+cd melange
+```
+
 ### Start environment
 
 ```
-limactl start --tty=false lima/melange-playground.yaml
+limactl start --tty=false mac/lima/melange-playground.yaml
 ```
 
 ### Obtain a shell
@@ -50,6 +57,6 @@ limactl shell melange-playground sudo su -c "HOME=\"${HOME}\" ash"
 ### Build an example apk
 
 ```
-melange build --keyring-append /usr/lib/wolfi-signing.rsa.pub --arch amd64 /examples/go-hello.yaml
+melange build --keyring-append /usr/lib/wolfi-signing.rsa.pub --arch amd64 examples/gnu-hello.yaml
 ```
 

--- a/mac/lima/melange-playground.yaml
+++ b/mac/lima/melange-playground.yaml
@@ -94,5 +94,5 @@ message: |-
   Run the following to get a root shell (needed to run apko build):
     limactl shell melange-playground sudo su -c "HOME=\"${HOME}\" ash"
   Try building an APK:
-     melange build -r https://packages.wolfi.dev/os -k /usr/lib/wolfi-signing.rsa.pub --arch x86_64 examples/go-hello.yaml
+     melange build -r https://packages.wolfi.dev/os -k /usr/lib/wolfi-signing.rsa.pub --arch x86_64 examples/gnu-hello.yaml
   ---

--- a/mac/lima/melange-playground.yaml
+++ b/mac/lima/melange-playground.yaml
@@ -1,7 +1,7 @@
 # apko lima configuration file
 #
 #   To start environment:
-#     limactl start --tty=false melange-playground.yaml
+#     limactl start --tty=false mac/lima/melange-playground.yaml
 #
 #   To obtain root shell (needed for apko build):
 #     limactl shell melange-playground sudo su -c "HOME=\"${HOME}\" ash"


### PR DESCRIPTION
I had a few issues getting up and running, I think this was mostly due to some out of date paths/filenames