### PR TITLE
Remove secfixes and advisories altogether

### DIFF
--- a/examples/options.yaml
+++ b/examples/options.yaml
@@ -8,13 +8,6 @@ package:
         - "*"
       attestation: TODO
       license: MIT
-secfixes:
-  7.87.0-r0:
-    - CVE-2022-43551
-    - CVE-2022-43552
-  7.86.0-r0:
-    - CVE-2022-42916
-    - CVE-2022-32221
 
 environment:
   contents:
@@ -106,21 +99,3 @@ subpackages:
       - runs: |
           mkdir -p "${{targets.subpkgdir}}"/usr/lib
           mv "${{targets.destdir}}"/usr/lib/libcurl.so.* "${{targets.subpkgdir}}"/usr/lib/
-
-advisories:
-  CVE-2022-32221:
-    - timestamp: 2022-12-09T12:10:34-05:00
-      status: fixed
-      fixed-version: 7.86.0-r0
-  CVE-2022-42916:
-    - timestamp: 2022-11-19T10:37:17-05:00
-      status: fixed
-      fixed-version: 7.86.0-r0
-  CVE-2022-43551:
-    - timestamp: 2022-12-21T13:16:36+00:00
-      status: fixed
-      fixed-version: 7.87.0-r0
-  CVE-2022-43552:
-    - timestamp: 2022-12-21T13:16:36+00:00
-      status: fixed
-      fixed-version: 7.87.0-r0

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,6 @@ require (
 	github.com/korovkin/limiter v0.0.0-20221015170604-22eb1ceceddc
 	github.com/lima-vm/lima v0.14.2
 	github.com/opencontainers/image-spec v1.1.0-rc2
-	github.com/openvex/go-vex v0.2.0
 	github.com/package-url/packageurl-go v0.1.1-0.20220203205134-d70459300c8a
 	github.com/pkg/errors v0.9.1
 	github.com/psanford/memfs v0.0.0-20230130182539-4dbf7e3e865e

--- a/go.sum
+++ b/go.sum
@@ -535,8 +535,6 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.0-rc2 h1:2zx/Stx4Wc5pIPDvIxHXvXtQFW/7XWJGmnM7r3wg034=
 github.com/opencontainers/image-spec v1.1.0-rc2/go.mod h1:3OVijpioIKYWTqjiG0zfF6wvoJ4fAXGbjdZuI2NgsRQ=
-github.com/openvex/go-vex v0.2.0 h1:7Q6VzdpZSZzYUyXB1dio/9LCGHp1iL3JldC+hMsbFg0=
-github.com/openvex/go-vex v0.2.0/go.mod h1:jYmYbhQAO/0hquryXND/jMVDBcob8/KkVgzUEUAHsFI=
 github.com/package-url/packageurl-go v0.1.1-0.20220203205134-d70459300c8a h1:tkTSd1nhioPqi5Whu3CQ79UjPtaGOytqyNnSCVOqzHM=
 github.com/package-url/packageurl-go v0.1.1-0.20220203205134-d70459300c8a/go.mod h1:uQd4a7Rh3ZsVg5j0lNyAfyxIeGde9yrlhjF78GzeW0c=
 github.com/pelletier/go-toml v1.7.0/go.mod h1:vwGMzjaWMwyfHwgIBhI2YUM4fB6nL6lVAvS1LBMMhTE=


### PR DESCRIPTION
This data is no longer managed by Melange (it's managed by `wolfictl`) and should not be used within a build configuration.