### PR TITLE
Remove `wget -q` from `fetch`

### DIFF
--- a/pkg/build/pipelines/fetch.yaml
+++ b/pkg/build/pipelines/fetch.yaml
@@ -74,7 +74,7 @@ pipeline:
       fi
 
       if [ ! -f $bn ]; then
-        wget -q '-T${{inputs.timeout}}' '--dns-timeout=${{inputs.dns-timeout}}' '--tries=${{inputs.retry-limit}}' --random-wait --retry-connrefused --continue '${{inputs.uri}}'
+        wget '-T${{inputs.timeout}}' '--dns-timeout=${{inputs.dns-timeout}}' '--tries=${{inputs.retry-limit}}' --random-wait --retry-connrefused --continue '${{inputs.uri}}'
       fi
 
       if [ "${{inputs.expected-sha256}}" != "" ]; then


### PR DESCRIPTION
This removes the `-q` from the `wget` options in the `fetch` pipeline because it masks any errors `wget` saw that resulted in failures, which hinders our ability to triage without retrying the `wget` ourselves (in some cases enough for it to fail again).

This logging seems like small peas compared to other things, so hopefully this isn't contentious.

As anecdata, in my last world build, 4 of the builds failed with silent `wget` failures, and I was only able to reproduce `nasm.us` being down.