### PR TITLE
Add build-gpep517 pipeline for Python

### DIFF
--- a/pkg/build/pipelines/python/build-gpep517.yaml
+++ b/pkg/build/pipelines/python/build-gpep517.yaml
@@ -1,0 +1,17 @@
+name: Build a Python wheel with gpep517
+
+needs:
+  packages:
+    - busybox
+
+pipeline:
+  - runs: |
+      if ! [ -x "$(command -v python3)" ]; then
+        echo 'Error: Python is not installed.'
+        exit 1
+      fi
+
+  - runs: |
+      python3 -m gpep517 build-wheel --wheel-dir dist --output-fd 3 3>&1 >&2
+      python3 -m installer -d "${{targets.contextdir}}" dist/*.whl
+      find ${{targets.contextdir}} -name "*.pyc" -exec rm -rf '{}' +


### PR DESCRIPTION
This PR adds a new Python pipeline called: `python/build-gpep517`.

In case if upstream project does not provide neither `pyproject.toml` or `setup.py`, so `python/build` and `python/build-wheel` pipelines does not work as expected since both pipelines uses `build` module and depends on aforementioned files to run correctly. Invoking the `python-build` with `-m gpep517` rather than `-m build`, resolves this issue.