### PR TITLE
add --force option to recreate apk indexes with given signatures

### DIFF
--- a/docs/md/melange_sign-index.md
+++ b/docs/md/melange_sign-index.md
@@ -22,12 +22,19 @@ melange sign-index [flags]
 ### Examples
 
 ```
-  melange sign-index [--signing-key=key.rsa] <APKINDEX.tar.gz>
+
+    # Re-sign an index with the same signature
+    melange sign-index [--signing-key=key.rsa] <APKINDEX.tar.gz>
+
+    # Sign a new index with a new signature
+    melange sign-index [--signing-key=key.rsa] <APKINDEX.tar.gz> --force
+    
 ```
 
 ### Options
 
 ```
+  -f, --force                when toggled, overwrites the specified index with a new index using the provided signature
   -h, --help                 help for sign-index
       --signing-key string   the signing key to use (default "melange.rsa")
 ```


### PR DESCRIPTION
adds an opt in `--force` to `melange sign-index` that when provided, will create a new apk index with the provided key file, regardless of any existing signatures.

```bash
➜ curl -sfL https://packages.wolfi.dev/os/aarch64/APKINDEX.tar.gz -o idx
                                                                                                                                                                                                                                                                                                           
➜ tar tvf idx
-rw-r--r--  0 root   root      512 Dec 31  1969 .SIGN.RSA.wolfi-signing.rsa.pub
-rw-r--r--  0 0      0     3822057 Dec 31  1969 APKINDEX
-rw-r--r--  0 0      0           0 Dec 31  1969 DESCRIPTION
                                                                                                                                                                                                                                                                                                           
➜ melange sign-index --signing-key something-else.rsa idx -f
ℹ            | signing index /var/folders/5v/6gvb9x954sbd9tmqq14cwgrh0000gn/T/melange-sign-index2134875588 with key something-else.rsa
ℹ            | appending signature to index /var/folders/5v/6gvb9x954sbd9tmqq14cwgrh0000gn/T/melange-sign-index2134875588
ℹ            | writing signed index to /var/folders/5v/6gvb9x954sbd9tmqq14cwgrh0000gn/T/melange-sign-index2134875588
ℹ            | signed index /var/folders/5v/6gvb9x954sbd9tmqq14cwgrh0000gn/T/melange-sign-index2134875588 with key something-else.rsa
ℹ            | Replacing existing signed index (idx) with signed index with key something-else.rsa
                                                                                                                                                                                                                                                                                                           
➜ tar tvf idx
-rw-r--r--  0 root   root      512 Dec 31  1969 .SIGN.RSA.something-else.rsa.pub
-rw-r--r--  0 0      0     3822057 Dec 31  1969 APKINDEX
-rw-r--r--  0 0      0           0 Dec 31  1969 DESCRIPTION
```
