### PR TITLE
Tweak the strip pipeline so that it never fails for deleted files

### DIFF
--- a/pkg/build/pipelines/strip.yaml
+++ b/pkg/build/pipelines/strip.yaml
@@ -10,9 +10,8 @@ pipeline:
       cd "${{targets.destdir}}"
       scanelf --recursive --nobanner --osabi --etype "ET_DYN,ET_EXEC" . \
         | while read type osabi filename; do
-        # scanelf may have picked up a temp file so verify that file still exists
-        [ -e "$filename" ] || continue
 
         [ "$osabi" != "STANDALONE" ] || continue
-        strip "${filename}"
+        # scanelf may have picked up a temp file so verify that file still exists
+        strip "${filename}" || [ ! -e "$filename" ]
       done


### PR DESCRIPTION
This seems like a less racy way of achieving the temp file check, so figured I'd propose it. 🤞 