### PR TITLE
build: package: forcibly treat libc as a shared library

### DIFF
--- a/.github/workflows/wolfi-presubmit.yaml
+++ b/.github/workflows/wolfi-presubmit.yaml
@@ -75,4 +75,4 @@ jobs:
           sudo apt-get -y install bubblewrap
 
       - run: |
-          make MELANGE="sudo melange" BUILDWORLD="no" packages/${{matrix.package}}
+          make MELANGE="sudo melange" BUILDWORLD="no" package/${{matrix.package}}

--- a/pkg/build/package.go
+++ b/pkg/build/package.go
@@ -471,7 +471,10 @@ func generateSharedObjectNameDeps(pc *PackageContext, generated *Dependencies) e
 			// An executable program should never have a SONAME, but apparently binaries built
 			// with some versions of jlink do.  Thus, if an interpreter is set (meaning it is an
 			// executable program), we do not scan the object for SONAMEs.
-			if !pc.Options.NoProvides && interp == "" {
+			//
+			// Ugh: libc.so.6 has an PT_INTERP set on itself to make the `/lib/libc.so.6 --about`
+			// functionality work.  So we always generate provides entries for libc.
+			if !pc.Options.NoProvides && (interp == "" || strings.HasPrefix(basename, "libc")) {
 				sonames, err := ef.DynString(elf.DT_SONAME)
 				// most likely SONAME is not set on this object
 				if err != nil {


### PR DESCRIPTION
the GNU variant of libc (GLIBC) is built as a PIE binary, which otherwise behaves as a shared library.  this is done to enable the `/lib/libc.so.6 --about` command.