### PR TITLE
Print the path to generated melange config.

### DIFF
--- a/pkg/convert/apkbuild/apkbuild.go
+++ b/pkg/convert/apkbuild/apkbuild.go
@@ -147,6 +147,7 @@ func (c Context) getApkBuildFile(ctx context.Context, apkbuildURL, packageName s
 	c.ApkConvertors[packageName] = ApkConvertor{
 		Apkbuild: &parsedApkBuild,
 		GeneratedMelangeConfig: &manifest.GeneratedMelangeConfig{
+			Logger:               c.Logger,
 			GeneratedFromComment: apkbuildURL,
 			Package: config.Package{
 				Epoch: 0,

--- a/pkg/convert/gem/gem.go
+++ b/pkg/convert/gem/gem.go
@@ -238,7 +238,7 @@ func (c *GemContext) getGemMeta(ctx context.Context, gemURI string) (GemMeta, er
 // can continue and discrepancies can be handled later.
 func (c *GemContext) generateManifest(ctx context.Context, g GemMeta) (manifest.GeneratedMelangeConfig, error) {
 	// The actual generated manifest struct
-	generated := manifest.GeneratedMelangeConfig{}
+	generated := manifest.GeneratedMelangeConfig{Logger: c.Logger}
 
 	// Generate each field in the manifest
 	generated.GeneratedFromComment = g.RepoURI

--- a/pkg/convert/python/python.go
+++ b/pkg/convert/python/python.go
@@ -204,7 +204,7 @@ func (c *PythonContext) findDep(ctx context.Context) error {
 
 func (c *PythonContext) generateManifest(ctx context.Context, pack Package, version string) (manifest.GeneratedMelangeConfig, error) {
 	// The actual generated manifest struct
-	generated := manifest.GeneratedMelangeConfig{}
+	generated := manifest.GeneratedMelangeConfig{Logger: c.Logger}
 
 	// Generate each field in the manifest
 	generated.GeneratedFromComment = pack.Info.ProjectUrl

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -2,6 +2,7 @@ package manifest
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 
@@ -19,6 +20,7 @@ type GeneratedMelangeConfig struct {
 	Subpackages          []config.Subpackage          `yaml:"subpackages,omitempty"`
 	Vars                 map[string]string            `yaml:"vars,omitempty"`
 	GeneratedFromComment string                       `yaml:"-"`
+	Logger               *log.Logger                  `yaml:"-"`
 }
 
 func (m *GeneratedMelangeConfig) SetPackage(pkg config.Package) {
@@ -68,5 +70,8 @@ func (m *GeneratedMelangeConfig) Write(dir string) error {
 		return errors.Wrapf(err, "creating writing to file %s", manifestPath)
 	}
 
+	if m.Logger != nil {
+		m.Logger.Printf("Generated melange config: %s", manifestPath)
+	}
 	return nil
 }


### PR DESCRIPTION
I missed the fact that the file was generated in ./generated and because of a .gitignore in wolfi-os repo, it seemed to my untrained eye like nothing was created and I didn't see anything in the logs printed, so figured this might save somebody else a little bit of time/troubleshooting.

Example output 
```
vaikas@vaikas-MBP os % melange convert python pycparser
2023/08/29 14:21:32 convert:python: generating convert config files for python package pycparser version: 3.11 on python version:
2023/08/29 14:21:32 convert:python: [pycparser] Generating manifests
<SNIP SNIP SNIP>
2023/08/29 14:21:33 convert:python: [pycparser] Generate Pipeline for version 2.21
2023/08/29 14:21:33 convert:python: Generated melange config: generated/py3.11-pycparser.yaml
```
