### PR TITLE
pipelines: meson/configure: explicitly invoke meson setup action

### DIFF
--- a/pkg/build/pipelines/meson/configure.yaml
+++ b/pkg/build/pipelines/meson/configure.yaml
@@ -16,6 +16,6 @@ inputs:
 
 pipeline:
   - runs: |
-      meson . ${{inputs.output-dir}} \
+      meson setup . ${{inputs.output-dir}} \
         --prefix=/usr \
         ${{inputs.opts}}


### PR DESCRIPTION
Meson has deprecated the default behavior of invoking the setup action when a path is provided as the first command-line argument, printing:

```
WARNING: Running the setup command as `meson [options]` instead of `meson setup [options]` is ambiguous and deprecated.
```