### PR TITLE
Make var transforms work in bump

### DIFF
--- a/pkg/build/build_test.go
+++ b/pkg/build/build_test.go
@@ -40,7 +40,7 @@ func TestConfiguration_Load(t *testing.T) {
 		name                string
 		skipConfigCleanStep bool
 		requireErr          require.ErrorAssertionFunc
-		expected	    *config.Configuration
+		expected            *config.Configuration
 	}{
 		{
 			name:       "range-subpackages",
@@ -164,7 +164,7 @@ func TestConfiguration_Load(t *testing.T) {
 			expected:            nil,
 		},
 		{
-			name:               "invalid-package-name",
+			name:                "invalid-package-name",
 			skipConfigCleanStep: true,
 			requireErr:          requireErrInvalidConfiguration,
 			expected:            nil,

--- a/pkg/build/pipeline.go
+++ b/pkg/build/pipeline.go
@@ -118,18 +118,25 @@ func substitutionMap(pb *PipelineBuild) (map[string]string, error) {
 		substitutionCrossTripletGnuMusl:  pb.Build.Arch.ToTriplet("musl"),
 		substitutionBuildArch:            pb.Build.Arch.ToAPK(),
 	}
+	
+	// Retrieve vars from config
+	subst_nw, err := pb.Build.Configuration.GetVarsFromConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	for k, v := range subst_nw {
+		nw[k] = v
+	}
+
+	// Perform substitutions on current map
+	err = pb.Build.Configuration.PerformVarSubstitutions(nw)
+	if err != nil {
+		return nil, err
+	}
 
 	if pb.Subpackage != nil {
 		nw[substitutionSubPkgDir] = fmt.Sprintf("/home/build/melange-out/%s", pb.Subpackage.Subpackage.Name)
-	}
-
-	err := config.GetVarsFromConfig(&pb.Build.Configuration, nw)
-	if err != nil {
-		return nil, err
-	}
-	err = config.PerformVarSubstitutions(&pb.Build.Configuration, nw)
-	if err != nil {
-		return nil, err
 	}
 
 	for k := range pb.Build.Configuration.Options {

--- a/pkg/build/pipeline.go
+++ b/pkg/build/pipeline.go
@@ -105,7 +105,7 @@ func substitutionMap(pb *PipelineBuild) (map[string]string, error) {
 		config.SubstitutionCrossTripletGnuMusl:  pb.Build.Arch.ToTriplet("musl"),
 		config.SubstitutionBuildArch:            pb.Build.Arch.ToAPK(),
 	}
-	
+
 	// Retrieve vars from config
 	subst_nw, err := pb.Build.Configuration.GetVarsFromConfig()
 	if err != nil {

--- a/pkg/build/pipeline.go
+++ b/pkg/build/pipeline.go
@@ -49,19 +49,6 @@ func NewPipelineContext(p *config.Pipeline, logger apko_log.Logger) (*PipelineCo
 	}, nil
 }
 
-const (
-	substitutionPackageName          = "${{package.name}}"
-	substitutionPackageVersion       = "${{package.version}}"
-	substitutionPackageEpoch         = "${{package.epoch}}"
-	substitutionTargetsDestdir       = "${{targets.destdir}}"
-	substitutionSubPkgDir            = "${{targets.subpkgdir}}"
-	substitutionHostTripletGnu       = "${{host.triplet.gnu}}"
-	substitutionHostTripletRust      = "${{host.triplet.rust}}"
-	substitutionCrossTripletGnuGlibc = "${{cross.triplet.gnu.glibc}}"
-	substitutionCrossTripletGnuMusl  = "${{cross.triplet.gnu.musl}}"
-	substitutionBuildArch            = "${{build.arch}}"
-)
-
 type PipelineBuild struct {
 	Build      *Build
 	Package    *PackageContext
@@ -108,15 +95,15 @@ func MutateWith(pb *PipelineBuild, with map[string]string) (map[string]string, e
 
 func substitutionMap(pb *PipelineBuild) (map[string]string, error) {
 	nw := map[string]string{
-		substitutionPackageName:          pb.Package.Package.Name,
-		substitutionPackageVersion:       pb.Package.Package.Version,
-		substitutionPackageEpoch:         strconv.FormatUint(pb.Package.Package.Epoch, 10),
-		substitutionTargetsDestdir:       fmt.Sprintf("/home/build/melange-out/%s", pb.Package.Package.Name),
-		substitutionHostTripletGnu:       pb.Build.BuildTripletGnu(),
-		substitutionHostTripletRust:      pb.Build.BuildTripletRust(),
-		substitutionCrossTripletGnuGlibc: pb.Build.Arch.ToTriplet("gnu"),
-		substitutionCrossTripletGnuMusl:  pb.Build.Arch.ToTriplet("musl"),
-		substitutionBuildArch:            pb.Build.Arch.ToAPK(),
+		config.SubstitutionPackageName:          pb.Package.Package.Name,
+		config.SubstitutionPackageVersion:       pb.Package.Package.Version,
+		config.SubstitutionPackageEpoch:         strconv.FormatUint(pb.Package.Package.Epoch, 10),
+		config.SubstitutionTargetsDestdir:       fmt.Sprintf("/home/build/melange-out/%s", pb.Package.Package.Name),
+		config.SubstitutionHostTripletGnu:       pb.Build.BuildTripletGnu(),
+		config.SubstitutionHostTripletRust:      pb.Build.BuildTripletRust(),
+		config.SubstitutionCrossTripletGnuGlibc: pb.Build.Arch.ToTriplet("gnu"),
+		config.SubstitutionCrossTripletGnuMusl:  pb.Build.Arch.ToTriplet("musl"),
+		config.SubstitutionBuildArch:            pb.Build.Arch.ToAPK(),
 	}
 	
 	// Retrieve vars from config
@@ -136,7 +123,7 @@ func substitutionMap(pb *PipelineBuild) (map[string]string, error) {
 	}
 
 	if pb.Subpackage != nil {
-		nw[substitutionSubPkgDir] = fmt.Sprintf("/home/build/melange-out/%s", pb.Subpackage.Subpackage.Name)
+		nw[config.SubstitutionSubPkgDir] = fmt.Sprintf("/home/build/melange-out/%s", pb.Subpackage.Subpackage.Name)
 	}
 
 	for k := range pb.Build.Configuration.Options {

--- a/pkg/build/pipeline_test.go
+++ b/pkg/build/pipeline_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"chainguard.dev/melange/pkg/config"
+	"chainguard.dev/melange/pkg/util"
 
 	"github.com/stretchr/testify/require"
 )
@@ -29,7 +30,7 @@ func Test_mutateStringFromMap(t *testing.T) {
 	}
 
 	input1 := "${{inputs.foo}} ${{inputs.baz-bah-boom}}"
-	output1, err := MutateStringFromMap(keys, input1)
+	output1, err := util.MutateStringFromMap(keys, input1)
 
 	require.NoError(t, err)
 	require.Equal(t, output1, "foo ", "bogus variable substitution not deleted")

--- a/pkg/config/vars.go
+++ b/pkg/config/vars.go
@@ -36,6 +36,7 @@ const (
 	SubstitutionBuildArch            = "${{build.arch}}"
 )
 
+// Get get variables from configuration and return them in a map
 func (cfg Configuration) GetVarsFromConfig() (map[string]string, error) {
 	nw := map[string]string{}
 
@@ -53,6 +54,7 @@ func (cfg Configuration) GetVarsFromConfig() (map[string]string, error) {
 	return nw, nil
 }
 
+// Perform variable substitutions from the config on a given map
 func (cfg Configuration) PerformVarSubstitutions(nw map[string]string) error {
 	for _, v := range cfg.VarTransforms {
 		nk := fmt.Sprintf("${{vars.%s}}", v.To)

--- a/pkg/config/vars.go
+++ b/pkg/config/vars.go
@@ -36,7 +36,7 @@ const (
 	SubstitutionBuildArch            = "${{build.arch}}"
 )
 
-// Get get variables from configuration and return them in a map
+// Get variables from configuration and return them in a map
 func (cfg Configuration) GetVarsFromConfig() (map[string]string, error) {
 	nw := map[string]string{}
 
@@ -54,7 +54,7 @@ func (cfg Configuration) GetVarsFromConfig() (map[string]string, error) {
 	return nw, nil
 }
 
-// Perform variable substitutions from the config on a given map
+// Perform variable substitutions from the configuration on a given map
 func (cfg Configuration) PerformVarSubstitutions(nw map[string]string) error {
 	for _, v := range cfg.VarTransforms {
 		nk := fmt.Sprintf("${{vars.%s}}", v.To)

--- a/pkg/config/vars.go
+++ b/pkg/config/vars.go
@@ -23,6 +23,19 @@ import (
 	"chainguard.dev/melange/pkg/util"
 )
 
+const (
+	SubstitutionPackageName          = "${{package.name}}"
+	SubstitutionPackageVersion       = "${{package.version}}"
+	SubstitutionPackageEpoch         = "${{package.epoch}}"
+	SubstitutionTargetsDestdir       = "${{targets.destdir}}"
+	SubstitutionSubPkgDir            = "${{targets.subpkgdir}}"
+	SubstitutionHostTripletGnu       = "${{host.triplet.gnu}}"
+	SubstitutionHostTripletRust      = "${{host.triplet.rust}}"
+	SubstitutionCrossTripletGnuGlibc = "${{cross.triplet.gnu.glibc}}"
+	SubstitutionCrossTripletGnuMusl  = "${{cross.triplet.gnu.musl}}"
+	SubstitutionBuildArch            = "${{build.arch}}"
+)
+
 func (cfg Configuration) GetVarsFromConfig() (map[string]string, error) {
 	nw := map[string]string{}
 

--- a/pkg/config/vars.go
+++ b/pkg/config/vars.go
@@ -23,23 +23,25 @@ import (
 	"chainguard.dev/melange/pkg/util"
 )
 
-func GetVarsFromConfig(Configuration *Configuration, nw map[string]string) error {
-	for k, v := range Configuration.Vars {
+func (cfg Configuration) GetVarsFromConfig() (map[string]string, error) {
+	nw := map[string]string{}
+
+	for k, v := range cfg.Vars {
 		nk := fmt.Sprintf("${{vars.%s}}", k)
 
 		nv, err := util.MutateStringFromMap(nw, v)
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		nw[nk] = nv
 	}
 
-	return nil
+	return nw, nil
 }
 
-func PerformVarSubstitutions(Configuration *Configuration, nw map[string]string) error {
-	for _, v := range Configuration.VarTransforms {
+func (cfg Configuration) PerformVarSubstitutions(nw map[string]string) error {
+	for _, v := range cfg.VarTransforms {
 		nk := fmt.Sprintf("${{vars.%s}}", v.To)
 		from, err := util.MutateStringFromMap(nw, v.From)
 		if err != nil {

--- a/pkg/config/vars.go
+++ b/pkg/config/vars.go
@@ -1,0 +1,59 @@
+// Copyright 2023 Chainguard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/pkg/errors"
+
+	"chainguard.dev/melange/pkg/util"
+)
+
+func GetVarsFromConfig(Configuration *Configuration, nw map[string]string) error {
+	for k, v := range Configuration.Vars {
+		nk := fmt.Sprintf("${{vars.%s}}", k)
+
+		nv, err := util.MutateStringFromMap(nw, v)
+		if err != nil {
+			return err
+		}
+
+		nw[nk] = nv
+	}
+
+	return nil
+}
+
+func PerformVarSubstitutions(Configuration *Configuration, nw map[string]string) error {
+	for _, v := range Configuration.VarTransforms {
+		nk := fmt.Sprintf("${{vars.%s}}", v.To)
+		from, err := util.MutateStringFromMap(nw, v.From)
+		if err != nil {
+			return err
+		}
+
+		re, err := regexp.Compile(v.Match)
+		if err != nil {
+			return errors.Wrapf(err, "match value: %s string does not compile into a regex", v.Match)
+		}
+
+		output := re.ReplaceAllString(from, v.Replace)
+		nw[nk] = output
+	}
+
+	return nil
+}

--- a/pkg/renovate/bump/bump.go
+++ b/pkg/renovate/bump/bump.go
@@ -98,7 +98,10 @@ func New(opts ...Option) renovate.Renovator {
 		rc.Vars[config.SubstitutionPackageEpoch] = epochNode.Value
 
 		// Recompute variable transforms
-		rc.Configuration.PerformVarSubstitutions(rc.Vars)
+		err = rc.Configuration.PerformVarSubstitutions(rc.Vars)
+		if err != nil {
+			return err
+		}
 
 		// Find our main pipeline YAML node.
 		pipelineNode, err := renovate.NodeFromMapping(rc.Configuration.Root().Content[0], "pipeline")

--- a/pkg/renovate/bump/bump.go
+++ b/pkg/renovate/bump/bump.go
@@ -21,11 +21,11 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"strings"
 
 	"github.com/dprotaso/go-yit"
 	"gopkg.in/yaml.v3"
 
+	"chainguard.dev/melange/pkg/config"
 	"chainguard.dev/melange/pkg/renovate"
 	"chainguard.dev/melange/pkg/util"
 )
@@ -87,11 +87,18 @@ func New(opts ...Option) renovate.Renovator {
 		versionNode.Style = yaml.FlowStyle
 		versionNode.Tag = "!!str"
 
+		// Update the variable mapping with the target version
+		rc.Vars[config.SubstitutionPackageVersion] = bcfg.TargetVersion
+
 		epochNode, err := renovate.NodeFromMapping(packageNode, "epoch")
 		if err != nil {
 			return err
 		}
 		epochNode.Value = "0"
+		rc.Vars[config.SubstitutionPackageEpoch] = epochNode.Value
+
+		// Recompute variable transforms
+		rc.Configuration.PerformVarSubstitutions(rc.Vars)
 
 		// Find our main pipeline YAML node.
 		pipelineNode, err := renovate.NodeFromMapping(rc.Configuration.Root().Content[0], "pipeline")
@@ -105,7 +112,7 @@ func New(opts ...Option) renovate.Renovator {
 			Filter(yit.WithMapValue("fetch"))
 
 		for fetchNode, ok := it(); ok; fetchNode, ok = it() {
-			if err := updateFetch(ctx, fetchNode, bcfg.TargetVersion); err != nil {
+			if err := updateFetch(ctx, rc, fetchNode, bcfg.TargetVersion); err != nil {
 				return err
 			}
 		}
@@ -125,7 +132,7 @@ func New(opts ...Option) renovate.Renovator {
 }
 
 // updateFetch takes a "fetch" pipeline node and updates the parameters of it.
-func updateFetch(ctx context.Context, node *yaml.Node, targetVersion string) error {
+func updateFetch(ctx context.Context, rc *renovate.RenovationContext, node *yaml.Node, targetVersion string) error {
 	withNode, err := renovate.NodeFromMapping(node, "with")
 	if err != nil {
 		return err
@@ -139,7 +146,10 @@ func updateFetch(ctx context.Context, node *yaml.Node, targetVersion string) err
 	log.Printf("processing fetch node:")
 
 	// Fetch the new sources.
-	evaluatedUri := strings.ReplaceAll(uriNode.Value, "${{package.version}}", targetVersion)
+	evaluatedUri, err := util.MutateStringFromMap(rc.Vars, uriNode.Value)
+	if err != nil {
+		return err
+	}
 	log.Printf("  uri: %s", uriNode.Value)
 	log.Printf("  evaluated: %s", evaluatedUri)
 

--- a/pkg/renovate/bump/testdata/major_minor_patch.yaml
+++ b/pkg/renovate/bump/testdata/major_minor_patch.yaml
@@ -9,9 +9,13 @@ var-transforms:
     match: (\d.\d.\d)
     replace: $1
     to: same-package-version
+  - from: ${{package.name}}
+    match: (.*)
+    replace: $1
+    to: same-package-name
 
 pipeline:
   - uses: fetch
     with:
-      uri: REPLACE_ME/wine/cheese/cheese-${{vars.same-package-version}}.tar.gz
+      uri: REPLACE_ME/wine/${{vars.same-package-name}}/${{vars.same-package-name}}-${{vars.same-package-version}}.tar.gz
       expected-sha256: ab5a03176ee106d3f0fa90e381da478ddae405918153cca248e682cd0c4a2269

--- a/pkg/renovate/bump/testdata/major_minor_patch.yaml
+++ b/pkg/renovate/bump/testdata/major_minor_patch.yaml
@@ -4,8 +4,14 @@ package:
   epoch: 2
   description: "a cheesy library"
 
+var-transforms:
+  - from: ${{package.version}}
+    match: (\d.\d.\d)
+    replace: $1
+    to: same-package-version
+
 pipeline:
   - uses: fetch
     with:
-      uri: REPLACE_ME/wine/cheese/cheese-${{package.version}}.tar.gz
+      uri: REPLACE_ME/wine/cheese/cheese-${{vars.same-package-version}}.tar.gz
       expected-sha256: ab5a03176ee106d3f0fa90e381da478ddae405918153cca248e682cd0c4a2269

--- a/pkg/renovate/renovate.go
+++ b/pkg/renovate/renovate.go
@@ -26,6 +26,7 @@ import (
 // Context contains the default settings for renovations.
 type Context struct {
 	ConfigFile string
+	Vars map[string]string
 }
 
 type Option func(ctx *Context) error

--- a/pkg/renovate/renovate.go
+++ b/pkg/renovate/renovate.go
@@ -17,11 +17,14 @@ package renovate
 import (
 	"context"
 	"os"
+	"runtime"
 	"strconv"
 
-	"chainguard.dev/melange/pkg/config"
-
 	"github.com/chainguard-dev/yam/pkg/yam/formatted"
+
+	apko_types "chainguard.dev/apko/pkg/build/types"
+
+	"chainguard.dev/melange/pkg/config"
 )
 
 // Context contains the default settings for renovations.
@@ -98,9 +101,11 @@ func (rc *RenovationContext) LoadConfig() error {
 	}
 
 	// These are probably sufficient for now.
+	// TODO(Elizafox): Enable cross-arch bumping
 	vars[config.SubstitutionPackageName]    = cfg.Package.Name
 	vars[config.SubstitutionPackageVersion] = cfg.Package.Version
 	vars[config.SubstitutionPackageEpoch]   = strconv.FormatUint(cfg.Package.Epoch, 10)
+	vars[config.SubstitutionBuildArch]      = apko_types.ParseArchitecture(runtime.GOARCH).ToAPK()
 
 	err = cfg.PerformVarSubstitutions(vars)
 	if err != nil {

--- a/pkg/renovate/renovate.go
+++ b/pkg/renovate/renovate.go
@@ -58,9 +58,9 @@ func New(opts ...Option) (*Context, error) {
 // RenovationContext encapsulates state relating to an
 // ongoing renovation.
 type RenovationContext struct {
-	Context *Context
+	Context       *Context
 	Configuration *config.Configuration
-	Vars map[string]string
+	Vars          map[string]string
 }
 
 // Renovator performs a renovation.
@@ -102,10 +102,10 @@ func (rc *RenovationContext) LoadConfig() error {
 
 	// These are probably sufficient for now.
 	// TODO(Elizafox): Enable cross-arch bumping
-	vars[config.SubstitutionPackageName]    = cfg.Package.Name
+	vars[config.SubstitutionPackageName] = cfg.Package.Name
 	vars[config.SubstitutionPackageVersion] = cfg.Package.Version
-	vars[config.SubstitutionPackageEpoch]   = strconv.FormatUint(cfg.Package.Epoch, 10)
-	vars[config.SubstitutionBuildArch]      = apko_types.ParseArchitecture(runtime.GOARCH).ToAPK()
+	vars[config.SubstitutionPackageEpoch] = strconv.FormatUint(cfg.Package.Epoch, 10)
+	vars[config.SubstitutionBuildArch] = apko_types.ParseArchitecture(runtime.GOARCH).ToAPK()
 
 	err = cfg.PerformVarSubstitutions(vars)
 	if err != nil {

--- a/pkg/util/map_subst.go
+++ b/pkg/util/map_subst.go
@@ -20,6 +20,7 @@ import (
 	"chainguard.dev/melange/pkg/cond"
 )
 
+// Given a string and a map, replace the variables in the string with values in the map
 func MutateStringFromMap(with map[string]string, input string) (string, error) {
 	lookupWith := func(key string) (string, error) {
 		if val, ok := with[key]; ok {

--- a/pkg/util/map_subst.go
+++ b/pkg/util/map_subst.go
@@ -1,0 +1,38 @@
+// Copyright 2023 Chainguard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"fmt"
+
+	"chainguard.dev/melange/pkg/cond"
+)
+
+func MutateStringFromMap(with map[string]string, input string) (string, error) {
+	lookupWith := func(key string) (string, error) {
+		if val, ok := with[key]; ok {
+			return val, nil
+		}
+
+		nk := fmt.Sprintf("${{%s}}", key)
+		if val, ok := with[nk]; ok {
+			return val, nil
+		}
+
+		return "", fmt.Errorf("variable %s not defined", key)
+	}
+
+	return cond.Subst(input, lookupWith)
+}


### PR DESCRIPTION
My previous work has now come to a head and now var transforms work in bump with this patch.

Not all variables are available for substitution at the moment, as that would complicate the logic considerably. Variables that are presently supported for substitution:

- ${{package.name}}
- ${{package.version}}
- ${{package.epoch}}
- ${{build.arch}}

This is sufficient for now. All packages that use var transforms only transform the version at present.