### PR TITLE
add melange sign command, slightly refactor and make public the signing methods

### DIFF
--- a/docs/md/melange.md
+++ b/docs/md/melange.md
@@ -27,6 +27,7 @@ toc: true
 * [melange keygen](/open-source/melange/reference/melange_keygen/)	 - Generate a key for package signing
 * [melange package-version](/open-source/melange/reference/melange_package-version/)	 - Report the target package for a YAML configuration file
 * [melange query](/open-source/melange/reference/melange_query/)	 - Query a Melange YAML file for information
+* [melange sign](/open-source/melange/reference/melange_sign/)	 - Sign an APK package
 * [melange sign-index](/open-source/melange/reference/melange_sign-index/)	 - Sign an APK index
 * [melange update-cache](/open-source/melange/reference/melange_update-cache/)	 - Update a source artifact cache
 * [melange version](/open-source/melange/reference/melange_version/)	 - Prints the version

--- a/docs/md/melange_sign.md
+++ b/docs/md/melange_sign.md
@@ -1,0 +1,42 @@
+---
+title: "melange sign"
+slug: melange_sign
+url: /open-source/melange/reference/melange_sign/
+draft: false
+images: []
+type: "article"
+toc: true
+---
+## melange sign
+
+Sign an APK package
+
+### Synopsis
+
+Signs an APK package on disk with the provided key. The package is replaced with the APK containing the new signature.
+
+```
+melange sign [flags]
+```
+
+### Examples
+
+```
+
+		melange sign [--signing-key=key.rsa] package.apk
+
+		melange sign [--signing-key=key.rsa] *.apk
+		
+```
+
+### Options
+
+```
+  -h, --help                 help for sign
+  -k, --signing-key string   The signing key to use. (default "local-melange.rsa")
+```
+
+### SEE ALSO
+
+* [melange](/open-source/melange/reference/melange/)	 - 
+

--- a/pkg/build/sign.go
+++ b/pkg/build/sign.go
@@ -1,0 +1,109 @@
+package build
+
+import (
+	"archive/tar"
+	"bytes"
+	"context"
+	"crypto/sha1"
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	sign "github.com/chainguard-dev/go-apk/pkg/signature"
+	"github.com/klauspost/compress/gzip"
+	"go.opentelemetry.io/otel"
+)
+
+type ApkSigner interface {
+	Sign(controlData []byte) ([]byte, error)
+
+	SignatureName() string
+}
+
+func EmitSignature(ctx context.Context, signer ApkSigner, controlData []byte) ([]byte, error) {
+	_, span := otel.Tracer("melange").Start(ctx, "EmitSignature")
+	defer span.End()
+
+	sig, err := signer.Sign(controlData)
+	if err != nil {
+		return nil, err
+	}
+
+	var sigbuf bytes.Buffer
+
+	zw := gzip.NewWriter(&sigbuf)
+	tw := tar.NewWriter(zw)
+
+	// The signature tarball only contains a single file
+	if err := tw.WriteHeader(&tar.Header{
+		Name:  signer.SignatureName(),
+		Size:  int64(len(sig)),
+		Mode:  int64(os.ModePerm),
+		Uid:   0,
+		Gid:   0,
+		Uname: "root",
+		Gname: "root",
+	}); err != nil {
+		return nil, err
+	}
+
+	if _, err := tw.Write(sig); err != nil {
+		return nil, err
+	}
+
+	// Don't Close(), we don't want to include the end-of-archive markers since this signature gets prepended to other tarballs
+	if err := tw.Flush(); err != nil {
+		return nil, err
+	}
+
+	if err := zw.Close(); err != nil {
+		return nil, err
+	}
+
+	return sigbuf.Bytes(), nil
+}
+
+// Key base signature (normal) uses a SHA-1 hash on the control digest.
+type KeyApkSigner struct {
+	KeyFile       string
+	KeyPassphrase string
+}
+
+func (s KeyApkSigner) Sign(control []byte) ([]byte, error) {
+	digest := sha1.New()
+
+	_, err := digest.Write(control)
+	if err != nil {
+		return nil, err
+	}
+
+	return sign.RSASignSHA1Digest(digest.Sum(nil), s.KeyFile, s.KeyPassphrase)
+}
+
+func (s KeyApkSigner) SignatureName() string {
+	return fmt.Sprintf(".SIGN.RSA.%s.pub", filepath.Base(s.KeyFile))
+}
+
+// APKv2+Fulcio style signature is an SHA-256 hash on the control
+// digest.
+// TODO(kaniini): Emit fulcio signature if signing key not configured.
+type FulcioApkSigner struct{}
+
+// Sign implements ApkSigner.
+func (*FulcioApkSigner) Sign(control []byte) ([]byte, error) {
+	digest := sha256.New()
+
+	_, err := digest.Write(control)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: Do the signing
+	return nil, fmt.Errorf("APKv2+Fulcio style signature is not yet supported")
+}
+
+// SignatureName implements ApkSigner.
+func (*FulcioApkSigner) SignatureName() string {
+	panic("unimplemented")
+}

--- a/pkg/build/sign_test.go
+++ b/pkg/build/sign_test.go
@@ -1,0 +1,80 @@
+package build_test
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"io"
+	"testing"
+
+	"chainguard.dev/melange/pkg/build"
+)
+
+func TestEmitSignature(t *testing.T) {
+	ctx := context.Background()
+
+	controlData := []byte("donkey")
+
+	signer := &mockSigner{}
+
+	sig, err := build.EmitSignature(ctx, signer, controlData)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	gr, err := gzip.NewReader(bytes.NewReader(sig))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Decompress the sig to first check for end of archive markers
+	dsig, err := io.ReadAll(gr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Check for end of archive markers
+	if bytes.HasSuffix(dsig, make([]byte, 1024)) {
+		t.Fatalf("found end of archive makers in the signature tarball")
+	}
+
+	// Now create the tar reader from the decompressed sig archive for the remainder of the tests
+	tr := tar.NewReader(bytes.NewBuffer(dsig))
+
+	hdr, err := tr.Next()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Should only have a single file in here
+	if hdr.Name != "mockiavelli" {
+		t.Errorf("Unexpected tar header name: got %v want %v", hdr.Name, "mockaveli")
+	}
+
+	want, err := io.ReadAll(tr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !bytes.Equal(controlData, want) {
+		t.Errorf("Unexpected signature contents: got %v want %v", want, controlData)
+	}
+
+	_, err = tr.Next()
+	if err != io.EOF {
+		t.Fatalf("Expected tar EOF")
+	}
+}
+
+type mockSigner struct{}
+
+// Sign implements build.ApkSigner.
+func (*mockSigner) Sign(controlData []byte) ([]byte, error) {
+	return controlData, nil
+}
+
+// SignatureName implements build.ApkSigner.
+func (*mockSigner) SignatureName() string {
+	return "mockiavelli"
+}

--- a/pkg/cli/commands.go
+++ b/pkg/cli/commands.go
@@ -40,6 +40,7 @@ func New() *cobra.Command {
 	cmd.AddCommand(Bump())
 	cmd.AddCommand(Keygen())
 	cmd.AddCommand(Index())
+	cmd.AddCommand(Sign())
 	cmd.AddCommand(SignIndex())
 	cmd.AddCommand(UpdateCache())
 	cmd.AddCommand(Convert())


### PR DESCRIPTION
Adds a `melange sign ...` command to (re-)sign apks with the provided key.

This also slightly refactors the emit signature section of the PackageBuild to reuse the signing method.

The refactor includes:

- handle the control data + signing in memory
- hoist the signing into `build.EmitSignature(...)` to reuse the content digest for the various `ApkSigner` implementations


Sample:

```bash
❯ tar tvf packages/aarch64/kubelet-latest-0-r0.apk
-rwxrwxrwx  0 root   root      512 Dec 31  1969 .SIGN.RSA.local-melange.rsa.pub
-rw-r--r--  0 root   root      333 Aug 16 12:26 .PKGINFO
drwxr-xr-x  0 root   root        0 Aug 16 12:26 usr
drwxr-xr-x  0 root   root        0 Aug 16 12:26 usr/bin
lrwxr-xr-x  0 root   root        0 Aug 16 12:26 usr/bin/kubelet -> kubelet-1.28
drwxr-xr-x  0 root   root        0 Aug 16 12:26 var
drwxr-xr-x  0 root   root        0 Aug 16 12:26 var/lib
drwxr-xr-x  0 root   root        0 Aug 16 12:26 var/lib/db
drwxr-xr-x  0 root   root        0 Aug 16 12:26 var/lib/db/sbom
-rw-r--r--  0 root   root     1188 Aug 16 12:26 var/lib/db/sbom/kubelet-latest-0-r0.spdx.json

➜ melange sign packages/aarch64/*.apk -k something-else.rsa

➜ tar tvf packages/aarch64/kubelet-latest-0-r0.apk
-rwxrwxrwx  0 root   root      512 Dec 31  1969 .SIGN.RSA.something-else.rsa.pub
-rw-r--r--  0 root   root      333 Aug 16 12:26 .PKGINFO
drwxr-xr-x  0 root   root        0 Aug 16 12:26 usr
drwxr-xr-x  0 root   root        0 Aug 16 12:26 usr/bin
lrwxr-xr-x  0 root   root        0 Aug 16 12:26 usr/bin/kubelet -> kubelet-1.28
drwxr-xr-x  0 root   root        0 Aug 16 12:26 var
drwxr-xr-x  0 root   root        0 Aug 16 12:26 var/lib
drwxr-xr-x  0 root   root        0 Aug 16 12:26 var/lib/db
drwxr-xr-x  0 root   root        0 Aug 16 12:26 var/lib/db/sbom
-rw-r--r--  0 root   root     1188 Aug 16 12:26 var/lib/db/sbom/kubelet-latest-0-r0.spdx.json
```