### PR TITLE
renovate: update to use new config infrastructure

### DIFF
--- a/pkg/build/build_test.go
+++ b/pkg/build/build_test.go
@@ -227,8 +227,7 @@ func TestConfiguration_Load(t *testing.T) {
 				if d := cmp.Diff(
 					*tt.expected,
 					*cfg,
-					cmpopts.IgnoreUnexported(config.Pipeline{}),
-					cmpopts.IgnoreFields(config.Configuration{}, "Root"),
+					cmpopts.IgnoreUnexported(config.Pipeline{}, config.Configuration{}),
 				); d != "" {
 					t.Fatalf("actual didn't match expected (-want, +got): %s", d)
 				}
@@ -299,7 +298,7 @@ package:
 	if err != nil {
 		t.Fatal(err)
 	}
-	if d := cmp.Diff(expected, cfg, cmpopts.IgnoreFields(config.Configuration{}, "Root")); d != "" {
+	if d := cmp.Diff(expected, cfg, cmpopts.IgnoreUnexported(config.Configuration{})); d != "" {
 		t.Fatalf("actual didn't match expected: %s", d)
 	}
 }

--- a/pkg/build/build_test.go
+++ b/pkg/build/build_test.go
@@ -224,7 +224,12 @@ func TestConfiguration_Load(t *testing.T) {
 					t.Fatalf("actual didn't match expected (want nil, got config)")
 				}
 			} else {
-				if d := cmp.Diff(*tt.expected, *cfg, cmpopts.IgnoreUnexported(config.Pipeline{})); d != "" {
+				if d := cmp.Diff(
+					*tt.expected,
+					*cfg,
+					cmpopts.IgnoreUnexported(config.Pipeline{}),
+					cmpopts.IgnoreFields(config.Configuration{}, "Root"),
+				); d != "" {
 					t.Fatalf("actual didn't match expected (-want, +got): %s", d)
 				}
 			}
@@ -294,7 +299,7 @@ package:
 	if err != nil {
 		t.Fatal(err)
 	}
-	if d := cmp.Diff(expected, cfg); d != "" {
+	if d := cmp.Diff(expected, cfg, cmpopts.IgnoreFields(config.Configuration{}, "Root")); d != "" {
 		t.Fatalf("actual didn't match expected: %s", d)
 	}
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -273,7 +273,7 @@ type Configuration struct {
 	Options map[string]BuildOption `yaml:"options,omitempty"`
 
 	// Parsed AST for this configuration
-	Root yaml.Node `yaml:"-"`
+	root *yaml.Node
 }
 
 // Name returns a name for the configuration, using the package name.
@@ -481,10 +481,11 @@ func ParseConfiguration(configurationFilePath string, opts ...ConfigurationParsi
 		return nil, err
 	}
 
-	cfg := Configuration{}
+	root := yaml.Node{}
+
+	cfg := Configuration{root: &root}
 
 	// Unmarshal into a node first
-	root := yaml.Node{}
 	decoder_node := yaml.NewDecoder(f)
 	err = decoder_node.Decode(&root)
 	if err != nil {
@@ -505,8 +506,6 @@ func ParseConfiguration(configurationFilePath string, opts ...ConfigurationParsi
 	if err != nil {
 		return nil, fmt.Errorf("unable to decode configuration file %q: %w", configurationFilePath, err)
 	}
-
-	cfg.Root = root
 
 	detectedCommit := detectCommit(configurationDirPath, options.logger)
 	if cfg.Package.Commit == "" {
@@ -672,6 +671,10 @@ func ParseConfiguration(configurationFilePath string, opts ...ConfigurationParsi
 	}
 
 	return &cfg, nil
+}
+
+func (cfg Configuration) Root() *yaml.Node {
+	return cfg.root
 }
 
 type ErrInvalidConfiguration struct {

--- a/pkg/renovate/bump/bump.go
+++ b/pkg/renovate/bump/bump.go
@@ -74,7 +74,7 @@ func New(opts ...Option) renovate.Renovator {
 		log.Printf("attempting to bump version to %s", bcfg.TargetVersion)
 
 		// Find the package.version node first and change it.
-		packageNode, err := renovate.NodeFromMapping(rc.Root.Content[0], "package")
+		packageNode, err := renovate.NodeFromMapping(rc.Configuration.Root.Content[0], "package")
 		if err != nil {
 			return err
 		}
@@ -94,7 +94,7 @@ func New(opts ...Option) renovate.Renovator {
 		epochNode.Value = "0"
 
 		// Find our main pipeline YAML node.
-		pipelineNode, err := renovate.NodeFromMapping(rc.Root.Content[0], "pipeline")
+		pipelineNode, err := renovate.NodeFromMapping(rc.Configuration.Root.Content[0], "pipeline")
 		if err != nil {
 			return err
 		}

--- a/pkg/renovate/bump/bump.go
+++ b/pkg/renovate/bump/bump.go
@@ -74,7 +74,7 @@ func New(opts ...Option) renovate.Renovator {
 		log.Printf("attempting to bump version to %s", bcfg.TargetVersion)
 
 		// Find the package.version node first and change it.
-		packageNode, err := renovate.NodeFromMapping(rc.Configuration.Root.Content[0], "package")
+		packageNode, err := renovate.NodeFromMapping(rc.Configuration.Root().Content[0], "package")
 		if err != nil {
 			return err
 		}
@@ -94,7 +94,7 @@ func New(opts ...Option) renovate.Renovator {
 		epochNode.Value = "0"
 
 		// Find our main pipeline YAML node.
-		pipelineNode, err := renovate.NodeFromMapping(rc.Configuration.Root.Content[0], "pipeline")
+		pipelineNode, err := renovate.NodeFromMapping(rc.Configuration.Root().Content[0], "pipeline")
 		if err != nil {
 			return err
 		}

--- a/pkg/renovate/cache/cache.go
+++ b/pkg/renovate/cache/cache.go
@@ -73,7 +73,7 @@ func New(opts ...Option) renovate.Renovator {
 
 	return func(ctx context.Context, rc *renovate.RenovationContext) error {
 		// Find the package.name and package.version nodes.
-		packageNode, err := renovate.NodeFromMapping(rc.Configuration.Root.Content[0], "package")
+		packageNode, err := renovate.NodeFromMapping(rc.Configuration.Root().Content[0], "package")
 		if err != nil {
 			return err
 		}
@@ -93,7 +93,7 @@ func New(opts ...Option) renovate.Renovator {
 		log.Printf("fetching artifacts relating to %s-%s", cfg.packageName, cfg.packageVersion)
 
 		// Find our main pipeline YAML node.
-		pipelineNode, err := renovate.NodeFromMapping(rc.Configuration.Root.Content[0], "pipeline")
+		pipelineNode, err := renovate.NodeFromMapping(rc.Configuration.Root().Content[0], "pipeline")
 		if err != nil {
 			return err
 		}

--- a/pkg/renovate/cache/cache.go
+++ b/pkg/renovate/cache/cache.go
@@ -73,7 +73,7 @@ func New(opts ...Option) renovate.Renovator {
 
 	return func(ctx context.Context, rc *renovate.RenovationContext) error {
 		// Find the package.name and package.version nodes.
-		packageNode, err := renovate.NodeFromMapping(rc.Root.Content[0], "package")
+		packageNode, err := renovate.NodeFromMapping(rc.Configuration.Root.Content[0], "package")
 		if err != nil {
 			return err
 		}
@@ -93,7 +93,7 @@ func New(opts ...Option) renovate.Renovator {
 		log.Printf("fetching artifacts relating to %s-%s", cfg.packageName, cfg.packageVersion)
 
 		// Find our main pipeline YAML node.
-		pipelineNode, err := renovate.NodeFromMapping(rc.Root.Content[0], "pipeline")
+		pipelineNode, err := renovate.NodeFromMapping(rc.Configuration.Root.Content[0], "pipeline")
 		if err != nil {
 			return err
 		}

--- a/pkg/renovate/renovate.go
+++ b/pkg/renovate/renovate.go
@@ -105,7 +105,7 @@ func (rc *RenovationContext) WriteConfig() error {
 
 	enc := formatted.NewEncoder(configFile).AutomaticConfig()
 
-	if err := enc.Encode(rc.Configuration.Root.Content[0]); err != nil {
+	if err := enc.Encode(rc.Configuration.Root().Content[0]); err != nil {
 		return err
 	}
 

--- a/pkg/renovate/renovate.go
+++ b/pkg/renovate/renovate.go
@@ -18,8 +18,9 @@ import (
 	"context"
 	"os"
 
+	"chainguard.dev/melange/pkg/config"
+
 	"github.com/chainguard-dev/yam/pkg/yam/formatted"
-	"gopkg.in/yaml.v3"
 )
 
 // Context contains the default settings for renovations.
@@ -54,7 +55,7 @@ func New(opts ...Option) (*Context, error) {
 // ongoing renovation.
 type RenovationContext struct {
 	Context *Context
-	Root    yaml.Node
+	Configuration *config.Configuration
 }
 
 // Renovator performs a renovation.
@@ -84,15 +85,12 @@ func (c *Context) Renovate(ctx context.Context, renovators ...Renovator) error {
 
 // LoadConfig loads the configuration data into an AST for renovation.
 func (rc *RenovationContext) LoadConfig() error {
-	configData, err := os.ReadFile(rc.Context.ConfigFile)
+	cfg, err := config.ParseConfiguration(rc.Context.ConfigFile)
 	if err != nil {
 		return err
 	}
 
-	if err := yaml.Unmarshal(configData, &rc.Root); err != nil {
-		return err
-	}
-
+	rc.Configuration = cfg
 	return nil
 }
 
@@ -107,7 +105,7 @@ func (rc *RenovationContext) WriteConfig() error {
 
 	enc := formatted.NewEncoder(configFile).AutomaticConfig()
 
-	if err := enc.Encode(rc.Root.Content[0]); err != nil {
+	if err := enc.Encode(rc.Configuration.Root.Content[0]); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
This is part of the project to add var transforms to renovate.

This does not yet do the var transforms, that is forthcoming work.