### PR TITLE
Add ${{targets.contextdir}}

### DIFF
--- a/pkg/build/pipeline.go
+++ b/pkg/build/pipeline.go
@@ -128,6 +128,16 @@ func substitutionMap(pb *PipelineBuild) (map[string]string, error) {
 		nw[config.SubstitutionTargetsContextdir] = nw[config.SubstitutionSubPkgDir]
 	}
 
+	packageNames := []string{pb.Package.Package.Name}
+	for _, sp := range pb.Build.Configuration.Subpackages {
+		packageNames = append(packageNames, sp.Name)
+	}
+
+	for _, pn := range packageNames {
+		k := fmt.Sprintf("${{targets.package.%s}}", pn)
+		nw[k] = fmt.Sprintf("/home/build/melange-out/%s", pn)
+	}
+
 	for k := range pb.Build.Configuration.Options {
 		nk := fmt.Sprintf("${{options.%s.enabled}}", k)
 		nw[nk] = "false"

--- a/pkg/build/pipeline.go
+++ b/pkg/build/pipeline.go
@@ -99,6 +99,7 @@ func substitutionMap(pb *PipelineBuild) (map[string]string, error) {
 		config.SubstitutionPackageVersion:       pb.Package.Package.Version,
 		config.SubstitutionPackageEpoch:         strconv.FormatUint(pb.Package.Package.Epoch, 10),
 		config.SubstitutionTargetsDestdir:       fmt.Sprintf("/home/build/melange-out/%s", pb.Package.Package.Name),
+		config.SubstitutionTargetsContextdir:    fmt.Sprintf("/home/build/melange-out/%s", pb.Package.Package.Name),
 		config.SubstitutionHostTripletGnu:       pb.Build.BuildTripletGnu(),
 		config.SubstitutionHostTripletRust:      pb.Build.BuildTripletRust(),
 		config.SubstitutionCrossTripletGnuGlibc: pb.Build.Arch.ToTriplet("gnu"),
@@ -124,6 +125,7 @@ func substitutionMap(pb *PipelineBuild) (map[string]string, error) {
 
 	if pb.Subpackage != nil {
 		nw[config.SubstitutionSubPkgDir] = fmt.Sprintf("/home/build/melange-out/%s", pb.Subpackage.Subpackage.Name)
+		nw[config.SubstitutionTargetsContextdir] = nw[config.SubstitutionSubPkgDir]
 	}
 
 	for k := range pb.Build.Configuration.Options {

--- a/pkg/build/pipelines/autoconf/make-install.yaml
+++ b/pkg/build/pipelines/autoconf/make-install.yaml
@@ -12,10 +12,10 @@ needs:
 
 pipeline:
   - runs: |
-      make -C "${{inputs.dir}}" install DESTDIR="${{targets.destdir}}" V=1
+      make -C "${{inputs.dir}}" install DESTDIR="${{targets.contextdir}}" V=1
 
   # Delete all GNU libtool metadata files.  These things are the bane of a
   # packager's existence: they contain useless metadata, cause overlinking and
   # provide no real-world value in a modern UNIX environment.
   - runs: |
-      find ${{targets.destdir}} -name '*.la' -print -exec rm \{} \;
+      find ${{targets.contextdir}} -name '*.la' -print -exec rm \{} \;

--- a/pkg/build/pipelines/cmake/install.yaml
+++ b/pkg/build/pipelines/cmake/install.yaml
@@ -13,4 +13,4 @@ inputs:
 
 pipeline:
   - runs: |
-      DESTDIR="${{targets.destdir}}" cmake --install ${{inputs.output-dir}}
+      DESTDIR="${{targets.contextdir}}" cmake --install ${{inputs.output-dir}}

--- a/pkg/build/pipelines/go/build.yaml
+++ b/pkg/build/pipelines/go/build.yaml
@@ -22,10 +22,10 @@ inputs:
   tags:
     description: |
       A comma-separated list of build tags to pass to the go compiler
-  
+
   output:
     description: |
-      Filename to use when writing the binary. The final install location inside 
+      Filename to use when writing the binary. The final install location inside
       the apk will be in prefix / install-dir / output
     required: true
 
@@ -78,11 +78,6 @@ pipeline:
       fi
 
       BASE_PATH="${{inputs.prefix}}/${{inputs.install-dir}}/${{inputs.output}}"
-      if [ "${{inputs.subpackage}}" == "true" ]; then
-        DEST_PATH="-o ${{targets.subpkgdir}}/${BASE_PATH}"
-      else
-        DEST_PATH="-o ${{targets.destdir}}/${BASE_PATH}"
-      fi
 
       cd "${{inputs.modroot}}"
 
@@ -95,4 +90,4 @@ pipeline:
         # If vendor is specified, update the vendor directory
         "${{inputs.vendor}}" && go mod vendor
       fi
-      go build ${DEST_PATH} -tags "${TAGS}" -ldflags "${LDFLAGS}" -trimpath ${{inputs.packages}}
+      go build -o "${{targets.contextdir}}"/${BASE_PATH} -tags "${TAGS}" -ldflags "${LDFLAGS}" -trimpath ${{inputs.packages}}

--- a/pkg/build/pipelines/go/install.yaml
+++ b/pkg/build/pipelines/go/install.yaml
@@ -15,12 +15,12 @@ inputs:
 
   package:
     description: |
-      Import path to the package 
+      Import path to the package
     required: true
 
-  version: 
+  version:
     description: |
-      Package version to install. This can be a version tag (v1.0.0), a 
+      Package version to install. This can be a version tag (v1.0.0), a
       commit hash or another ref (eg latest or HEAD).
 
   prefix:
@@ -64,11 +64,11 @@ pipeline:
 
       # Run go install
       go install ${DEST_PATH} -tags "${TAGS}" -ldflags "${LDFLAGS}" ${{inputs.package}}${VERSION}
-      mkdir -p ${{targets.destdir}}/${{inputs.prefix}}/${{inputs.install-dir}}
+      mkdir -p ${{targets.contextdir}}/${{inputs.prefix}}/${{inputs.install-dir}}
 
       # Move all resulting files to the target dir
       echo "go/install: Installing built binaries"
       for f in $(ls ${GOBIN})
       do
-        mv -v ${GOBIN}/${f} ${{targets.destdir}}/${{inputs.prefix}}/${{inputs.install-dir}}/${f}
+        mv -v ${GOBIN}/${f} ${{targets.contextdir}}/${{inputs.prefix}}/${{inputs.install-dir}}/${f}
       done

--- a/pkg/build/pipelines/meson/install.yaml
+++ b/pkg/build/pipelines/meson/install.yaml
@@ -12,4 +12,4 @@ inputs:
 
 pipeline:
   - runs: |
-      DESTDIR="${{targets.destdir}}" meson install -C ${{inputs.output-dir}}
+      DESTDIR="${{targets.contextdir}}" meson install -C ${{inputs.output-dir}}

--- a/pkg/build/pipelines/ruby/install.yaml
+++ b/pkg/build/pipelines/ruby/install.yaml
@@ -51,8 +51,8 @@ pipeline:
       [ -n '${{inputs.gem-file}}' ] && GEM=${{inputs.gem-file}}
       [ -n '${{inputs.gem}}' ] && GEM=${{inputs.gem}}-${{inputs.version}}.gem
 
-      TARGET_DIR_BIN="${{targets.destdir}}/usr/bin"
-      TARGET_DIR_INSTALL="${{targets.destdir}}$(ruby -e 'puts Gem.default_dir')/"
+      TARGET_DIR_BIN="${{targets.contextdir}}/usr/bin"
+      TARGET_DIR_INSTALL="${{targets.contextdir}}$(ruby -e 'puts Gem.default_dir')/"
 
       mkdir -p "${TARGET_DIR_BIN}"
       mkdir -p "${TARGET_DIR_INSTALL}"

--- a/pkg/build/pipelines/split/debug.yaml
+++ b/pkg/build/pipelines/split/debug.yaml
@@ -6,14 +6,15 @@ needs:
     - scanelf
 
 pipeline:
-  - runs: |
+  - if: ${{targets.destdir}} != ${{targets.contextdir}}
+    runs: |
       mkdir -p "${{targets.destdir}}/.dbg-tmp"
       # note: the ${{targets.subpkgdir}} doesn't exist when the glob is evaluated
       scanelf -Ry "${{targets.destdir}}"/* | while read type src; do
         if [ "$type" != ET_DYN ]; then
           continue
         fi
-        dst=${{targets.subpkgdir}}/usr/lib/debug/${src#"${{targets.destdir}}"/*/}.debug
+        dst=${{targets.contextdir}}/usr/lib/debug/${src#"${{targets.destdir}}"/*/}.debug
         mkdir -p "${dst%/*}"
         ino=$(stat -c %i "$src")
         if ! [ -e "${{targets.destdir}}/.dbg-tmp/$ino" ]; then

--- a/pkg/build/pipelines/split/dev.yaml
+++ b/pkg/build/pipelines/split/dev.yaml
@@ -1,7 +1,8 @@
 name: Split development files
 
 pipeline:
-  - runs: |
+  - if: ${{targets.destdir}} != ${{targets.contextdir}}
+    runs: |
       i= j=
       cd "${{targets.destdir}}" || exit 0
 
@@ -18,7 +19,7 @@ pipeline:
         $(find $libdirs -name '*.[cho]' \
           -o -name '*.prl' 2>/dev/null); do
             if [ -e "${{targets.destdir}}/$i" ] || [ -L "${{targets.destdir}}/$i" ]; then
-              d="${{targets.subpkgdir}}/${i%/*}" # dirname $i
+              d="${{targets.contextdir}}/${i%/*}" # dirname $i
               mkdir -p "$d"
               mv "${{targets.destdir}}/$i" "$d"
               rmdir "${{targets.destdir}}/${i%/*}" 2>/dev/null || :
@@ -28,7 +29,7 @@ pipeline:
         # move *.so links needed when linking the apps to -dev packages
         for i in lib/*.so usr/lib/*.so; do
           if [ -L "$i" ]; then
-            mkdir -p "${{targets.subpkgdir}}"/"${i%/*}"
-            mv "$i" "${{targets.subpkgdir}}/$i" || return 1
+            mkdir -p "${{targets.contextdir}}"/"${i%/*}"
+            mv "$i" "${{targets.contextdir}}/$i" || return 1
           fi
         done

--- a/pkg/build/pipelines/split/infodir.yaml
+++ b/pkg/build/pipelines/split/infodir.yaml
@@ -1,10 +1,11 @@
 name: Split GNU info pages
 
 pipeline:
-  - runs: |
+  - if: ${{targets.destdir}} != ${{targets.contextdir}}
+    runs: |
       if [ -d "${{targets.destdir}}/usr/share/info" ]; then
         rm -f "${{targets.destdir}}"/usr/share/info/dir
 
-        mkdir -p "${{targets.subpkgdir}}/usr/share"
-        mv "${{targets.destdir}}"/usr/share/info "${{targets.subpkgdir}}/usr/share"
+        mkdir -p "${{targets.contextdir}}/usr/share"
+        mv "${{targets.destdir}}"/usr/share/info "${{targets.contextdir}}/usr/share"
       fi

--- a/pkg/build/pipelines/split/locales.yaml
+++ b/pkg/build/pipelines/split/locales.yaml
@@ -1,6 +1,9 @@
 name: Split locales
 
 pipeline:
-  - runs: |
-      mkdir -p "${{targets.subpkgdir}}"/usr/share
-      mv "${{targets.destdir}}"/usr/share/locale "${{targets.subpkgdir}}"/usr/share/locale
+  - if: ${{targets.destdir}} != ${{targets.contextdir}}
+    runs: |
+      if [ -d "${{targets.destdir}}"/usr/share/locale ]; then
+        mkdir -p "${{targets.contextdir}}"/usr/share
+        mv "${{targets.destdir}}"/usr/share/locale "${{targets.contextdir}}"/usr/share/locale
+      fi

--- a/pkg/build/pipelines/split/manpages.yaml
+++ b/pkg/build/pipelines/split/manpages.yaml
@@ -1,8 +1,9 @@
 name: Split manpages
 
 pipeline:
-  - runs: |
+  - if: ${{targets.destdir}} != ${{targets.contextdir}}
+    runs: |
       if [ -d "${{targets.destdir}}/usr/share/man" ]; then
-        mkdir -p "${{targets.subpkgdir}}/usr/share"
-        mv "${{targets.destdir}}/usr/share/man" "${{targets.subpkgdir}}/usr/share"
+        mkdir -p "${{targets.contextdir}}/usr/share"
+        mv "${{targets.destdir}}/usr/share/man" "${{targets.contextdir}}/usr/share"
       fi

--- a/pkg/build/pipelines/split/static.yaml
+++ b/pkg/build/pipelines/split/static.yaml
@@ -1,7 +1,8 @@
 name: Split static library files
 
 pipeline:
-  - runs: |
+  - if: ${{targets.destdir}} != ${{targets.contextdir}}
+    runs: |
       i= j=
       cd "${{targets.destdir}}" || exit 0
 
@@ -10,7 +11,7 @@ pipeline:
       for i in \
         $(find $libdirs -name '*.a' 2>/dev/null); do
             if [ -e "${{targets.destdir}}/$i" ] || [ -L "${{targets.destdir}}/$i" ]; then
-              d="${{targets.subpkgdir}}/${i%/*}" # dirname $i
+              d="${{targets.contextdir}}/${i%/*}" # dirname $i
               mkdir -p "$d"
               mv "${{targets.destdir}}/$i" "$d"
               rmdir "${{targets.destdir}}/${i%/*}" 2>/dev/null || :

--- a/pkg/build/pipelines/strip.yaml
+++ b/pkg/build/pipelines/strip.yaml
@@ -6,8 +6,8 @@ needs:
     - scanelf
 
 pipeline:
-  - runs: |
-      cd "${{targets.destdir}}"
+  - working-directory: ${{targets.contextdir}}
+    runs: |
       scanelf --recursive --nobanner --osabi --etype "ET_DYN,ET_EXEC" . \
         | while read type osabi filename; do
 

--- a/pkg/config/vars.go
+++ b/pkg/config/vars.go
@@ -29,6 +29,7 @@ const (
 	SubstitutionPackageEpoch         = "${{package.epoch}}"
 	SubstitutionPackageDescription   = "${{package.description}}"
 	SubstitutionTargetsDestdir       = "${{targets.destdir}}"
+	SubstitutionTargetsContextdir    = "${{targets.contextdir}}"
 	SubstitutionSubPkgDir            = "${{targets.subpkgdir}}"
 	SubstitutionHostTripletGnu       = "${{host.triplet.gnu}}"
 	SubstitutionHostTripletRust      = "${{host.triplet.rust}}"


### PR DESCRIPTION
Adds `${{targets.contextdir}}` variable expansion which maps to the current package output context directory.  This is intended to be used as a destination target instead of `${{targets.destdir}}` and `${{targets.subpkgdir}}`, allowing pipelines to be more reusable in subpackages, without hacks like `${{inputs.subpackage}}`.