### PR TITLE
Validate configuration at the end of parsing

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -1187,7 +1187,7 @@ func (e ErrInvalidConfiguration) Error() string {
 	return fmt.Sprintf("build configuration is invalid: %v", e.Problem)
 }
 
-var packageNameRegex = regexp.MustCompile(`^[a-z][a-z0-9_.-]*$`)
+var packageNameRegex = regexp.MustCompile(`^[a-zA-Z\d][a-zA-Z\d+_.-]*$`)
 
 func (cfg Configuration) validate() error {
 	if !packageNameRegex.MatchString(cfg.Package.Name) {

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -22,6 +22,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"sort"
 	"strconv"
@@ -1170,7 +1171,42 @@ func ParseConfiguration(configurationFilePath string, opts ...ConfigurationParsi
 
 	cfg.Subpackages = subpackages
 
+	// Finally, validate the configuration we ended up with before returning it for use downstream.
+	if err = cfg.validate(); err != nil {
+		return nil, fmt.Errorf("validating configuration: %w", err)
+	}
+
 	return &cfg, nil
+}
+
+type ErrInvalidConfiguration struct {
+	Problem error
+}
+
+func (e ErrInvalidConfiguration) Error() string {
+	return fmt.Sprintf("build configuration is invalid: %v", e.Problem)
+}
+
+var packageNameRegex = regexp.MustCompile(`^[a-z][a-z0-9_.-]*$`)
+
+func (cfg Configuration) validate() error {
+	if !packageNameRegex.MatchString(cfg.Package.Name) {
+		return ErrInvalidConfiguration{Problem: fmt.Errorf("package name must match regex %q", packageNameRegex)}
+	}
+
+	if cfg.Package.Version == "" {
+		return ErrInvalidConfiguration{Problem: errors.New("package version must not be empty")}
+	}
+
+	// TODO: try to validate value of .package.version
+
+	for i, sp := range cfg.Subpackages {
+		if !packageNameRegex.MatchString(sp.Name) {
+			return ErrInvalidConfiguration{Problem: fmt.Errorf("subpackage name %q (subpackages index: %d) must match regex %q", sp.Name, i, packageNameRegex)}
+		}
+	}
+
+	return nil
 }
 
 // Load the configuration data from the build context configuration file.

--- a/pkg/build/build_test.go
+++ b/pkg/build/build_test.go
@@ -26,6 +26,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var requireErrInvalidConfiguration require.ErrorAssertionFunc = func(t require.TestingT, err error, _ ...interface{}) {
+	require.ErrorAs(t, err, &ErrInvalidConfiguration{})
+}
+
 // TestConfiguration_Load is the main set of tests for loading a configuration
 // file. When in doubt, add your test here.
 func TestConfiguration_Load(t *testing.T) {
@@ -64,10 +68,10 @@ func TestConfiguration_Load(t *testing.T) {
 						Runs: "turtles are slow",
 					}},
 				}, {
-					Name: "Donatello",
+					Name: "donatello",
 					Pipeline: []Pipeline{
 						{
-							Runs: "Donatello's color is purple",
+							Runs: "donatello's color is purple",
 						},
 						{
 							Uses: "go/build",
@@ -75,10 +79,10 @@ func TestConfiguration_Load(t *testing.T) {
 						},
 					},
 				}, {
-					Name: "Leonardo",
+					Name: "leonardo",
 					Pipeline: []Pipeline{
 						{
-							Runs: "Leonardo's color is blue",
+							Runs: "leonardo's color is blue",
 						},
 						{
 							Uses: "go/build",
@@ -86,10 +90,10 @@ func TestConfiguration_Load(t *testing.T) {
 						},
 					},
 				}, {
-					Name: "Michelangelo",
+					Name: "michelangelo",
 					Pipeline: []Pipeline{
 						{
-							Runs: "Michelangelo's color is orange",
+							Runs: "michelangelo's color is orange",
 						},
 						{
 							Uses: "go/build",
@@ -97,10 +101,10 @@ func TestConfiguration_Load(t *testing.T) {
 						},
 					},
 				}, {
-					Name: "Raphael",
+					Name: "raphael",
 					Pipeline: []Pipeline{
 						{
-							Runs: "Raphael's color is red",
+							Runs: "raphael's color is red",
 						},
 						{
 							Uses: "go/build",
@@ -146,6 +150,21 @@ func TestConfiguration_Load(t *testing.T) {
 		{
 			name:       "unknown-fields",
 			requireErr: require.Error,
+			expected:   Configuration{},
+		},
+		{
+			name:       "missing-package-name",
+			requireErr: requireErrInvalidConfiguration,
+			expected:   Configuration{},
+		},
+		{
+			name:       "invalid-package-name",
+			requireErr: requireErrInvalidConfiguration,
+			expected:   Configuration{},
+		},
+		{
+			name:       "invalid-range-subpackage-name",
+			requireErr: requireErrInvalidConfiguration,
 			expected:   Configuration{},
 		},
 	}

--- a/pkg/build/testdata/configuration_load/invalid-package-name.melange.yaml
+++ b/pkg/build/testdata/configuration_load/invalid-package-name.melange.yaml
@@ -1,0 +1,4 @@
+package:
+  name: boost-"mobile"
+  version: 2.0.0
+  epoch: 0

--- a/pkg/build/testdata/configuration_load/invalid-range-subpackage-name.melange.yaml
+++ b/pkg/build/testdata/configuration_load/invalid-range-subpackage-name.melange.yaml
@@ -13,19 +13,10 @@ data:
       raphael: red
       leonardo: blue
       donatello: purple
-  - name: animals
-    items:
-      dogs: loyal
-      cats: angry
-      turtles: slow
 
 subpackages:
-  - range: animals
-    name: ${{range.key}}
-    pipeline:
-      - runs: ${{range.key}} are ${{range.value}}
   - range: ninja-turtles
-    name: ${{range.key}}
+    name: turtle-"${{range.key}}"
     pipeline:
       - runs: ${{range.key}}'s color is ${{range.value}}
       - uses: go/build

--- a/pkg/build/testdata/configuration_load/missing-package-name.melange.yaml
+++ b/pkg/build/testdata/configuration_load/missing-package-name.melange.yaml
@@ -1,0 +1,4 @@
+package:
+  name:
+  version: 2.0.0
+  epoch: 0


### PR DESCRIPTION
This ensures we fail fast when detect that a user-supplied value in the build configuration is not valid.

This helps guard against package names like `boost-"atomic"`, which we saw recently (see https://github.com/wolfi-dev/os/pull/2269).

**Note:** For names of packages and subpackages, this implementation requires the following:
- all letters are lowecase
- must start with letter
- the only valid characters are letters, numbers, periods (`.`), dashes (`-`), and underscores (`_`)

Underscores in package names are very rare, but they do exist in Wolfi right now. If we wanted, we could disallow underscores and update any offending package names accordingly:

- `libnetfilter_conntrack`
- `libnetfilter_cthelper`
- `libnetfilter_cttimeout`
- `libnetfilter_queue`
- `ruby3.2-http_parser.rb`