### PR TITLE
Allow built in melange pipelines to be used in subpackages

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -1061,10 +1061,22 @@ func ParseConfiguration(configurationFilePath string, opts ...ConfigurationParsi
 				Description: replacer.Replace(sp.Description),
 			}
 			for _, p := range sp.Pipeline {
+
+				// take a copy of the with map, so we can replace the values
+				replacedWith := make(map[string]string)
+				for key, value := range p.With {
+					replacedWith[key] = replacer.Replace(value)
+				}
+
+				// if the map is empty, set it to nil to avoid serializing an empty map
+				if len(replacedWith) == 0 {
+					replacedWith = nil
+				}
+
 				thingToAdd.Pipeline = append(thingToAdd.Pipeline, Pipeline{
 					Name:   p.Name,
 					Uses:   p.Uses,
-					With:   p.With,
+					With:   replacedWith,
 					Inputs: p.Inputs,
 					Needs:  p.Needs,
 					Label:  p.Label,

--- a/pkg/build/build_test.go
+++ b/pkg/build/build_test.go
@@ -104,6 +104,9 @@ subpackages:
     name: ${{range.key}}
     pipeline:
       - runs: ${{range.key}}'s color is ${{range.value}}
+      - uses: go/build
+        with:
+          packages: ${{range.value}}
 `
 
 	expected := []Subpackage{{
@@ -123,24 +126,48 @@ subpackages:
 		}},
 	}, {
 		Name: "Donatello",
-		Pipeline: []Pipeline{{
-			Runs: "Donatello's color is purple",
-		}},
+		Pipeline: []Pipeline{
+			{
+				Runs: "Donatello's color is purple",
+			},
+			{
+				Uses: "go/build",
+				With: map[string]string{"packages": "purple"},
+			},
+		},
 	}, {
 		Name: "Leonardo",
-		Pipeline: []Pipeline{{
-			Runs: "Leonardo's color is blue",
-		}},
+		Pipeline: []Pipeline{
+			{
+				Runs: "Leonardo's color is blue",
+			},
+			{
+				Uses: "go/build",
+				With: map[string]string{"packages": "blue"},
+			},
+		},
 	}, {
 		Name: "Michelangelo",
-		Pipeline: []Pipeline{{
-			Runs: "Michelangelo's color is orange",
-		}},
+		Pipeline: []Pipeline{
+			{
+				Runs: "Michelangelo's color is orange",
+			},
+			{
+				Uses: "go/build",
+				With: map[string]string{"packages": "orange"},
+			},
+		},
 	}, {
 		Name: "Raphael",
-		Pipeline: []Pipeline{{
-			Runs: "Raphael's color is red",
-		}},
+		Pipeline: []Pipeline{
+			{
+				Runs: "Raphael's color is red",
+			},
+			{
+				Uses: "go/build",
+				With: map[string]string{"packages": "red"},
+			},
+		},
 	}}
 
 	f := filepath.Join(t.TempDir(), "config")

--- a/pkg/build/pipelines/go/build.yaml
+++ b/pkg/build/pipelines/go/build.yaml
@@ -29,6 +29,11 @@ inputs:
       If true, the go mod command will also update the vendor directory
     default: "false"
 
+  subpackage:
+    description: |
+      Indicates that the build will write to a subpackage target folder
+    default: "false"
+
   modroot:
     default: "."
     required: false
@@ -67,7 +72,13 @@ pipeline:
         LDFLAGS="${{inputs.ldflags}}"
       fi
 
-      DEST_PATH="-o ${{targets.destdir}}/${{inputs.prefix}}/${{inputs.install-dir}}/${{inputs.output}}"
+      BASE_PATH="${{inputs.prefix}}/${{inputs.install-dir}}/${{inputs.output}}"
+      if [ "${{inputs.subpackage}}" == "true" ]; then
+        DEST_PATH="-o ${{targets.subpkgdir}}/${BASE_PATH}"
+      else
+        DEST_PATH="-o ${{targets.destdir}}/${BASE_PATH}"
+      fi
+
       cd "${{inputs.modroot}}"
 
       # Install any specified dependencies
@@ -80,4 +91,3 @@ pipeline:
         "${{inputs.vendor}}" && go mod vendor
       fi
       go build ${DEST_PATH} -tags "${TAGS}" -ldflags "${LDFLAGS}" -trimpath ${{inputs.packages}}
-      


### PR DESCRIPTION
This PR makes sure range data is included in var substitutions for subpackage pipeline `with:` options.  It also allows a boolean to indicate a built go binary should be written to `${{targets.subpkgdir}}` rather than `${{targets.destdir}}`