### PR TITLE
Make sure we log errors.

### DIFF
--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -62,12 +62,11 @@ func Build() *cobra.Command {
 	var runner string
 
 	cmd := &cobra.Command{
-		Use:           "build",
-		Short:         "Build a package from a YAML configuration file",
-		Long:          `Build a package from a YAML configuration file.`,
-		Example:       `  melange build [config.yaml]`,
-		SilenceErrors: true,
-		Args:          cobra.MinimumNArgs(0),
+		Use:     "build",
+		Short:   "Build a package from a YAML configuration file",
+		Long:    `Build a package from a YAML configuration file.`,
+		Example: `  melange build [config.yaml]`,
+		Args:    cobra.MinimumNArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			archs := apko_types.ParseArchitectures(archstrs)
 			options := []build.Option{


### PR DESCRIPTION
This reverts fdf0cbfc73548c6bae6bf85a5a7120889867c81e which avoided double-printing (some?) errors, but the net effect of this is that some errors are never printed.

Performing world builds, I see half a dozen failures(?) where the logs end without actually printing anything actionable:
```
...
ℹ️  x86_64    | populating cache from
ℹ️  x86_64    | populating workspace /home/user/tmp/melange-workspace-2016802746 from ./jaeger-agent/
ℹ️  x86_64    | --cache-dir ./melange-cache/ not a dir; skipping
ℹ️  x86_64    | ImgRef = gcr.io/mattmoor-chainguard/wolfi-os-builds@sha256:98b659b74c47411018b386fdb4fbb8aa0140eb5b11c19b1473c99c96da2524ef
ℹ️  x86_64    | creating mount 'mount-0' from /home/user/tmp/melange-workspace-2016802746 at /home/build
ℹ️  x86_64    |   workspace dir: /home/user/tmp/melange-workspace-2016802746
ℹ️  x86_64    |   guest dir: /home/user/tmp/melange-guest-1521123713
```

IMO printing some things twice is strictly worse than not printing some errors at all, and this is the surest way to ensure all errors are printed.

cc @luhring who made the original change