### PR TITLE
Fix the links to commands, fix the URLs generated.

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -25,7 +25,7 @@ jobs:
           version: v1.53
           args: --timeout=5m
 
-      - run: make docs
+      - run: make docs-repo
 
       - run: |
           go mod tidy

--- a/Makefile
+++ b/Makefile
@@ -167,11 +167,20 @@ sign-image: ko ## Sign images built using ko
 	./hack/sign-images.sh
 
 ##################
-# docs
+# docs - This appears to create the docs for the Chainguard Academy site, so
+# left as is.
 ##################
 .PHONY: docs
 docs:
 	go run docs/main.go --out docs/md
+
+##################
+# docs - This creates documents where the links are self-referential to this
+# repo.
+##################
+.PHONY: docs-repo
+docs-repo:
+	go run docs/main.go --baseurl /docs/md/ --suffix .md --out docs/md
 
 ##################
 # help

--- a/docs/main.go
+++ b/docs/main.go
@@ -43,20 +43,22 @@ func main() {
 
 	var pathout string
 	var baseURL string
+	var suffix string
 	flag.StringVar(&pathout, "out", "./md", "Path to the output directory.")
 	flag.StringVar(&baseURL, "baseurl", "/open-source/melange/reference/", "Base URL for melange-docs on Academy site.")
+	flag.StringVar(&suffix, "suffix", "/", "Suffix for the MD files.")
 	flag.Parse()
 
 	filePrepender := func(filename string) string {
 		name := filepath.Base(filename)
 		base := strings.Split(strings.TrimSuffix(name, path.Ext(name)), "/")[:1][0]
-		url := baseURL + strings.ToLower(base) + "/"
+		url := baseURL + strings.ToLower(base) + suffix
 		return fmt.Sprintf(fmTemplate, strings.ReplaceAll(base, "_", " "), base, url)
 	}
 
 	linkHandler := func(name string) string {
 		base := strings.TrimSuffix(name, path.Ext(name))
-		return baseURL + strings.ToLower(base) + "/"
+		return baseURL + strings.ToLower(base) + suffix
 	}
 
 	if err := os.MkdirAll(pathout, os.ModePerm); err != nil && !os.IsExist(err) {

--- a/docs/md/melange.md
+++ b/docs/md/melange.md
@@ -1,7 +1,7 @@
 ---
 title: "melange"
 slug: melange
-url: /open-source/melange/reference/melange/
+url: /docs/md/melange.md
 draft: false
 images: []
 type: "article"
@@ -19,16 +19,16 @@ toc: true
 
 ### SEE ALSO
 
-* [melange build](/open-source/melange/reference/melange_build/)	 - Build a package from a YAML configuration file
-* [melange bump](/open-source/melange/reference/melange_bump/)	 - Update a Melange YAML file to reflect a new package version
-* [melange completion](/open-source/melange/reference/melange_completion/)	 - Generate completion script
-* [melange convert](/open-source/melange/reference/melange_convert/)	 - EXPERIMENTAL COMMAND - Attempts to convert packages/gems/apkbuild files into melange configuration files
-* [melange index](/open-source/melange/reference/melange_index/)	 - Creates a repository index from a list of package files
-* [melange keygen](/open-source/melange/reference/melange_keygen/)	 - Generate a key for package signing
-* [melange package-version](/open-source/melange/reference/melange_package-version/)	 - Report the target package for a YAML configuration file
-* [melange query](/open-source/melange/reference/melange_query/)	 - Query a Melange YAML file for information
-* [melange sign](/open-source/melange/reference/melange_sign/)	 - Sign an APK package
-* [melange sign-index](/open-source/melange/reference/melange_sign-index/)	 - Sign an APK index
-* [melange update-cache](/open-source/melange/reference/melange_update-cache/)	 - Update a source artifact cache
-* [melange version](/open-source/melange/reference/melange_version/)	 - Prints the version
+* [melange build](/docs/md/melange_build.md)	 - Build a package from a YAML configuration file
+* [melange bump](/docs/md/melange_bump.md)	 - Update a Melange YAML file to reflect a new package version
+* [melange completion](/docs/md/melange_completion.md)	 - Generate completion script
+* [melange convert](/docs/md/melange_convert.md)	 - EXPERIMENTAL COMMAND - Attempts to convert packages/gems/apkbuild files into melange configuration files
+* [melange index](/docs/md/melange_index.md)	 - Creates a repository index from a list of package files
+* [melange keygen](/docs/md/melange_keygen.md)	 - Generate a key for package signing
+* [melange package-version](/docs/md/melange_package-version.md)	 - Report the target package for a YAML configuration file
+* [melange query](/docs/md/melange_query.md)	 - Query a Melange YAML file for information
+* [melange sign](/docs/md/melange_sign.md)	 - Sign an APK package
+* [melange sign-index](/docs/md/melange_sign-index.md)	 - Sign an APK index
+* [melange update-cache](/docs/md/melange_update-cache.md)	 - Update a source artifact cache
+* [melange version](/docs/md/melange_version.md)	 - Prints the version
 

--- a/docs/md/melange_build.md
+++ b/docs/md/melange_build.md
@@ -1,7 +1,7 @@
 ---
 title: "melange build"
 slug: melange_build
-url: /open-source/melange/reference/melange_build/
+url: /docs/md/melange_build.md
 draft: false
 images: []
 type: "article"
@@ -52,7 +52,7 @@ melange build [flags]
       --overlay-binsh string        use specified file as /bin/sh overlay in build environment
       --pipeline-dir string         directory used to extend defined built-in pipelines
   -r, --repository-append strings   path to extra repositories to include in the build environment
-      --runner string               which runner to use to enable running commands, default is based on your platform. Options are ["bubblewrap" "docker" "lima" "kubernetes"] (default "bubblewrap")
+      --runner string               which runner to use to enable running commands, default is based on your platform. Options are ["bubblewrap" "docker" "lima" "kubernetes"] (default "docker")
       --signing-key string          key to use for signing
       --source-dir string           directory used for included sources
       --strip-origin-name           whether origin names should be stripped (for bootstrap)
@@ -62,5 +62,5 @@ melange build [flags]
 
 ### SEE ALSO
 
-* [melange](/open-source/melange/reference/melange/)	 - 
+* [melange](/docs/md/melange.md)	 - 
 

--- a/docs/md/melange_build.md
+++ b/docs/md/melange_build.md
@@ -52,7 +52,7 @@ melange build [flags]
       --overlay-binsh string        use specified file as /bin/sh overlay in build environment
       --pipeline-dir string         directory used to extend defined built-in pipelines
   -r, --repository-append strings   path to extra repositories to include in the build environment
-      --runner string               which runner to use to enable running commands, default is based on your platform. Options are ["bubblewrap" "docker" "lima" "kubernetes"] (default "docker")
+      --runner string               which runner to use to enable running commands, default is based on your platform. Options are ["bubblewrap" "docker" "lima" "kubernetes"] (default "bubblewrap")
       --signing-key string          key to use for signing
       --source-dir string           directory used for included sources
       --strip-origin-name           whether origin names should be stripped (for bootstrap)

--- a/docs/md/melange_bump.md
+++ b/docs/md/melange_bump.md
@@ -1,7 +1,7 @@
 ---
 title: "melange bump"
 slug: melange_bump
-url: /open-source/melange/reference/melange_bump/
+url: /docs/md/melange_bump.md
 draft: false
 images: []
 type: "article"
@@ -34,5 +34,5 @@ melange bump [flags]
 
 ### SEE ALSO
 
-* [melange](/open-source/melange/reference/melange/)	 - 
+* [melange](/docs/md/melange.md)	 - 
 

--- a/docs/md/melange_completion.md
+++ b/docs/md/melange_completion.md
@@ -1,7 +1,7 @@
 ---
 title: "melange completion"
 slug: melange_completion
-url: /open-source/melange/reference/melange_completion/
+url: /docs/md/melange_completion.md
 draft: false
 images: []
 type: "article"
@@ -56,5 +56,5 @@ melange completion [bash|zsh|fish|powershell]
 
 ### SEE ALSO
 
-* [melange](/open-source/melange/reference/melange/)	 - 
+* [melange](/docs/md/melange.md)	 - 
 

--- a/docs/md/melange_convert.md
+++ b/docs/md/melange_convert.md
@@ -1,7 +1,7 @@
 ---
 title: "melange convert"
 slug: melange_convert
-url: /open-source/melange/reference/melange_convert/
+url: /docs/md/melange_convert.md
 draft: false
 images: []
 type: "article"
@@ -26,8 +26,8 @@ Convert is an EXPERIMENTAL COMMAND - Attempts to convert packages/gems/apkbuild 
 
 ### SEE ALSO
 
-* [melange](/open-source/melange/reference/melange/)	 - 
-* [melange convert apkbuild](/open-source/melange/reference/melange_convert_apkbuild/)	 - Converts an APKBUILD package into a melange.yaml
-* [melange convert gem](/open-source/melange/reference/melange_convert_gem/)	 - Converts an gem into a melange.yaml
-* [melange convert python](/open-source/melange/reference/melange_convert_python/)	 - Converts a python package into a melange.yaml
+* [melange](/docs/md/melange.md)	 - 
+* [melange convert apkbuild](/docs/md/melange_convert_apkbuild.md)	 - Converts an APKBUILD package into a melange.yaml
+* [melange convert gem](/docs/md/melange_convert_gem.md)	 - Converts an gem into a melange.yaml
+* [melange convert python](/docs/md/melange_convert_python.md)	 - Converts a python package into a melange.yaml
 

--- a/docs/md/melange_convert_apkbuild.md
+++ b/docs/md/melange_convert_apkbuild.md
@@ -1,7 +1,7 @@
 ---
 title: "melange convert apkbuild"
 slug: melange_convert_apkbuild
-url: /open-source/melange/reference/melange_convert_apkbuild/
+url: /docs/md/melange_convert_apkbuild.md
 draft: false
 images: []
 type: "article"
@@ -38,5 +38,5 @@ melange convert apkbuild [flags]
 
 ### SEE ALSO
 
-* [melange convert](/open-source/melange/reference/melange_convert/)	 - EXPERIMENTAL COMMAND - Attempts to convert packages/gems/apkbuild files into melange configuration files
+* [melange convert](/docs/md/melange_convert.md)	 - EXPERIMENTAL COMMAND - Attempts to convert packages/gems/apkbuild files into melange configuration files
 

--- a/docs/md/melange_convert_gem.md
+++ b/docs/md/melange_convert_gem.md
@@ -1,7 +1,7 @@
 ---
 title: "melange convert gem"
 slug: melange_convert_gem
-url: /open-source/melange/reference/melange_convert_gem/
+url: /docs/md/melange_convert_gem.md
 draft: false
 images: []
 type: "article"
@@ -40,5 +40,5 @@ convert gem fluentd
 
 ### SEE ALSO
 
-* [melange convert](/open-source/melange/reference/melange_convert/)	 - EXPERIMENTAL COMMAND - Attempts to convert packages/gems/apkbuild files into melange configuration files
+* [melange convert](/docs/md/melange_convert.md)	 - EXPERIMENTAL COMMAND - Attempts to convert packages/gems/apkbuild files into melange configuration files
 

--- a/docs/md/melange_convert_python.md
+++ b/docs/md/melange_convert_python.md
@@ -1,7 +1,7 @@
 ---
 title: "melange convert python"
 slug: melange_convert_python
-url: /open-source/melange/reference/melange_convert_python/
+url: /docs/md/melange_convert_python.md
 draft: false
 images: []
 type: "article"
@@ -41,5 +41,5 @@ convert python botocore
 
 ### SEE ALSO
 
-* [melange convert](/open-source/melange/reference/melange_convert/)	 - EXPERIMENTAL COMMAND - Attempts to convert packages/gems/apkbuild files into melange configuration files
+* [melange convert](/docs/md/melange_convert.md)	 - EXPERIMENTAL COMMAND - Attempts to convert packages/gems/apkbuild files into melange configuration files
 

--- a/docs/md/melange_index.md
+++ b/docs/md/melange_index.md
@@ -1,7 +1,7 @@
 ---
 title: "melange index"
 slug: melange_index
-url: /open-source/melange/reference/melange_index/
+url: /docs/md/melange_index.md
 draft: false
 images: []
 type: "article"
@@ -35,5 +35,5 @@ melange index [flags]
 
 ### SEE ALSO
 
-* [melange](/open-source/melange/reference/melange/)	 - 
+* [melange](/docs/md/melange.md)	 - 
 

--- a/docs/md/melange_keygen.md
+++ b/docs/md/melange_keygen.md
@@ -1,7 +1,7 @@
 ---
 title: "melange keygen"
 slug: melange_keygen
-url: /open-source/melange/reference/melange_keygen/
+url: /docs/md/melange_keygen.md
 draft: false
 images: []
 type: "article"
@@ -34,5 +34,5 @@ melange keygen [flags]
 
 ### SEE ALSO
 
-* [melange](/open-source/melange/reference/melange/)	 - 
+* [melange](/docs/md/melange.md)	 - 
 

--- a/docs/md/melange_package-version.md
+++ b/docs/md/melange_package-version.md
@@ -1,0 +1,41 @@
+---
+title: "melange package-version"
+slug: melange_package-version
+url: /docs/md/melange_package-version.md
+draft: false
+images: []
+type: "article"
+toc: true
+---
+## melange package-version
+
+Report the target package for a YAML configuration file
+
+### Synopsis
+
+Report the target package for a YAML configuration file.
+		Equivalent to running:
+		
+			melange query config.yaml '{{ .Package.Name }}-{{ .Package.Version }}-r{{ .Package.Epoch }}'
+		
+
+```
+melange package-version [flags]
+```
+
+### Examples
+
+```
+  melange package-version [config.yaml]
+```
+
+### Options
+
+```
+  -h, --help   help for package-version
+```
+
+### SEE ALSO
+
+* [melange](/docs/md/melange.md)	 - 
+

--- a/docs/md/melange_query.md
+++ b/docs/md/melange_query.md
@@ -1,0 +1,38 @@
+---
+title: "melange query"
+slug: melange_query
+url: /docs/md/melange_query.md
+draft: false
+images: []
+type: "article"
+toc: true
+---
+## melange query
+
+Query a Melange YAML file for information
+
+### Synopsis
+
+Query a Melange YAML file for information.
+		Uses templates with go templates syntax to query the YAML file.
+
+```
+melange query [flags]
+```
+
+### Examples
+
+```
+  melange query config.yaml "{{ .Package.Name }}-{{ .Package.Version }}-{{ .Package.Epoch }}"
+```
+
+### Options
+
+```
+  -h, --help   help for query
+```
+
+### SEE ALSO
+
+* [melange](/docs/md/melange.md)	 - 
+

--- a/docs/md/melange_sign-index.md
+++ b/docs/md/melange_sign-index.md
@@ -1,7 +1,7 @@
 ---
 title: "melange sign-index"
 slug: melange_sign-index
-url: /open-source/melange/reference/melange_sign-index/
+url: /docs/md/melange_sign-index.md
 draft: false
 images: []
 type: "article"
@@ -41,5 +41,5 @@ melange sign-index [flags]
 
 ### SEE ALSO
 
-* [melange](/open-source/melange/reference/melange/)	 - 
+* [melange](/docs/md/melange.md)	 - 
 

--- a/docs/md/melange_sign.md
+++ b/docs/md/melange_sign.md
@@ -1,7 +1,7 @@
 ---
 title: "melange sign"
 slug: melange_sign
-url: /open-source/melange/reference/melange_sign/
+url: /docs/md/melange_sign.md
 draft: false
 images: []
 type: "article"
@@ -38,5 +38,5 @@ melange sign [flags]
 
 ### SEE ALSO
 
-* [melange](/open-source/melange/reference/melange/)	 - 
+* [melange](/docs/md/melange.md)	 - 
 

--- a/docs/md/melange_update-cache.md
+++ b/docs/md/melange_update-cache.md
@@ -1,7 +1,7 @@
 ---
 title: "melange update-cache"
 slug: melange_update-cache
-url: /open-source/melange/reference/melange_update-cache/
+url: /docs/md/melange_update-cache.md
 draft: false
 images: []
 type: "article"
@@ -34,5 +34,5 @@ melange update-cache [flags]
 
 ### SEE ALSO
 
-* [melange](/open-source/melange/reference/melange/)	 - 
+* [melange](/docs/md/melange.md)	 - 
 

--- a/docs/md/melange_version.md
+++ b/docs/md/melange_version.md
@@ -1,7 +1,7 @@
 ---
 title: "melange version"
 slug: melange_version
-url: /open-source/melange/reference/melange_version/
+url: /docs/md/melange_version.md
 draft: false
 images: []
 type: "article"
@@ -24,5 +24,5 @@ melange version [flags]
 
 ### SEE ALSO
 
-* [melange](/open-source/melange/reference/melange/)	 - 
+* [melange](/docs/md/melange.md)	 - 
 


### PR DESCRIPTION
Fixes #623 

Since it would seem that the existing behavior creates something elsewhere, added a new Makefile target that produces correct links within the repo, and to control that needed to add a --suffix flag (previously, it hardcoded '/').

Also add two previously missed files:
`query`, and `package-version`.