### PR TITLE
Change GeneratedMelangeConfig to embed pkg/config/config instead of redefining it.

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -276,7 +276,7 @@ type Configuration struct {
 	// Package metadata
 	Package Package `yaml:"package"`
 	// The specification for the packages build environment
-	Environment apko_types.ImageConfiguration
+	Environment apko_types.ImageConfiguration `yaml:"environment,omitempty"`
 	// Required: The list of pipelines that produce the package.
 	Pipeline []Pipeline `yaml:"pipeline,omitempty"`
 	// Optional: The list of subpackages that this package also produces.
@@ -520,8 +520,8 @@ func ParseConfiguration(configurationFilePath string, opts ...ConfigurationParsi
 	cfg := Configuration{root: &root}
 
 	// Unmarshal into a node first
-	decoder_node := yaml.NewDecoder(f)
-	err = decoder_node.Decode(&root)
+	decoderNode := yaml.NewDecoder(f)
+	err = decoderNode.Decode(&root)
 	if err != nil {
 		return nil, fmt.Errorf("unable to decode configuration file %q: %w", configurationFilePath, err)
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -276,7 +276,7 @@ type Configuration struct {
 	// Package metadata
 	Package Package `yaml:"package"`
 	// The specification for the packages build environment
-	Environment apko_types.ImageConfiguration `yaml:"environment,omitempty"`
+	Environment apko_types.ImageConfiguration
 	// Required: The list of pipelines that produce the package.
 	Pipeline []Pipeline `yaml:"pipeline,omitempty"`
 	// Optional: The list of subpackages that this package also produces.

--- a/pkg/convert/apkbuild/apkbuild.go
+++ b/pkg/convert/apkbuild/apkbuild.go
@@ -148,10 +148,10 @@ func (c Context) getApkBuildFile(ctx context.Context, apkbuildURL, packageName s
 		GeneratedMelangeConfig: &manifest.GeneratedMelangeConfig{
 			Logger:               c.Logger,
 			GeneratedFromComment: apkbuildURL,
-			Package: config.Package{
-				Epoch: 0,
-			},
 		},
+	}
+	c.ApkConvertors[packageName].GeneratedMelangeConfig.Package = config.Package{
+		Epoch: 0,
 	}
 	c.OrderedKeys = append(c.OrderedKeys, packageName)
 	return nil

--- a/pkg/convert/apkbuild/apkbuild_test.go
+++ b/pkg/convert/apkbuild/apkbuild_test.go
@@ -282,8 +282,6 @@ func Test_context_mapconvert(t *testing.T) {
 
 			assert.NoError(t, err)
 
-			t.Logf("expected: %s", string(expected))
-			t.Logf("actual: %s", string(actual))
 			assert.YAMLEqf(t, string(expected), string(actual), "generated convert yaml not the same as expected")
 		})
 	}

--- a/pkg/convert/apkbuild/apkbuild_test.go
+++ b/pkg/convert/apkbuild/apkbuild_test.go
@@ -282,6 +282,8 @@ func Test_context_mapconvert(t *testing.T) {
 
 			assert.NoError(t, err)
 
+			t.Logf("expected: %s", string(expected))
+			t.Logf("actual: %s", string(actual))
 			assert.YAMLEqf(t, string(expected), string(actual), "generated convert yaml not the same as expected")
 		})
 	}

--- a/pkg/convert/apkbuild/testdata/no_sub_packages.yaml
+++ b/pkg/convert/apkbuild/testdata/no_sub_packages.yaml
@@ -5,6 +5,7 @@ package:
   description: test package description
   copyright:
     - license: MIT
+environment: {}
 pipeline:
   - uses: autoconf/configure
   - uses: autoconf/make

--- a/pkg/convert/apkbuild/testdata/with_multi_sub_packages.yaml
+++ b/pkg/convert/apkbuild/testdata/with_multi_sub_packages.yaml
@@ -5,6 +5,7 @@ package:
   description: test package description
   copyright:
     - license: MIT
+environment: {}
 pipeline:
   - uses: autoconf/configure
   - uses: autoconf/make

--- a/pkg/convert/apkbuild/testdata/with_unrecognised_sub_packages.yaml
+++ b/pkg/convert/apkbuild/testdata/with_unrecognised_sub_packages.yaml
@@ -5,6 +5,7 @@ package:
   description: test package description
   copyright:
     - license: MIT
+environment: {}
 pipeline:
   - uses: autoconf/configure
   - uses: autoconf/make

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -60,7 +60,6 @@ func (m *GeneratedMelangeConfig) Write(dir string) error {
 	}
 
 	ye := yaml.NewEncoder(f)
-	ye.SetIndent(10)
 	defer ye.Close()
 
 	if err := ye.Encode(m); err != nil {

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -14,14 +14,9 @@ import (
 )
 
 type GeneratedMelangeConfig struct {
-	Package              config.Package               `yaml:"package"`
-	Environment          apkotypes.ImageConfiguration `yaml:"environment,omitempty"`
-	Pipeline             []config.Pipeline            `yaml:"pipeline,omitempty"`
-	Subpackages          []config.Subpackage          `yaml:"subpackages,omitempty"`
-	Vars                 map[string]string            `yaml:"vars,omitempty"`
-	Update               config.Update                `yaml:"update,omitempty"`
-	GeneratedFromComment string                       `yaml:"-"`
-	Logger               *log.Logger                  `yaml:"-"`
+	config.Configuration `yaml:",inline"`
+	GeneratedFromComment string      `yaml:"-"`
+	Logger               *log.Logger `yaml:"-"`
 }
 
 func (m *GeneratedMelangeConfig) SetPackage(pkg config.Package) {
@@ -65,6 +60,7 @@ func (m *GeneratedMelangeConfig) Write(dir string) error {
 	}
 
 	ye := yaml.NewEncoder(f)
+	ye.SetIndent(10)
 	defer ye.Close()
 
 	if err := ye.Encode(m); err != nil {


### PR DESCRIPTION
In order to make the tests pass, I had to change the tests (which I always dislike), but after talking it through, the Environment is required field, so make that change in tests. But I think not having to double-define things is a good thing.