### PR TITLE
lima startup issues fixed

### DIFF
--- a/pkg/container/lima.yaml
+++ b/pkg/container/lima.yaml
@@ -24,6 +24,6 @@ provision:
   script: |
     rm -f $HOME/containerd.sock
     ln -s /proc/$(cat $XDG_RUNTIME_DIR/containerd-rootless/child_pid)/root/run/containerd/containerd.sock ${HOME}/containerd.sock
- - mode: system
-   script: |
-     chmod 0755 /etc/cni
+- mode: system
+  script: |
+    chmod 0755 /etc/cni

--- a/pkg/container/lima_runner.go
+++ b/pkg/container/lima_runner.go
@@ -333,7 +333,7 @@ func (l *lima) start(ctx context.Context, name string, exists bool) error {
 
 	if !exists {
 		buf = bytes.NewReader(config)
-		args = append(args, "/dev/stdin")
+		args = append(args, "-")
 	}
 	return l.limactl(ctx, buf, nil, nil, args...)
 }


### PR DESCRIPTION
1. `limactl` now accepts a more normal `-` for stdin
2. There was a misalignment in our template `lima.yaml`. Older limactl did not care, but newer is stricter (as it should be)

