### PR TITLE
Bug fix: silent env var replacement

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -1082,8 +1082,17 @@ func ParseConfiguration(configurationFilePath string, opts ...ConfigurationParsi
 		cfg.Environment.Environment = make(map[string]string)
 	}
 
-	cfg.Environment.Environment["HOME"] = "/home/build"
-	cfg.Environment.Environment["GOPATH"] = "/home/build/.cache/go"
+	const (
+		defaultEnvVarHOME   = "/home/build"
+		defaultEnvVarGOPATH = "/home/build/.cache/go"
+	)
+
+	if cfg.Environment.Environment["HOME"] == "" {
+		cfg.Environment.Environment["HOME"] = defaultEnvVarHOME
+	}
+	if cfg.Environment.Environment["GOPATH"] == "" {
+		cfg.Environment.Environment["GOPATH"] = defaultEnvVarGOPATH
+	}
 
 	// If a variables file was defined, merge it into the variables block.
 	if varsFile := options.varsFilePath; varsFile != "" {

--- a/pkg/build/testdata/configuration_load/env-vars-set-that-have-default-values.melange.yaml
+++ b/pkg/build/testdata/configuration_load/env-vars-set-that-have-default-values.melange.yaml
@@ -1,0 +1,9 @@
+package:
+  name: cosign
+  version: 2.0.0
+  epoch: 0
+
+environment:
+  environment:
+    HOME: /home/build/special-case
+    GOPATH: /var/cache/melange/go


### PR DESCRIPTION
Melange has sensible default values for the build environment variables for `HOME` and `GOPATH`. But it was using these values even if the Melange user had explicitly set env var values in their config — so their env var values were silently ignored in this case.