### PR TITLE
docs: fix link in pkg/build/pipelines/README.md

### DIFF
--- a/pkg/build/pipelines/README.md
+++ b/pkg/build/pipelines/README.md
@@ -1,4 +1,4 @@
 # Melange pipelines
 
 This directory contains built-in pipelines. For more information on how to add
-new built-in pipelines, consult [Creating a new built-in pipeline](/docs/PIPELINES.md#Creating-new-built---in-pipelines).
+new built-in pipelines, consult [Creating a new built-in pipeline](/docs/PIPELINES.md#creating-new-built-in-pipelines).


### PR DESCRIPTION
Minor fix in the `pkg/build/pipelines/README.md` to point to the correct header.