### PR TITLE
feat: add output logs for the apkbuild converter

### DIFF
--- a/pkg/convert/apkbuild/apkbuild.go
+++ b/pkg/convert/apkbuild/apkbuild.go
@@ -513,5 +513,10 @@ func (c ApkConvertor) write(orderNumber, outdir string) error {
 	if err != nil {
 		return errors.Wrapf(err, "creating writing to file %s", mconvertFile)
 	}
+
+	if c.Logger != nil {
+		c.Logger.Printf("Generated melange config: %s", mconvertFile)
+	}
+
 	return nil
 }


### PR DESCRIPTION
### Changes

Add generated file logs for the APKBUILD converter to match the behaviour of the remaining file converters. This makes the resulting folder more visible to the user.