### PR TITLE
Change git-checkout depth default to 1

### DIFF
--- a/pkg/build/pipelines/git-checkout.yaml
+++ b/pkg/build/pipelines/git-checkout.yaml
@@ -18,7 +18,7 @@ inputs:
   depth:
     description: |
       The depth to use when cloning.
-    default: 50
+    default: 1
 
   branch:
     description: |


### PR DESCRIPTION
Deep cloning can cost a lot of time on a per-dev-cycle basis. This changes the default depth to `1` — and it can still be adjusted to any number on a per-build-config basis as needed.