### PR TITLE
package: dereference symlinks for aliased pkg-config modules

### DIFF
--- a/.github/workflows/wolfi-presubmit.yaml
+++ b/.github/workflows/wolfi-presubmit.yaml
@@ -57,6 +57,7 @@ jobs:
           - s3cmd
           - perl-yaml-syck
           - xmlto
+          - ncurses
 
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3

--- a/pkg/build/package.go
+++ b/pkg/build/package.go
@@ -594,8 +594,6 @@ func generatePkgConfigDeps(pc *PackageBuild, generated *config.Dependencies) err
 			return nil
 		}
 
-		realPath := path
-
 		fi, err := d.Info()
 		if err != nil {
 			return err
@@ -604,16 +602,12 @@ func generatePkgConfigDeps(pc *PackageBuild, generated *config.Dependencies) err
 		mode := fi.Mode()
 
 		// Sigh.  ncurses uses symlinks to alias .pc files to other .pc files.
-		// We want to catalog all of the provided pkg-config identifiers, but
-		// that requires us to dereference the symlink.
+		// Skip the symlinks for now.
 		if mode.Type()&fs.ModeSymlink == fs.ModeSymlink {
-			realPath, err = os.Readlink(filepath.Join(pc.WorkspaceSubdir(), path))
-			if err != nil {
-				return fmt.Errorf("dereferencing pkg-config file %s: %w", path, err)
-			}
+			return nil
 		}
 
-		pkg, err := pkgconfig.Load(filepath.Join(pc.WorkspaceSubdir(), realPath))
+		pkg, err := pkgconfig.Load(filepath.Join(pc.WorkspaceSubdir(), path))
 		if err != nil {
 			return err
 		}

--- a/pkg/build/package.go
+++ b/pkg/build/package.go
@@ -594,7 +594,26 @@ func generatePkgConfigDeps(pc *PackageBuild, generated *config.Dependencies) err
 			return nil
 		}
 
-		pkg, err := pkgconfig.Load(filepath.Join(pc.WorkspaceSubdir(), path))
+		realPath := path
+
+		fi, err := d.Info()
+		if err != nil {
+			return err
+		}
+
+		mode := fi.Mode()
+
+		// Sigh.  ncurses uses symlinks to alias .pc files to other .pc files.
+		// We want to catalog all of the provided pkg-config identifiers, but
+		// that requires us to dereference the symlink.
+		if mode.Type()&fs.ModeSymlink == fs.ModeSymlink {
+			realPath, err = os.Readlink(filepath.Join(pc.WorkspaceSubdir(), path))
+			if err != nil {
+				return fmt.Errorf("dereferencing pkg-config file %s: %w", path, err)
+			}
+		}
+
+		pkg, err := pkgconfig.Load(filepath.Join(pc.WorkspaceSubdir(), realPath))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Fixes building ncurses, which uses symlinks to alias pkg-config modules to other identifiers.