### PR TITLE
convert/python: check if release is found

### DIFF
--- a/pkg/convert/python/python.go
+++ b/pkg/convert/python/python.go
@@ -312,6 +312,10 @@ func (c *PythonContext) generatePipeline(ctx context.Context, pack Package, vers
 		}
 	}
 
+	if release.Url == "" {
+		return pipeline, errors.New("could not find any sdist package in available releases")
+	}
+
 	artifact256SHA, err := c.PackageIndex.Client.GetArtifactSHA256(ctx, release.Url)
 	if err != nil {
 		c.Logger.Printf("[%s] SHA256 Generation FAILED. %v", pack.Info.Name, err)


### PR DESCRIPTION
In case there is no `sdist` package, `convert python` command currently error out `SHA256 Generation FAILED`. Which might be slightly mislead. The actually error is that, we couldn't even find any release to proceed.

Example package to reproduce: https://pypi.org/pypi/ml-metadata/json