### PR TITLE
K8s runner fetch workspace tgz

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -16,6 +16,7 @@ package build
 
 import (
 	"archive/tar"
+	"compress/gzip"
 	"context"
 	"errors"
 	"fmt"
@@ -1939,9 +1940,17 @@ func (b *Build) RetrieveWorkspace(ctx context.Context) error {
 	r, err := b.Runner.WorkspaceTar(ctx, b.containerConfig)
 	if err != nil {
 		return err
+	} else if r == nil {
+		return nil
 	}
 	defer r.Close()
-	tr := tar.NewReader(r)
+
+	gr, err := gzip.NewReader(r)
+	if err != nil {
+		return err
+	}
+	defer gr.Close()
+	tr := tar.NewReader(gr)
 
 	fs := apkofs.DirFS(b.WorkspaceDir)
 	for {

--- a/pkg/container/bubblewrap_runner.go
+++ b/pkg/container/bubblewrap_runner.go
@@ -16,7 +16,6 @@ package container
 
 import (
 	"archive/tar"
-	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -123,8 +122,7 @@ func (bw *bubblewrap) TerminatePod(ctx context.Context, cfg *Config) error {
 // WorkspaceTar implements Runner
 // This is a noop for Bubblewrap, which uses bind-mounts to manage the workspace
 func (bw *bubblewrap) WorkspaceTar(ctx context.Context, cfg *Config) (io.ReadCloser, error) {
-	var buffer bytes.Buffer
-	return io.NopCloser(&buffer), nil
+	return nil, nil
 }
 
 type bubblewrapOCILoader struct{}

--- a/pkg/container/docker_runner.go
+++ b/pkg/container/docker_runner.go
@@ -15,7 +15,6 @@
 package container
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -249,8 +248,7 @@ func (dk *docker) Run(ctx context.Context, cfg *Config, args ...string) error {
 // WorkspaceTar implements Runner
 // This is a noop for Docker, which uses bind-mounts to manage the workspace
 func (d *docker) WorkspaceTar(ctx context.Context, cfg *Config) (io.ReadCloser, error) {
-	var buffer bytes.Buffer
-	return io.NopCloser(&buffer), nil
+	return nil, nil
 }
 
 type dockerLoader struct{}

--- a/pkg/container/lima_runner.go
+++ b/pkg/container/lima_runner.go
@@ -259,7 +259,7 @@ func (l *lima) WorkspaceTar(ctx context.Context, cfg *Config) (io.ReadCloser, er
 	go func() {
 		defer pw.Close()
 
-		if err := l.nerdctl(ctx, melangeVMName, nil, pw, nil, "exec", "-i", cfg.PodID, "tar", "cf", "-", "-C", runnerWorkdir, "melange-out"); err != nil {
+		if err := l.nerdctl(ctx, melangeVMName, nil, pw, nil, "exec", "-i", cfg.PodID, "tar", "czf", "-", "-C", runnerWorkdir, "melange-out"); err != nil {
 			pw.CloseWithError(fmt.Errorf("failed to tar workspace: %w", err))
 		}
 	}()


### PR DESCRIPTION
- changes the workspace fetcher to use a tgz stream instead
- adds a retryable workspace fetcher for the k8s runner. this was a significant source of flakes that is mostly eliminated now
- updates the other runners that use workspace fetcher to use tgz (`lima`)