### PR TITLE
container: bubblewrap: do not defer closing files

### DIFF
--- a/pkg/container/bubblewrap_runner.go
+++ b/pkg/container/bubblewrap_runner.go
@@ -160,10 +160,10 @@ func (b bubblewrapOCILoader) LoadImage(ctx context.Context, layer v1.Layer, arch
 			if err != nil {
 				return ref, fmt.Errorf("failed to create file %s: %w", fullname, err)
 			}
-			defer f.Close()
 			if _, err := io.Copy(f, tr); err != nil {
 				return ref, fmt.Errorf("failed to copy file %s: %w", fullname, err)
 			}
+			f.Close()
 		case tar.TypeSymlink:
 			if err := os.Symlink(hdr.Linkname, filepath.Join(guestDir, hdr.Name)); err != nil {
 				return ref, fmt.Errorf("failed to create symlink %s: %w", fullname, err)


### PR DESCRIPTION
In go, defer statements are scoped to the function level, not the block level, so this results in file descriptor exhaustion for guests which have more than RLIMIT_NOFILE files installed in them.

Instead, immediately close files after writing their contents.