### PR TITLE
add extra logging when runner fails to TestUsability

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -583,7 +583,7 @@ func New(opts ...Option) (*Context, error) {
 
 	// Check that we actually can run things in containers.
 	if !runner.TestUsability() {
-		return nil, fmt.Errorf("unable to run containers")
+		return nil, fmt.Errorf("unable to run containers using %s, specify --runner and one of %s", runner.Name(), GetAllRunners())
 	}
 
 	// Apply build options to the context.

--- a/pkg/container/bubblewrap_runner.go
+++ b/pkg/container/bubblewrap_runner.go
@@ -85,7 +85,7 @@ func (bw *bubblewrap) Run(cfg *Config, args ...string) error {
 func (bw *bubblewrap) TestUsability() bool {
 	_, err := exec.LookPath("bwrap")
 	if err != nil {
-		bw.logger.Debugf("cannot use bubblewrap for containers: bwrap not found on $PATH")
+		bw.logger.Warnf("cannot use bubblewrap for containers: bwrap not found on $PATH")
 		return false
 	}
 


### PR DESCRIPTION
a recent change made bubblewrap the default when running melange build natively on mac, as a result builds fail to start...

```
2023/05/13 11:29:15 error during command execution: unable to run container
```

This change adds a warning when the check fails and offers the user help of how to fix.  For example now I need to run `melange build --runner docker`