### PR TITLE
doc and lint revisions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+repos:
+  - repo: https://github.com/jessp01/pre-commit-golang.git
+    rev: v0.5.7
+    hooks:
+      - id: go-fmt
+        #- id: go-imports
+        #- id: go-vet
+        #- id: go-lint
+        #- id: go-critic
+      - id: go-ineffassign
+      - id: shellcheck

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Melange provides the following default substitutions which can be referenced in 
 | `${{targets.destdir}}`   | Directory where targets will be stored            |
 | `${{targets.subpkgdir}}` | Directory where subpackage targets will be stored |
 
-An example build file pipeline with subsitutuions:
+An example build file pipeline with substitutions:
 
 ```yaml
 pipeline:

--- a/hack/make-devenv.sh
+++ b/hack/make-devenv.sh
@@ -19,7 +19,7 @@ run_builder() {
     if ! (docker inspect melange-inception:latest >/dev/null 2>&1 ); then
         set -e
         mkdir _output > /dev/null 2>&1 || : 
-        docker run --rm -v $(pwd):/melange -w /melange \
+        docker run --rm -v "$(pwd)":/melange -w /melange \
             cgr.dev/chainguard/apko@${BUILDER_APKO_TAG} build \
             ./hack/melange-devenv.yaml ${IMAGE_TAG}:latest ./_output/melange-inception.tar.gz  \
             --sbom=false
@@ -31,7 +31,7 @@ run_builder() {
 
 run() {
     docker run --rm --privileged -w /melage -v /var/run/docker.sock:/var/run/docker.sock \
-        -v $(pwd):/melage -ti ${IMAGE_TAG}:latest hack/make-devenv.sh setup
+        -v "$(pwd)":/melange -ti ${IMAGE_TAG}:latest hack/make-devenv.sh setup
 }
 
 setup() {

--- a/pkg/build/runner.go
+++ b/pkg/build/runner.go
@@ -28,7 +28,7 @@ func GetDefaultRunner() runner {
 	return r
 }
 
-// GetAllrunners returns a list of all valid runners.
+// GetAllRunners returns a list of all valid runners.
 func GetAllRunners() []runner {
 	return []runner{
 		runnerBubblewrap,

--- a/pkg/cli/index.go
+++ b/pkg/cli/index.go
@@ -21,6 +21,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// Index is a constructor for a cobra.Command which wraps the IndexCmd function.
 func Index() *cobra.Command {
 	var apkIndexFilename string
 	var expectedArch string
@@ -45,6 +46,7 @@ func Index() *cobra.Command {
 	return cmd
 }
 
+// IndexCmd is the backend implementation of the "melange index" command.
 func IndexCmd(ctx context.Context, opts ...index.Option) error {
 	ic, err := index.New(opts...)
 	if err != nil {

--- a/pkg/cli/packageversion.go
+++ b/pkg/cli/packageversion.go
@@ -23,7 +23,7 @@ func PackageVersion() *cobra.Command {
 		Use:   "package-version",
 		Short: "Report the target package for a YAML configuration file",
 		Long: `Report the target package for a YAML configuration file.
-		Shortcut for equivlaent of running:
+		Equivalent to running:
 		
 			melange query config.yaml '{{ .Package.Name }}-{{ .Package.Version }}-r{{ .Package.Epoch }}'
 		`,

--- a/pkg/cli/sign.go
+++ b/pkg/cli/sign.go
@@ -21,6 +21,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// SignIndex is a constructor that returns a cobra.Command which wraps the SignIndexCmd() function.
 func SignIndex() *cobra.Command {
 	var signingKey string
 
@@ -40,6 +41,7 @@ func SignIndex() *cobra.Command {
 	return cmd
 }
 
+// SignIndexCmd is the backend implementation of the "melange sign-index" command.
 func SignIndexCmd(ctx context.Context, signingKey string, indexFile string) error {
 	return sign.SignIndex(ctx, LogDefault(), signingKey, indexFile)
 }

--- a/pkg/cli/update_cache.go
+++ b/pkg/cli/update_cache.go
@@ -15,7 +15,6 @@
 package cli
 
 import (
-
 	"github.com/spf13/cobra"
 
 	"chainguard.dev/melange/pkg/renovate"

--- a/pkg/cli/update_cache.go
+++ b/pkg/cli/update_cache.go
@@ -15,8 +15,6 @@
 package cli
 
 import (
-	_ "context"
-	_ "fmt"
 
 	"github.com/spf13/cobra"
 

--- a/pkg/cli/update_cache.go
+++ b/pkg/cli/update_cache.go
@@ -22,6 +22,7 @@ import (
 	"chainguard.dev/melange/pkg/renovate/cache"
 )
 
+// UpdateCache is a constructor for a cobra.Command which provides the "melange update-cache" command.
 func UpdateCache() *cobra.Command {
 	var cacheDir string
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -391,7 +391,7 @@ func WithFS(filesystem fs.FS) ConfigurationParsingOption {
 	}
 }
 
-// WithEnvFileForParsing set the paths from whcih to read an environment file.
+// WithEnvFileForParsing set the paths from which to read an environment file.
 func WithEnvFileForParsing(path string) ConfigurationParsingOption {
 	return func(options *configOptions) {
 		options.envFilePath = path

--- a/pkg/container/kubernetes_runner.go
+++ b/pkg/container/kubernetes_runner.go
@@ -619,6 +619,7 @@ func (c KubernetesRunnerConfig) defaultBuilderPod(cfg *Config) *corev1.Pod {
 
 type KubernetesRunnerConfigOptions func(*KubernetesRunnerConfig)
 
+// WithKubernetesRunnerConfigBaseConfigFile sets the path to a config file with KubernetesRunner-specific options
 func WithKubernetesRunnerConfigBaseConfigFile(path string) KubernetesRunnerConfigOptions {
 	return func(c *KubernetesRunnerConfig) {
 		c.baseConfigFile = path

--- a/pkg/container/kubernetes_runner.go
+++ b/pkg/container/kubernetes_runner.go
@@ -490,10 +490,8 @@ func NewKubernetesConfig(opt ...KubernetesRunnerConfigOptions) (*KubernetesRunne
 	data, err := os.ReadFile(cfg.baseConfigFile)
 	if err != nil && !os.IsNotExist(err) {
 		return nil, fmt.Errorf("error reading config file %s: %w", cfg.baseConfigFile, err)
-	} else {
-		if err := yaml.Unmarshal(data, global); err != nil {
-			return nil, fmt.Errorf("error parsing config file %s: %w", cfg.baseConfigFile, err)
-		}
+	} else if err := yaml.Unmarshal(data, global); err != nil {
+		return nil, fmt.Errorf("error parsing config file %s: %w", cfg.baseConfigFile, err)
 	}
 
 	if err := mergo.Merge(cfg, global, mergo.WithOverride); err != nil {

--- a/pkg/convert/gem/gem_test.go
+++ b/pkg/convert/gem/gem_test.go
@@ -61,11 +61,11 @@ func TestGetGemMeta(t *testing.T) {
 			expected.RepoURI = expected.HomepageURI
 		}
 
-		gemUrl := fmt.Sprintf("%s/%s/", server.URL, gem.Name())
+		gemURL := fmt.Sprintf("%s/%s/", server.URL, gem.Name())
 		assert.NoError(t, err)
 
 		// Ensure expected == got
-		got, err := gemctx.getGemMeta(context.Background(), gemUrl)
+		got, err := gemctx.getGemMeta(context.Background(), gemURL)
 		assert.NoError(t, err)
 		assert.Equal(t, expected, got)
 	}

--- a/pkg/http/http.go
+++ b/pkg/http/http.go
@@ -45,7 +45,7 @@ func NewClient(rl *rate.Limiter) *RLHTTPClient {
 // sha256 hash of it.
 //
 // On success, it will return the sha256 hash as a string.
-func (r *RLHTTPClient) GetArtifactSHA256(ctx context.Context, artifactURI string) (string, error) {
+func (c *RLHTTPClient) GetArtifactSHA256(ctx context.Context, artifactURI string) (string, error) {
 	req, err := http.NewRequestWithContext(ctx, "GET", artifactURI, nil)
 	if err != nil {
 		return "", errors.Wrapf(err, "creating request for %s", artifactURI)

--- a/pkg/renovate/bump/bump.go
+++ b/pkg/renovate/bump/bump.go
@@ -149,14 +149,14 @@ func updateFetch(ctx context.Context, rc *renovate.RenovationContext, node *yaml
 	log.Printf("processing fetch node:")
 
 	// Fetch the new sources.
-	evaluatedUri, err := util.MutateStringFromMap(rc.Vars, uriNode.Value)
+	evaluatedURI, err := util.MutateStringFromMap(rc.Vars, uriNode.Value)
 	if err != nil {
 		return err
 	}
 	log.Printf("  uri: %s", uriNode.Value)
-	log.Printf("  evaluated: %s", evaluatedUri)
+	log.Printf("  evaluated: %s", evaluatedURI)
 
-	downloadedFile, err := util.DownloadFile(ctx, evaluatedUri)
+	downloadedFile, err := util.DownloadFile(ctx, evaluatedURI)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
- Some typo corrections
- Doc line above exported consts and functions
- Implemented some golint suggestions

I also added `.pre-commit-config.yaml` to the repo. To use it:

- `pip install pre-commit`
- Install the following Go packages:
  * go install github.com/go-critic/go-critic/cmd/gocritic@latest
  * go install https://pkg.go.dev/golang.org/x/tools/cmd/goimports@latest
  * go install golang.org/x/lint/golint@latest
- In your clone, run: `pre-commit install`

This will create .git/hooks/pre-commit and following that, these tests will run every time you invoke `git commit`:
```sh
go fmt...................................................................Passed
go imports...............................................................Passed
go vet...................................................................Passed
go lint..................................................................Passed
go-critic................................................................Passed
```

For now, I commented the `go-imports`, `go-vet`, `go-lint` and `go-critic` as they still have findings that should be looked it but I recommend enabling these once that's done.

To run all checks, uncomment them in `.pre-commit-config.yaml`, invoke `pre-commit install` and run `pre-commit run --all-files`

Attached is the full output of such a run.
[melange-lint.log](https://github.com/chainguard-dev/melange/files/12307877/melange-lint.log)
