### PR TITLE
Add environment var overriding to the pipeline.

### DIFF
--- a/pkg/build/pipeline.go
+++ b/pkg/build/pipeline.go
@@ -425,6 +425,8 @@ func (pctx *PipelineContext) Run(ctx context.Context, pb *PipelineBuild) (bool, 
 			sp.WorkDir = pctx.Pipeline.WorkDir
 		}
 
+		sp.Environment = rightJoinMap(pctx.Pipeline.Environment, sp.Environment)
+
 		spctx, err := NewPipelineContext(&sp, pb.Build.Logger)
 		if err != nil {
 			return false, err

--- a/pkg/build/pipeline.go
+++ b/pkg/build/pipeline.go
@@ -273,6 +273,24 @@ func (pctx *PipelineContext) evalUse(ctx context.Context, pb *PipelineBuild) err
 	return nil
 }
 
+// Build a script to run as part of evalRun
+func (pctx *PipelineContext) buildEvalRunCommand(debugOption rune, sysPath string, workdir string, fragment string) []string {
+	envExport := "export %s='%s'"
+	envArr := []string{}
+	for k, v := range pctx.Pipeline.Environment {
+		envArr = append(envArr, fmt.Sprintf(envExport, k, v))
+	}
+	envString := strings.Join(envArr, "\n")
+	script := fmt.Sprintf(`set -e%c
+export PATH='%s'
+%s
+[ -d '%s' ] || mkdir -p '%s'
+cd '%s'
+%s
+exit 0`, debugOption, sysPath, envString, workdir, workdir, workdir, fragment)
+	return []string{"/bin/sh", "-c", script}
+}
+
 func (pctx *PipelineContext) evalRun(ctx context.Context, pb *PipelineBuild) error {
 	var err error
 	pctx.Pipeline.With, err = MutateWith(pb, pctx.Pipeline.With)
@@ -280,6 +298,13 @@ func (pctx *PipelineContext) evalRun(ctx context.Context, pb *PipelineBuild) err
 		return err
 	}
 	pctx.dumpWith()
+
+	debugOption := ' '
+	if pb.Build.Debug {
+		debugOption = 'x'
+	}
+
+	sysPath := "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
 	workdir := "/home/build"
 	if pctx.Pipeline.WorkDir != "" {
@@ -294,21 +319,8 @@ func (pctx *PipelineContext) evalRun(ctx context.Context, pb *PipelineBuild) err
 		return err
 	}
 
-	debugOption := ' '
-	if pb.Build.Debug {
-		debugOption = 'x'
-	}
-
-	sysPath := "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
-	script := fmt.Sprintf(`set -e%c
-export PATH='%s'
-[ -d '%s' ] || mkdir -p '%s'
-cd '%s'
-%s
-exit 0`, debugOption, sysPath, workdir, workdir, workdir, fragment)
-	command := []string{"/bin/sh", "-c", script}
+	command := pctx.buildEvalRunCommand(debugOption, sysPath, workdir, fragment)
 	config := pb.Build.WorkspaceConfig()
-
 	if err := pb.Build.Runner.Run(ctx, config, command...); err != nil {
 		return err
 	}

--- a/pkg/build/pipeline_test.go
+++ b/pkg/build/pipeline_test.go
@@ -163,6 +163,30 @@ func Test_substitutionNeedPackages(t *testing.T) {
 	require.Equal(t, "go-5.4.3", pb.Build.Configuration.Pipeline[0].With["go-package"])
 }
 
+func Test_buildEvalRunCommand(t *testing.T) {
+	p := &config.Pipeline{
+		Environment: map[string]string{"FOO": "bar"},
+	}
+
+	log := logger.NopLogger{}
+	pctx, err := NewPipelineContext(p, log)
+	require.NoError(t, err)
+
+	debugOption := ' '
+	sysPath := "/foo"
+	workdir := "/bar"
+	fragment := "baz"
+	command := pctx.buildEvalRunCommand(debugOption, sysPath, workdir, fragment)
+	expected := []string{"/bin/sh", "-c", `set -e 
+export PATH='/foo'
+export FOO='bar'
+[ -d '/bar' ] || mkdir -p '/bar'
+cd '/bar'
+baz
+exit 0`}
+	require.Equal(t, command, expected)
+}
+
 func TestAllPipelines(t *testing.T) {
 	// Get all the yamls in pipelines/*/*.yaml and test that they unmarshal
 	pipelines, err := filepath.Glob("pipelines/*/*.yaml")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -220,6 +220,8 @@ type Pipeline struct {
 	WorkDir string `yaml:"working-directory,omitempty"`
 	// Optional: Configuration for the generated SBOM
 	SBOM SBOM `yaml:"sbom,omitempty"`
+	// Optional: environment variables to override the apko environment
+	Environment map[string]string `yaml:"environment,omitempty"`
 }
 
 type Subpackage struct {


### PR DESCRIPTION
Add environment var overriding to the pipeline block in Melange config.

Fixes #675