### PR TITLE
add a split/debug pipeline

### DIFF
--- a/pkg/build/pipelines/split/debug.yaml
+++ b/pkg/build/pipelines/split/debug.yaml
@@ -1,0 +1,29 @@
+name: Split debug files
+
+needs:
+  packages:
+    - binutils
+    - scanelf
+
+pipeline:
+  - runs: |
+      mkdir -p "${{targets.destdir}}/.dbg-tmp"
+      # note: the ${{targets.subpkgdir}} doesn't exist when the glob is evaluated
+      scanelf -Ry "${{targets.destdir}}"/* | while read type src; do
+        if [ "$type" != ET_DYN ]; then
+          continue
+        fi
+        dst=${{targets.subpkgdir}}/usr/lib/debug/${src#"${{targets.destdir}}"/*/}.debug
+        mkdir -p "${dst%/*}"
+        ino=$(stat -c %i "$src")
+        if ! [ -e "${{targets.destdir}}/.dbg-tmp/$ino" ]; then
+          tmp=${{targets.destdir}}/.dbg-tmp/${src##*/}
+          objcopy --only-keep-debug "$src" "$dst"
+          objcopy --add-gnu-debuglink="$dst" --strip-unneeded -R .comment "$src" "$tmp"
+          # preserve attributes, links
+          cat "$tmp" > "$src"
+          rm "$tmp"
+          ln "$dst" "${{targets.destdir}}/.dbg-tmp/$ino"
+        fi
+      done
+      rm -r "${{targets.destdir}}/.dbg-tmp"


### PR DESCRIPTION
adds a `split/debug` package, adopted from splitfunc dbg

sample output testing with openjdk:

```bash
bash-5.2# ls /home/build/melange-out/openjdk-17-dbg/usr/lib/debug/lib/jvm/java-17-openjdk/*
/home/build/melange-out/openjdk-17-dbg/usr/lib/debug/lib/jvm/java-17-openjdk/bin:
jar.debug          jconsole.debug     jinfo.debug        jshell.debug
jarsigner.debug    jdb.debug          jlink.debug        jstack.debug
java.debug         jdeprscan.debug    jmap.debug         jstat.debug
javac.debug        jdeps.debug        jmod.debug         jstatd.debug
javadoc.debug      jfr.debug          jpackage.debug     keytool.debug
javap.debug        jhsdb.debug        jps.debug          rmiregistry.debug
jcmd.debug         jimage.debug       jrunscript.debug   serialver.debug
                                                                                             
/home/build/melange-out/openjdk-17-dbg/usr/lib/debug/lib/jvm/java-17-openjdk/lib:
jexec.debug                   libjaas.so.debug              libmanagement_ext.so.debug
jspawnhelper.debug            libjava.so.debug              libmlib_image.so.debug
libattach.so.debug            libjavajpeg.so.debug          libnet.so.debug
libawt.so.debug               libjawt.so.debug              libnio.so.debug
libawt_headless.so.debug      libjdwp.so.debug              libprefs.so.debug
libawt_xawt.so.debug          libjimage.so.debug            librmi.so.debug
libdt_socket.so.debug         libjli.so.debug               libsaproc.so.debug
libextnet.so.debug            libjsig.so.debug              libsctp.so.debug
libfontmanager.so.debug       libjsound.so.debug            libsplashscreen.so.debug
libinstrument.so.debug        libjsvml.so.debug             libsyslookup.so.debug
libj2gss.so.debug             liblcms.so.debug              libverify.so.debug
libj2pcsc.so.debug            libmanagement.so.debug        libzip.so.debug
libj2pkcs11.so.debug          libmanagement_agent.so.debug  server

```