### PR TITLE
allow override go version for uses: go/build and go/install

### DIFF
--- a/pkg/build/pipeline.go
+++ b/pkg/build/pipeline.go
@@ -213,6 +213,14 @@ func (pctx *PipelineContext) loadUse(pb *PipelineBuild, uses string, with map[st
 		return err
 	}
 
+	// allow input mutations on needs.packages
+	for p := range pctx.Pipeline.Needs.Packages {
+		pctx.Pipeline.Needs.Packages[p], err = util.MutateStringFromMap(pctx.Pipeline.With, pctx.Pipeline.Needs.Packages[p])
+		if err != nil {
+			return err
+		}
+	}
+
 	for k := range pctx.Pipeline.Pipeline {
 		pctx.Pipeline.Pipeline[k].With = rightJoinMap(pctx.Pipeline.With, pctx.Pipeline.Pipeline[k].With)
 	}

--- a/pkg/build/pipelines/go/build.yaml
+++ b/pkg/build/pipelines/go/build.yaml
@@ -2,11 +2,16 @@ name: Run a build using the go compiler
 
 needs:
   packages:
-    - go
+    - ${{inputs.go-package}}
     - busybox
     - ca-certificates-bundle
 
 inputs:
+  go-package:
+    description: |
+      The go package to install
+    default: go
+
   packages:
     description: |
       List of space-separated packages to compile. Files con also be specified.

--- a/pkg/build/pipelines/go/install.yaml
+++ b/pkg/build/pipelines/go/install.yaml
@@ -2,12 +2,17 @@ name: Run a build using the go compiler
 
 needs:
   packages:
-    - go
+    - ${{inputs.go-package}}
     - busybox
     - ca-certificates-bundle
     - git
 
 inputs:
+  go-package:
+    description: |
+      The go package to install
+    default: go
+
   package:
     description: |
       Import path to the package 


### PR DESCRIPTION
The go 1.21 release included breaking changes that result in breaking some go based packages.  Until upstream projects support go 1.21 a melange config can [pin](https://github.com/search?q=repo%3Awolfi-dev%2Fos%20Pinned%20to%201.20&type=code) to a specific go version, i.e. `go-1.20`.  

This causes a problem however as melange configs that take advantage of the reusable go pipeline are not able to specify a different go package version because the melange pipeline [hardcodes latest](https://github.com/chainguard-dev/melange/blob/11bdc1c01638a2574919a50cc00b07f416327ffa/pkg/build/pipelines/go/build.yaml#L5)

I'm not 100% this is the right answer but we need to be able to choose which go version is installed for melange configs that leverage
```yaml
uses: go/build
```
and
```yaml
uses: go/install
```

An alternative is we remove the go package from the built in pipeline and update all melange configs to explicitly specify the go package using the standard environment config, i.e.

```yaml
environment:
  contents:
    packages:
      - go-1.20

pipeline:
  - uses: go/build
``` 

This seems to be how the ruby pipeline works as no ruby package is defined in the [needs](https://github.com/chainguard-dev/melange/blob/11bdc1c01638a2574919a50cc00b07f416327ffa/pkg/build/pipelines/ruby/build.yaml#L3-L6) section.  However that would be a breaking change so I don't think this is viable.

Any other options?
