### PR TITLE
sign: do not rename across device boundaries

### DIFF
--- a/pkg/cli/sign.go
+++ b/pkg/cli/sign.go
@@ -76,7 +76,7 @@ func (o signIndexOpts) SignIndex(ctx context.Context, indexFile string) error {
 		return err
 	}
 
-	t, err := os.CreateTemp("", "melange-sign-index")
+	t, err := os.Create(fmt.Sprintf("%s.new", indexFile))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Previously, we used os.CreateTemp to create the new index in /tmp, but renaming from tmpfs to on-disk storage cannot work due to being on different filesystems.