### PR TITLE
add strip prefix and suffix update config for release monitor

### DIFF
--- a/docs/UPDATE.md
+++ b/docs/UPDATE.md
@@ -27,6 +27,8 @@ update:
   shared: false # indicate that an update to this package requires an epoch bump of downstream dependencies, e.g. golang, java
   release-monitor:
     identifier: 38 # Mandatory, ID number for release monitor
+    strip-prefix: v # Optional, if the version obtained from the update service contains a prefix which should be ignored
+    strip-suffix: ignore_me # Optional, if the version obtained from the update service contains a suffix which should be ignored
 ```
 
 ## GitHub

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -335,6 +335,10 @@ type Update struct {
 type ReleaseMonitor struct {
 	// Required: ID number for release monitor
 	Identifier int `yaml:"identifier"`
+	// If the version in release monitor contains a prefix which should be ignored
+	StripPrefix string `yaml:"strip-prefix,omitempty"`
+	// If the version in release monitor contains a suffix which should be ignored
+	StripSuffix string `yaml:"strip-suffix,omitempty"`
 }
 
 // GitHubMonitor indicates using the GitHub API


### PR DESCRIPTION
If I'd have known at the start that release monitor also has versions that need modifying then I would have added these configs directly under the top level `update:`.  Doing that now would be a breaking change so this change duplicates the config that is already used by the github section.