### PR TITLE
skip the cache mount for kubernetes runner builds

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -1879,8 +1879,8 @@ func (b *Build) buildWorkspaceConfig() *container.Config {
 	}
 
 	mounts := []container.BindMount{
-		{Source: b.WorkspaceDir, Destination: "/home/build"},
-		{Source: "/etc/resolv.conf", Destination: "/etc/resolv.conf"},
+		{Source: b.WorkspaceDir, Destination: container.DefaultWorkspaceDir},
+		{Source: "/etc/resolv.conf", Destination: container.DefaultResolvConfPath},
 	}
 
 	if b.CacheDir != "" {
@@ -1890,7 +1890,7 @@ func (b *Build) buildWorkspaceConfig() *container.Config {
 				b.Logger.Printf("could not resolve path for --cache-dir: %s", err)
 			}
 
-			mounts = append(mounts, container.BindMount{Source: mountSource, Destination: "/var/cache/melange"})
+			mounts = append(mounts, container.BindMount{Source: mountSource, Destination: container.DefaultCacheDir})
 		} else {
 			b.Logger.Printf("--cache-dir %s not a dir; skipping", b.CacheDir)
 		}

--- a/pkg/container/config.go
+++ b/pkg/container/config.go
@@ -19,6 +19,15 @@ import (
 	"chainguard.dev/apko/pkg/log"
 )
 
+const (
+	// DefaultWorkspaceDir is the default path to the workspace directory in the runner's environment.
+	DefaultWorkspaceDir = "/home/build"
+	// DefaultCacheDir is the default path to the cache directory in the runner's environment.
+	DefaultCacheDir = "/var/cache/melange"
+	// DefaultResolvConfPath is the default path to the resolv.conf file in the runner's environment.
+	DefaultResolvConfPath = "/etc/resolv.conf"
+)
+
 type BindMount struct {
 	Source      string
 	Destination string

--- a/pkg/container/kubernetes_runner.go
+++ b/pkg/container/kubernetes_runner.go
@@ -392,11 +392,11 @@ func (k *k8s) bundle(ctx context.Context, path string, tag name.Tag) (name.Diges
 // filterMounts filters mounts that are not supported by the k8s runner
 func (k *k8s) filterMounts(mount BindMount) bool {
 	// the kubelet handles this
-	if mount.Source == "/etc/resolv.conf" {
+	if mount.Source == DefaultResolvConfPath {
 		return true
 	}
 
-	if mount.Destination == "/var/cache/melange" {
+	if mount.Destination == DefaultCacheDir {
 		k.logger.Warnf("skipping k8s runner irrelevant cache mount %s -> %s", mount.Source, mount.Destination)
 		return true
 	}

--- a/pkg/container/kubernetes_runner.go
+++ b/pkg/container/kubernetes_runner.go
@@ -396,12 +396,16 @@ func (k *k8s) filterMounts(mount BindMount) bool {
 		return true
 	}
 
+	if mount.Destination == "/var/cache/melange" {
+		k.logger.Warnf("skipping k8s runner irrelevant cache mount %s -> %s", mount.Source, mount.Destination)
+		return true
+	}
+
 	// Skip anything that can't be mounted to a destination
 	if mount.Destination == "" {
 		return true
 	}
 
-	// TODO: More filtering?
 	return false
 }
 


### PR DESCRIPTION
the melange cache mounts are primarily designed for bind-mounted runners, which k8s is not. in remote execution environments, it's usually just faster to redownload things than to push/pull them in.

using the cache mount for k8s runner ends up just creating more things that need to be transferred over the network via kontext -> OCI registry, and can lead to pretty silly processing if you're not careful.

this also prevents @mattmoor from destroying his poor computer/network