### PR TITLE
add ${{package.full-version}} = ${{package.version}}-r${{package.epoch}}

### DIFF
--- a/pkg/build/pipeline.go
+++ b/pkg/build/pipeline.go
@@ -98,6 +98,7 @@ func substitutionMap(pb *PipelineBuild) (map[string]string, error) {
 		config.SubstitutionPackageName:          pb.Package.Package.Name,
 		config.SubstitutionPackageVersion:       pb.Package.Package.Version,
 		config.SubstitutionPackageEpoch:         strconv.FormatUint(pb.Package.Package.Epoch, 10),
+		config.SubstitutionPackageFullVersion:   fmt.Sprintf("%s-r%s", config.SubstitutionPackageVersion, config.SubstitutionPackageEpoch),
 		config.SubstitutionTargetsDestdir:       fmt.Sprintf("/home/build/melange-out/%s", pb.Package.Package.Name),
 		config.SubstitutionTargetsContextdir:    fmt.Sprintf("/home/build/melange-out/%s", pb.Package.Package.Name),
 		config.SubstitutionHostTripletGnu:       pb.Build.BuildTripletGnu(),

--- a/pkg/build/pipeline_test.go
+++ b/pkg/build/pipeline_test.go
@@ -84,6 +84,39 @@ func Test_substitutionMap(t *testing.T) {
 	}
 }
 
+func Test_MutateWith(t *testing.T) {
+	for _, tc := range []struct {
+		version string
+		epoch   uint64
+		want    string
+	}{{version: "1.2.3",
+		epoch: 0,
+		want:  "1.2.3-r0",
+	}, {
+		version: "1.2.3",
+		epoch:   3,
+		want:    "1.2.3-r3",
+	}} {
+		pb := &PipelineBuild{
+			Package: &PackageContext{
+				Package: &config.Package{
+					Version: tc.version,
+					Epoch:   tc.epoch,
+				},
+			},
+			Build: &Build{},
+		}
+		got, err := MutateWith(pb, map[string]string{})
+		if err != nil {
+			t.Fatalf("MutateWith failed with: %v", err)
+		}
+		gotFullVer := got[config.SubstitutionPackageFullVersion]
+		if gotFullVer != tc.want {
+			t.Errorf("got %s, want %s", gotFullVer, tc.want)
+		}
+	}
+}
+
 func Test_substitutionNeedPackages(t *testing.T) {
 	pkgctx, err := NewPackageContext(
 		&config.Package{

--- a/pkg/config/vars.go
+++ b/pkg/config/vars.go
@@ -26,6 +26,7 @@ import (
 const (
 	SubstitutionPackageName          = "${{package.name}}"
 	SubstitutionPackageVersion       = "${{package.version}}"
+	SubstitutionPackageFullVersion   = "${{package.full-version}}"
 	SubstitutionPackageEpoch         = "${{package.epoch}}"
 	SubstitutionPackageDescription   = "${{package.description}}"
 	SubstitutionTargetsDestdir       = "${{targets.destdir}}"


### PR DESCRIPTION
Signed-off-by: Ville Aikas <vaikas@chainguard.dev>

For version streams you can now use this (instead of the previous .999)

```
  dependencies:
    provides:
      - php=${{package.full-version}}
 ```

To get version streams.