### PR TITLE
Default remove builder

### DIFF
--- a/docs/md/melange_build.md
+++ b/docs/md/melange_build.md
@@ -38,6 +38,7 @@ melange build [flags]
       --continue-label string       continue build execution at the specified label
       --create-build-log            creates a package.log file containing a list of packages that were built by the command
       --debug                       enables debug logging of build pipelines
+      --debug-runner                when enabled, the builder pod will persist after the build suceeds or fails
       --dependency-log string       log dependencies to a specified file
       --empty-workspace             whether the build workspace should be empty
       --env-file string             file to use for preloaded environment variables

--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -58,6 +58,7 @@ func Build() *cobra.Command {
 	var logPolicy []string
 	var createBuildLog bool
 	var debug bool
+	var debugRunner bool
 	var runner string
 
 	cmd := &cobra.Command{
@@ -94,6 +95,7 @@ func Build() *cobra.Command {
 				build.WithEnabledBuildOptions(buildOption),
 				build.WithCreateBuildLog(createBuildLog),
 				build.WithDebug(debug),
+				build.WithDebugRunner(debugRunner),
 				build.WithLogPolicy(logPolicy),
 				build.WithRunner(runner),
 			}
@@ -142,6 +144,7 @@ func Build() *cobra.Command {
 	cmd.Flags().StringSliceVarP(&extraRepos, "repository-append", "r", []string{}, "path to extra repositories to include in the build environment")
 	cmd.Flags().BoolVar(&createBuildLog, "create-build-log", false, "creates a package.log file containing a list of packages that were built by the command")
 	cmd.Flags().BoolVar(&debug, "debug", false, "enables debug logging of build pipelines")
+	cmd.Flags().BoolVar(&debugRunner, "debug-runner", false, "when enabled, the builder pod will persist after the build suceeds or fails")
 
 	return cmd
 }


### PR DESCRIPTION
Change the default for runners that create a persisting build environment (everything except `bwrap`) to always destroy the build environment when the build succeeds/fails.

This means runners like `docker`/`kubernetes` don't leave dangling resources around on failures unless the user opts in (`--debug-runner`).

I originally coupled this to the existing `--debug` flag, but then changed my mind and used `--debug-runner`. I'm not married to the semantics so please suggest otherwise!