### PR TITLE
Add an optional "deps" paramter to the go/build pipeline.

### DIFF
--- a/docs/PIPELINES-GO.md
+++ b/docs/PIPELINES-GO.md
@@ -97,6 +97,10 @@ you can define the following values:
   ldflags:
     description:
       List of [pattern=]arg to pass to the go compiler with -ldflags
+
+  deps:
+    description: |
+      space separated list of go modules to update before building. example: github.com/foo/bar@v1.2.3
 ```
 
 For the most up to date supported features check the

--- a/pkg/build/pipelines/go/build.yaml
+++ b/pkg/build/pipelines/go/build.yaml
@@ -45,6 +45,10 @@ inputs:
       Directory where binaries will be installed
     default: bin
 
+  deps:
+    description: |
+      space separated list of go modules to update before building. example: github.com/foo/bar@v1.2.3
+
 pipeline:
   - runs: |
       TAGS=""
@@ -60,5 +64,13 @@ pipeline:
 
       DEST_PATH="-o ${{targets.destdir}}/${{inputs.prefix}}/${{inputs.install-dir}}/${{inputs.output}}"
       cd "${{inputs.modroot}}"
+
+      # Install any specified dependencies
+      if [ ! "${{inputs.deps}}" == "" ]; then
+        for dep in ${{inputs.deps}}; do
+          go get $dep
+        done
+        go mod tidy
+      fi
       go build ${DEST_PATH} -tags "${TAGS}" -ldflags "${LDFLAGS}" -trimpath ${{inputs.packages}}
       


### PR DESCRIPTION
We can use this to hoist up some of the imperative "go get'ing" we do to fix CVEs into a structured format.