### PR TITLE
include filename when parsing fails

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -1009,7 +1009,7 @@ func ParseConfiguration(configurationFilePath string, opts ...ConfigurationParsi
 	decoder.KnownFields(true)
 	err = decoder.Decode(&cfg)
 	if err != nil {
-		return nil, fmt.Errorf("unable to decode configuration file: %w", err)
+		return nil, fmt.Errorf("unable to decode configuration file %q: %w", configurationFilePath, err)
 	}
 
 	for vulnerability, entries := range cfg.Advisories {


### PR DESCRIPTION
It can be useful when parsing fails to log the filename of the offending file.