### PR TITLE
Add --wolfi-defaults flag, clean up flag handling.

### DIFF
--- a/docs/md/melange_convert.md
+++ b/docs/md/melange_convert.md
@@ -15,13 +15,17 @@ EXPERIMENTAL COMMAND - Attempts to convert packages/gems/apkbuild files into mel
 
 Convert is an EXPERIMENTAL COMMAND - Attempts to convert packages/gems/apkbuild files into melange configuration files
 								Check that the build executes and builds the apk as expected, using the wolfi-dev/sdk to test the install of built apk
-								Dependencies are recursively generated and a lot of assumptions are made for you, there be dragons here. 
+								Dependencies are recursively generated and a lot of assumptions are made for you, there be dragons here.
 							
 
 ### Options
 
 ```
-  -h, --help   help for convert
+      --additional-keyrings stringArray       additional repositories to be added to convert environment config
+      --additional-repositories stringArray   additional repositories to be added to convert environment config
+  -h, --help                                  help for convert
+  -o, --out-dir string                        directory where convert config will be output (default "./generated")
+      --wolfi-defaults                        if true, adds wolfi repo, and keyring to config (default true)
 ```
 
 ### SEE ALSO

--- a/docs/md/melange_convert_apkbuild.md
+++ b/docs/md/melange_convert_apkbuild.md
@@ -28,12 +28,18 @@ melange convert apkbuild [flags]
 ### Options
 
 ```
+      --base-uri-format string         URI to use for querying APKBUILD for provided package name (default "https://git.alpinelinux.org/aports/plain/main/%s/APKBUILD")
+      --exclude-packages stringArray   packages to exclude from auto generation of melange configs when detected in APKBUILD files
+  -h, --help                           help for apkbuild
+```
+
+### Options inherited from parent commands
+
+```
       --additional-keyrings stringArray       additional repositories to be added to convert environment config
       --additional-repositories stringArray   additional repositories to be added to convert environment config
-      --base-uri-format string                URI to use for querying APKBUILD for provided package name (default "https://git.alpinelinux.org/aports/plain/main/%s/APKBUILD")
-      --exclude-packages stringArray          packages to exclude from auto generation of melange configs when detected in APKBUILD files
-  -h, --help                                  help for apkbuild
-      --out-dir string                        directory where convert config will be output (default "./generated")
+  -o, --out-dir string                        directory where convert config will be output (default "./generated")
+      --wolfi-defaults                        if true, adds wolfi repo, and keyring to config (default true)
 ```
 
 ### SEE ALSO

--- a/docs/md/melange_convert_gem.md
+++ b/docs/md/melange_convert_gem.md
@@ -30,12 +30,18 @@ convert gem fluentd
 ### Options
 
 ```
+      --base-uri-format string   URI to use for querying gems for provided package name (default "https://rubygems.org/api/v1/gems/%s.json")
+  -h, --help                     help for gem
+      --ruby-version string      version of ruby to use throughout generated manifests (default "3.2")
+```
+
+### Options inherited from parent commands
+
+```
       --additional-keyrings stringArray       additional repositories to be added to convert environment config
       --additional-repositories stringArray   additional repositories to be added to convert environment config
-      --base-uri-format string                URI to use for querying gems for provided package name (default "https://rubygems.org/api/v1/gems/%s.json")
-  -h, --help                                  help for gem
-      --out-dir string                        directory where convert config will be output (default "./generated")
-      --ruby-version string                   version of ruby to use throughout generated manifests (default "3.2")
+  -o, --out-dir string                        directory where convert config will be output (default "./generated")
+      --wolfi-defaults                        if true, adds wolfi repo, and keyring to config (default true)
 ```
 
 ### SEE ALSO

--- a/docs/md/melange_convert_python.md
+++ b/docs/md/melange_convert_python.md
@@ -30,13 +30,19 @@ convert python botocore
 ### Options
 
 ```
+      --base-uri-format string   URI to use for querying gems for provided package name (default "https://pypi.org")
+  -h, --help                     help for python
+      --package-version string   version of the python package to convert
+      --python-version string    version of the python to build the package (default "3.11")
+```
+
+### Options inherited from parent commands
+
+```
       --additional-keyrings stringArray       additional repositories to be added to convert environment config
       --additional-repositories stringArray   additional repositories to be added to convert environment config
-      --base-uri-format string                URI to use for querying gems for provided package name (default "https://pypi.org")
-  -h, --help                                  help for python
-      --out-dir string                        directory where convert config will be output (default "./generated")
-      --package-version string                version of the python package to convert
-      --python-version string                 version of the python to build the package (default "3.11")
+  -o, --out-dir string                        directory where convert config will be output (default "./generated")
+      --wolfi-defaults                        if true, adds wolfi repo, and keyring to config (default true)
 ```
 
 ### SEE ALSO

--- a/go.mod
+++ b/go.mod
@@ -76,6 +76,7 @@ require (
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/evanphx/json-patch v5.6.0+incompatible // indirect
 	github.com/fatih/color v1.15.0 // indirect
+	github.com/frankban/quicktest v1.14.4 // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
 	github.com/go-git/go-billy/v5 v5.4.1 // indirect
 	github.com/go-logr/logr v1.2.4 // indirect
@@ -103,6 +104,7 @@ require (
 	github.com/googleapis/gax-go/v2 v2.12.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
+	github.com/hashicorp/go-hclog v1.2.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.4 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -141,9 +141,11 @@ github.com/envoyproxy/go-control-plane v0.9.10-0.20210907150352-cf90f659a021/go.
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/evanphx/json-patch v5.6.0+incompatible h1:jBYDEEiFBPxA0v50tFdvOzQQTCvpL6mnFh5mB2/l16U=
 github.com/evanphx/json-patch v5.6.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
+github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.15.0 h1:kOqh6YHBtK8aywxGerMG2Eq3H6Qgoqeo13Bk2Mv/nBs=
 github.com/fatih/color v1.15.0/go.mod h1:0h5ZqXfHYED7Bhv2ZJamyIOUej9KtShiJESRwBDUSsw=
-github.com/frankban/quicktest v1.14.0 h1:+cqqvzZV87b4adx/5ayVOaYZ2CrvM4ejQvUdBzPPUss=
+github.com/frankban/quicktest v1.14.4 h1:g2rn0vABPOOXmZUj+vbmUp0lPoXEMuhTpIluN0XL9UY=
+github.com/frankban/quicktest v1.14.4/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
@@ -333,8 +335,9 @@ github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
 github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
-github.com/hashicorp/go-hclog v0.9.2 h1:CG6TE5H9/JXsFWJCfoIVpKFIkFe6ysEuHirp4DxCsHI=
 github.com/hashicorp/go-hclog v0.9.2/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
+github.com/hashicorp/go-hclog v1.2.0 h1:La19f8d7WIlm4ogzNHB0JGqs5AUDAZ2UfCY4sJXcJdM=
+github.com/hashicorp/go-hclog v1.2.0/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
 github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/go-retryablehttp v0.7.4 h1:ZQgVdpTdAL7WpMIwLzCfbalOcSUdkDZnpUv3/+BxzFA=
@@ -386,6 +389,7 @@ github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
+github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
@@ -406,8 +410,11 @@ github.com/markbates/oncer v0.0.0-20181203154359-bf2de49a0be2/go.mod h1:Ld9puTsI
 github.com/markbates/safe v1.0.1/go.mod h1:nAqgmRi7cY2nqMc92/bSEeQA+R4OheNU2T1kNSCBdG0=
 github.com/matryer/is v1.2.0 h1:92UTHpy8CDwaJ08GqLDzhhuixiBUUD1p3AU6PHddz4A=
 github.com/matryer/is v1.2.0/go.mod h1:2fLPjFQM9rhQ15aVEtbuwhJinnOqrmgXPNdZsdwlWXA=
+github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
+github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
+github.com/mattn/go-isatty v0.0.10/go.mod h1:qgIWMr58cqv1PHHyhnkY9lrL7etaEgOFcMEpPG5Rm84=
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-isatty v0.0.19 h1:JITubQf0MOLdlGRuRq+jtsDlekdYPia9ZFsB8h/APPA=
 github.com/mattn/go-isatty v0.0.19/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
@@ -459,6 +466,7 @@ github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58/go.mod h1:DXv8WO4yhM
 github.com/pelletier/go-toml v1.7.0/go.mod h1:vwGMzjaWMwyfHwgIBhI2YUM4fB6nL6lVAvS1LBMMhTE=
 github.com/pjbgf/sha1cd v0.3.0 h1:4D5XXmUUBUl/xQ6IjCkEAbqXskkq/4O7LmGn0AqMDs4=
 github.com/pjbgf/sha1cd v0.3.0/go.mod h1:nZ1rrWOcGJ5uZgEEVL1VUM9iRQiZvWdbZjkKyFzPPsI=
+github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
@@ -477,6 +485,7 @@ github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6L
 github.com/rogpeppe/go-internal v1.1.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.2.2/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
+github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
@@ -706,6 +715,7 @@ golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190312061237-fead79001313/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190403152447-81d4e9dc473e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -720,6 +730,7 @@ golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190904154756-749cb33beabd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191001151750-bb3f8db39f24/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191008105621-543471e840be/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191120155948-bd437916bb0e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191204072324-ce4227a45e2e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/pkg/cli/apkbuild.go
+++ b/pkg/cli/apkbuild.go
@@ -46,14 +46,20 @@ func ApkBuild() *cobra.Command {
 				return errors.New("too many arguments, expected only 1")
 			}
 
+			var err error
+			// Note we pass false here to avoid the default behaviour of adding
+			// the wolfi repo and keyring. This is because we don't want to
+			// add them by default for apkbuilds, but we do want to add them
+			// but we want them for others.
+			o.outDir, o.additionalRepositories, o.additionalKeyrings, err = getCommonValues(cmd, false)
+			if err != nil {
+				return err
+			}
 			return o.ApkBuildCmd(cmd.Context(), args[0])
 		},
 	}
 
-	cmd.Flags().StringVar(&o.outDir, "out-dir", "./generated", "directory where convert config will be output")
 	cmd.Flags().StringVar(&o.baseURIFormat, "base-uri-format", "https://git.alpinelinux.org/aports/plain/main/%s/APKBUILD", "URI to use for querying APKBUILD for provided package name")
-	cmd.Flags().StringArrayVar(&o.additionalRepositories, "additional-repositories", []string{}, "additional repositories to be added to convert environment config")
-	cmd.Flags().StringArrayVar(&o.additionalKeyrings, "additional-keyrings", []string{}, "additional repositories to be added to convert environment config")
 	cmd.Flags().StringArrayVar(&o.excludePackages, "exclude-packages", []string{}, "packages to exclude from auto generation of melange configs when detected in APKBUILD files")
 
 	return cmd

--- a/pkg/cli/convert.go
+++ b/pkg/cli/convert.go
@@ -26,10 +26,8 @@ const (
 )
 
 type convertCmd struct {
-	outDir                 string
-	additionalRepositories []string
-	additionalKeyrings     []string
-	wolfiDefaults          bool
+	outDir        string
+	wolfiDefaults bool
 }
 
 func Convert() *cobra.Command {

--- a/pkg/cli/convert.go
+++ b/pkg/cli/convert.go
@@ -14,23 +14,92 @@
 
 package cli
 
-import "github.com/spf13/cobra"
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	wolfiRepo    = "https://packages.wolfi.dev/os"
+	wolfiKeyring = "https://packages.wolfi.dev/os/wolfi-signing.rsa.pub"
+)
+
+type convertCmd struct {
+	outDir                 string
+	additionalRepositories []string
+	additionalKeyrings     []string
+	wolfiDefaults          bool
+}
 
 func Convert() *cobra.Command {
+	c := &convertCmd{}
 	cmd := &cobra.Command{
 		Use:               "convert",
 		DisableAutoGenTag: true,
 		SilenceUsage:      true,
+		TraverseChildren:  true,
 		Short:             "EXPERIMENTAL COMMAND - Attempts to convert packages/gems/apkbuild files into melange configuration files",
 		Long: `Convert is an EXPERIMENTAL COMMAND - Attempts to convert packages/gems/apkbuild files into melange configuration files
 								Check that the build executes and builds the apk as expected, using the wolfi-dev/sdk to test the install of built apk
-								Dependencies are recursively generated and a lot of assumptions are made for you, there be dragons here. 
+								Dependencies are recursively generated and a lot of assumptions are made for you, there be dragons here.
 							`,
 	}
+	// Add out-dir, as well as additional-repos and additiona-keyrings flag to
+	// all subcommands
+	cmd.PersistentFlags().StringVarP(&c.outDir, "out-dir", "o", "./generated", "directory where convert config will be output")
+	cmd.PersistentFlags().StringArray(
+		"additional-repositories", []string{},
+		"additional repositories to be added to convert environment config",
+	)
+	cmd.PersistentFlags().StringArray(
+		"additional-keyrings", []string{},
+		"additional repositories to be added to convert environment config",
+	)
+
+	// To support backwards compatibility, keep the default behavior of adding
+	// wolfi repos, unless this flag is given, and it's not apk build which did
+	// not add them by default.
+	cmd.PersistentFlags().BoolVar(&c.wolfiDefaults, "wolfi-defaults", true, "if true, adds wolfi repo, and keyring to config")
+
 	cmd.AddCommand(
 		ApkBuild(),
 		GemBuild(),
 		PythonBuild(),
 	)
 	return cmd
+}
+
+// Helper function for getting the out-dir, additional-repositories and
+// additional-keyrings since that's common to all subcommands.
+// apkBuild did not add by default the wolfi repos, we we have to account for
+// that to override the default behavior.
+func getCommonValues(cmd *cobra.Command, honorWolfiDefaults bool) (string, []string, []string, error) {
+	outDir, err := cmd.Flags().GetString("out-dir")
+	if err != nil {
+		return "", nil, nil, fmt.Errorf("failed to get out-dir flag: %v", err)
+	}
+
+	additionalRepositories, err := cmd.Flags().GetStringArray("additional-repositories")
+	if err != nil {
+		return "", nil, nil, fmt.Errorf("failed to get additional-repositories flag: %v", err)
+	}
+
+	additionalKeyrings, err := cmd.Flags().GetStringArray("additional-keyrings")
+	if err != nil {
+		return "", nil, nil, fmt.Errorf("failed to get additional-keyrings flag: %v", err)
+	}
+	// To ensure backwards compatibility while we migrate to the
+	// explicitly specifying the wolfi repos, we add them by default
+	// unless instructed not to.
+	wolfiDefaults, err := cmd.Flags().GetBool("wolfi-defaults")
+	if err != nil {
+		return "", nil, nil, fmt.Errorf("failed to get wolfi-defaults flag: %v", err)
+	}
+
+	if honorWolfiDefaults && wolfiDefaults {
+		additionalRepositories = append(additionalRepositories, wolfiRepo)
+		additionalKeyrings = append(additionalKeyrings, wolfiKeyring)
+	}
+	return outDir, additionalRepositories, additionalKeyrings, nil
 }

--- a/pkg/cli/gem.go
+++ b/pkg/cli/gem.go
@@ -51,6 +51,14 @@ convert gem fluentd`,
 				return errors.New("too many arguments, expected only 1")
 			}
 
+			var err error
+			// Note we pass true here to get the default behaviour of adding
+			// the wolfi repo and keyring. This is because we want to add them
+			// by default for gem.
+			o.outDir, o.additionalRepositories, o.additionalKeyrings, err = getCommonValues(cmd, true)
+			if err != nil {
+				return err
+			}
 			return o.gemBuild(cmd.Context(), args[0])
 		},
 	}
@@ -60,19 +68,8 @@ convert gem fluentd`,
 		"version of ruby to use throughout generated manifests",
 	)
 	cmd.Flags().StringVar(
-		&o.outDir, "out-dir", "./generated", "directory where convert config will be output",
-	)
-	cmd.Flags().StringVar(
 		&o.baseURIFormat, "base-uri-format", gem.DefaultBaseURIFormat,
 		"URI to use for querying gems for provided package name",
-	)
-	cmd.Flags().StringArrayVar(
-		&o.additionalRepositories, "additional-repositories", []string{},
-		"additional repositories to be added to convert environment config",
-	)
-	cmd.Flags().StringArrayVar(
-		&o.additionalKeyrings, "additional-keyrings", []string{},
-		"additional repositories to be added to convert environment config",
 	)
 	return cmd
 }

--- a/pkg/cli/python.go
+++ b/pkg/cli/python.go
@@ -49,18 +49,22 @@ convert python botocore`,
 				return errors.New("too many arguments, expected only 1")
 			}
 
+			var err error
+			// Note we pass true here to get the default behaviour of adding
+			// the wolfi repo and keyring. This is because we want to add them
+			// by default for python.
+			o.outDir, o.additionalRepositories, o.additionalKeyrings, err = getCommonValues(cmd, true)
+			if err != nil {
+				return err
+			}
 			return o.pythonBuild(cmd.Context(), args[0])
 		},
 	}
 
-	cmd.Flags().StringVar(&o.outDir, "out-dir", "./generated", "directory where convert config will be output")
 	cmd.Flags().StringVar(&o.packageVersion, "package-version", "", "version of the python package to convert")
 	cmd.Flags().StringVar(&o.baseURIFormat, "base-uri-format", "https://pypi.org",
 		"URI to use for querying gems for provided package name")
 	cmd.Flags().StringVar(&o.pythonVersion, "python-version", "3.11", "version of the python to build the package")
-	cmd.Flags().StringArrayVar(&o.additionalRepositories, "additional-repositories", []string{}, "additional repositories to be added to convert environment config")
-	cmd.Flags().StringArrayVar(&o.additionalKeyrings, "additional-keyrings", []string{}, "additional repositories to be added to convert environment config")
-
 	return cmd
 }
 

--- a/pkg/convert/gem/gem.go
+++ b/pkg/convert/gem/gem.go
@@ -283,8 +283,6 @@ func (c *GemContext) generatePackage(g GemMeta) config.Package {
 func (c *GemContext) generateEnvironment() apkotypes.ImageConfiguration {
 	env := apkotypes.ImageConfiguration{
 		Contents: apkotypes.ImageContents{
-			Repositories: []string{"https://packages.wolfi.dev/os"},
-			Keyring:      []string{"https://packages.wolfi.dev/os/wolfi-signing.rsa.pub"},
 			Packages: []string{
 				"ca-certificates-bundle",
 				fmt.Sprintf("ruby-%s", c.RubyVersion),

--- a/pkg/convert/gem/gem_test.go
+++ b/pkg/convert/gem/gem_test.go
@@ -132,6 +132,10 @@ func TestGenerateManifest(t *testing.T) {
 
 	gemctx.RubyVersion = DefaultRubyVersion
 
+	// Add additionalReposities and additionalKeyrings
+	gemctx.AdditionalRepositories = []string{"https://packages.wolfi.dev/os"}
+	gemctx.AdditionalKeyrings = []string{"https://packages.wolfi.dev/os/wolfi-signing.rsa.pub"}
+
 	// Read the gem meta into
 	data, err := os.ReadFile(filepath.Join(gemMetaDir, "async.json"))
 	assert.NoError(t, err)
@@ -259,8 +263,9 @@ func TestGenerateEnvironment(t *testing.T) {
 	gemctx, err := New()
 	assert.NoError(t, err)
 
-	gemctx.AdditionalKeyrings = []string{"melange.rsa.pub"}
-	gemctx.AdditionalRepositories = []string{"local /github/workspace/packages"}
+	// Add additionalReposities and additionalKeyrings
+	gemctx.AdditionalRepositories = []string{"https://packages.wolfi.dev/os", "local /github/workspace/packages"}
+	gemctx.AdditionalKeyrings = []string{"https://packages.wolfi.dev/os/wolfi-signing.rsa.pub", "melange.rsa.pub"}
 	gemctx.RubyVersion = DefaultRubyVersion
 
 	got := gemctx.generateEnvironment()

--- a/pkg/convert/python/python.go
+++ b/pkg/convert/python/python.go
@@ -266,9 +266,7 @@ func (c *PythonContext) generateEnvironment(pack Package) apkotypes.ImageConfigu
 
 	env := apkotypes.ImageConfiguration{
 		Contents: apkotypes.ImageContents{
-			Repositories: []string{"https://packages.wolfi.dev/os"},
-			Keyring:      []string{"https://packages.wolfi.dev/os/wolfi-signing.rsa.pub"},
-			Packages:     pythonStandard,
+			Packages: pythonStandard,
 		},
 	}
 

--- a/pkg/convert/python/python_test.go
+++ b/pkg/convert/python/python_test.go
@@ -140,8 +140,12 @@ func TestGenerateManifest(t *testing.T) {
 		pythonctxs, err := SetupContext(versions[i])
 		assert.NoError(t, err)
 
-		//botocore ctx
+		// botocore ctx
 		pythonctx := pythonctxs[0]
+		// Add additionalReposities and additionalKeyrings
+		pythonctx.AdditionalRepositories = []string{"https://packages.wolfi.dev/os"}
+		pythonctx.AdditionalKeyrings = []string{"https://packages.wolfi.dev/os/wolfi-signing.rsa.pub"}
+
 		got, err := pythonctx.generateManifest(ctx, pythonctx.Package, pythonctx.PackageVersion)
 		assert.NoError(t, err)
 
@@ -157,8 +161,8 @@ func TestGenerateManifest(t *testing.T) {
 		assert.Equal(t, got.Package.Copyright[0].License, "Apache License 2.0")
 
 		// Check Environment
-		assert.Equal(t, got.Environment.Contents.Repositories, []string{"https://packages.wolfi.dev/os"})
-		assert.Equal(t, got.Environment.Contents.Keyring, []string{"https://packages.wolfi.dev/os/wolfi-signing.rsa.pub"})
+		assert.Equal(t, []string{"https://packages.wolfi.dev/os"}, got.Environment.Contents.Repositories)
+		assert.Equal(t, []string{"https://packages.wolfi.dev/os/wolfi-signing.rsa.pub"}, got.Environment.Contents.Keyring)
 		assert.Equal(t, got.Environment.Contents.Packages, []string{
 			"ca-certificates-bundle",
 			"wolfi-base",
@@ -307,6 +311,9 @@ func TestGenerateEnvironment(t *testing.T) {
 	pythonctx := pythonctxs[0]
 
 	pythonctx.PythonVersion = "3.10"
+	// Add additionalReposities and additionalKeyrings
+	pythonctx.AdditionalRepositories = []string{"https://packages.wolfi.dev/os"}
+	pythonctx.AdditionalKeyrings = []string{"https://packages.wolfi.dev/os/wolfi-signing.rsa.pub"}
 	got310 := pythonctx.generateEnvironment(pythonctx.Package)
 
 	expected310 := apkotypes.ImageConfiguration{
@@ -324,13 +331,16 @@ func TestGenerateEnvironment(t *testing.T) {
 		},
 	}
 
-	assert.Equal(t, got310, expected310)
+	assert.Equal(t, expected310, got310)
 
 	pythonctxs, err = SetupContext("3.11")
 
 	//botocore ctx
 	pythonctx = pythonctxs[0]
 	assert.NoError(t, err)
+	pythonctx.AdditionalRepositories = []string{"https://packages.wolfi.dev/os"}
+	pythonctx.AdditionalKeyrings = []string{"https://packages.wolfi.dev/os/wolfi-signing.rsa.pub"}
+
 	got311 := pythonctx.generateEnvironment(pythonctx.Package)
 
 	expected311 := apkotypes.ImageConfiguration{
@@ -348,7 +358,7 @@ func TestGenerateEnvironment(t *testing.T) {
 		},
 	}
 
-	assert.Equal(t, got311, expected311)
+	assert.Equal(t, expected311, got311)
 }
 
 func removeVersionsFromURL(inputURL string) (string, error) {


### PR DESCRIPTION
Prior to this change, wolfi repo / keyring was hardcoded to python/gem convert command. Add a flag --wolfi-defaults if set to false will not do that. Motivation is that then removing them is manual work, that shouldn't be necessary. Default behaviour is unchanged.
Also unified the flag handling so that the common flags are specified in one place and not replicated.
Also fixed couple of .Equal commands where the expected / got were reversed which made it wonky to read the output.