### PR TITLE
ensure bundles are rooted correctly

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -72,7 +72,8 @@ jobs:
 
     - name: Build
       run: |
-        ./melange build --signing-key local-melange.rsa --pipeline-dir=pipelines examples/gnu-hello.yaml --arch=x86_64 --empty-workspace --runner kubernetes
+        # Pick an example that requires mounting to flex kontext.Bundle()
+        ./melange build --signing-key local-melange.rsa examples/simple-hello/melange.yaml --source-dir="examples/simple-hello" --workspace-dir="examples/simple-hello" --arch=x86_64 --runner kubernetes
 
   bootstrap:
     name: bootstrap package

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -1889,6 +1889,7 @@ func (ctx *Context) WorkspaceConfig() *container.Config {
 // to the workspace directory. The workspace retrieved from the runner is in a
 // tar stream containing the workspace contents rooted at ./melange-out
 func (ctx *Context) RetrieveWorkspace(sigh context.Context, cfg *container.Config) error {
+	ctx.Logger.Infof("retrieving workspace from builder: %s", cfg.PodID)
 	r, err := ctx.Runner.WorkspaceTar(sigh, ctx.containerConfig)
 	if err != nil {
 		return err


### PR DESCRIPTION
fixes an issue with local files not being bundled correctly in the k8s runner.

this fix is temporary until `kontext.Bundle()` is refactored to use the `go-apk.FullFS` filesystem to bundle/extract, which assumes the workspace is rooted at the base directory by default.

the e2e test is changed to pick a leg that enforces this behavior, so it'll break if we forget to implement the TODO in the future.