### PR TITLE
support substitutions in provides lists

### DIFF
--- a/examples/replacement-provides.yaml
+++ b/examples/replacement-provides.yaml
@@ -1,0 +1,13 @@
+package:
+  name: replacement-provides
+  version: 0.0.1
+  description: example using a replacement in provides
+  dependencies:
+    provides:
+      - replacement-provides-version=${{package.version}}
+      - replacement-provides-foo=${{vars.foo}}
+      - replacement-provides-bar=${{vars.bar}}
+
+vars:
+  foo: FOO
+  bar: BAR

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -10,7 +10,7 @@ import (
 
 func Test_applySubstitutionsInProvides(t *testing.T) {
 	fp := filepath.Join(os.TempDir(), "melange-test-applySubstitutionsInProvides")
-	os.WriteFile(fp, []byte(`
+	if err := os.WriteFile(fp, []byte(`
 package:
   name: replacement-provides
   version: 0.0.1
@@ -32,7 +32,9 @@ subpackages:
         - subpackage-version=${{package.version}}
         - subpackage-foo=${{vars.foo}}
         - subpackage-bar=${{vars.bar}}
-`), 0644)
+`), 0644); err != nil {
+		t.Fatal(err)
+	}
 	cfg, err := ParseConfiguration(fp)
 	if err != nil {
 		t.Fatalf("failed to parse configuration: %s", err)

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,0 +1,51 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_applySubstitutionsInProvides(t *testing.T) {
+	fp := filepath.Join(os.TempDir(), "melange-test-applySubstitutionsInProvides")
+	os.WriteFile(fp, []byte(`
+package:
+  name: replacement-provides
+  version: 0.0.1
+  description: example using a replacement in provides
+  dependencies:
+    provides:
+      - replacement-provides-version=${{package.version}}
+      - replacement-provides-foo=${{vars.foo}}
+      - replacement-provides-bar=${{vars.bar}}
+
+vars:
+  foo: FOO
+  bar: BAR
+
+subpackages:
+  - name: subpackage
+    dependencies:
+      provides:
+        - subpackage-version=${{package.version}}
+        - subpackage-foo=${{vars.foo}}
+        - subpackage-bar=${{vars.bar}}
+`), 0644)
+	cfg, err := ParseConfiguration(fp)
+	if err != nil {
+		t.Fatalf("failed to parse configuration: %s", err)
+	}
+	require.Equal(t, []string{
+		"replacement-provides-version=0.0.1",
+		"replacement-provides-foo=FOO",
+		"replacement-provides-bar=BAR",
+	}, cfg.Package.Dependencies.Provides)
+
+	require.Equal(t, []string{
+		"subpackage-version=0.0.1",
+		"subpackage-foo=FOO",
+		"subpackage-bar=BAR",
+	}, cfg.Subpackages[0].Dependencies.Provides)
+}

--- a/pkg/config/vars.go
+++ b/pkg/config/vars.go
@@ -27,6 +27,7 @@ const (
 	SubstitutionPackageName          = "${{package.name}}"
 	SubstitutionPackageVersion       = "${{package.version}}"
 	SubstitutionPackageEpoch         = "${{package.epoch}}"
+	SubstitutionPackageDescription   = "${{package.description}}"
 	SubstitutionTargetsDestdir       = "${{targets.destdir}}"
 	SubstitutionSubPkgDir            = "${{targets.subpkgdir}}"
 	SubstitutionHostTripletGnu       = "${{host.triplet.gnu}}"


### PR DESCRIPTION
This enables:

```
package:
  name: go-1.23
  version: 1.23.0
  dependencies:
    provides:
      - go=${{package.version}}
```

Also supported for subpackages, also supporting `vars:`.