### PR TITLE
construct the package.full-version in higher context than just pipeline.

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -474,6 +474,7 @@ func buildConfigMap(cfg *Configuration) map[string]string {
 		SubstitutionPackageVersion:     cfg.Package.Version,
 		SubstitutionPackageDescription: cfg.Package.Description,
 		SubstitutionPackageEpoch:       strconv.FormatUint(cfg.Package.Epoch, 10),
+		SubstitutionPackageFullVersion: fmt.Sprintf("%s-r%d", cfg.Package.Version, cfg.Package.Epoch),
 	}
 
 	for k, v := range cfg.Vars {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -14,12 +14,14 @@ func Test_applySubstitutionsInProvides(t *testing.T) {
 package:
   name: replacement-provides
   version: 0.0.1
+  epoch: 7
   description: example using a replacement in provides
   dependencies:
     provides:
       - replacement-provides-version=${{package.version}}
       - replacement-provides-foo=${{vars.foo}}
       - replacement-provides-bar=${{vars.bar}}
+      - replacement-provides=${{package.full-version}}
 
 vars:
   foo: FOO
@@ -43,6 +45,7 @@ subpackages:
 		"replacement-provides-version=0.0.1",
 		"replacement-provides-foo=FOO",
 		"replacement-provides-bar=BAR",
+		"replacement-provides=0.0.1-r7",
 	}, cfg.Package.Dependencies.Provides)
 
 	require.Equal(t, []string{


### PR DESCRIPTION
Follow up to #662 where the ${{package.full-version}} was only available in pipelines, now available for provides block where it was originally supposed to be in the first place.