### PR TITLE
Binary package linting

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -944,11 +944,6 @@ func (sp SubpackageContext) ShouldRun(pb *PipelineBuild) (bool, error) {
 	return result, nil
 }
 
-var defaultLinters = []string{
-	"setuidgid",
-	"usrlocal",
-}
-
 func (b *Build) BuildPackage(ctx context.Context) error {
 	ctx, span := otel.Tracer("melange").Start(ctx, "BuildPackage")
 	defer span.End()

--- a/pkg/build/linter.go
+++ b/pkg/build/linter.go
@@ -36,14 +36,14 @@ type Linter struct {
 }
 
 var Linters = map[string]Linter{
+	"setuidgid": Linter{isSetUidOrGidLinter, "Unset the setuid/setgid bit on the relevant files, or remove this linter"},
+	"tempdir":   Linter{tempDirLinter, "Remove any offending files in temporary dirs in the pipeline"},
 	"usrlocal":  Linter{usrLocalLinter, "This package should be a -compat package"},
 	"varempty":  Linter{varEmptyLinter, "Remove any offending files in /var/empty in the pipeline"},
-	"tempdir":   Linter{tempDirLinter, "Remove any offending files in temporary dirs in the pipeline"},
-	"setuidgid": Linter{isSetUidOrGidLinter, "Unset the setuid/setgid bit on the relevant files, or remove this linter"},
 }
 
 var isUsrLocalRegex = regexp.MustCompile("^usr/local/")
-var isVarEmptyRegex = regexp.MustCompile("^var/local/")
+var isVarEmptyRegex = regexp.MustCompile("^var/empty/")
 var isTempDirRegex = regexp.MustCompile("^(var/)?(tmp|run)/")
 var isCompatPackage = regexp.MustCompile("-compat$")
 

--- a/pkg/build/linter.go
+++ b/pkg/build/linter.go
@@ -1,0 +1,103 @@
+// Copyright 2023 Chainguard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build
+
+import (
+	"fmt"
+	"io/fs"
+	"regexp"
+
+	"chainguard.dev/melange/pkg/config"
+)
+
+type LinterContext struct {
+	pkgname string
+	cfg     *config.Configuration
+	chk     *config.Checks
+}
+
+type LinterFunc func(lctx LinterContext, path string, d fs.DirEntry) error
+
+type Linter struct {
+	LinterFunc LinterFunc
+	Explain    string
+}
+
+var Linters = map[string]Linter{
+	"usrlocal":  Linter{usrLocalLinter, "This package should be a -compat package"},
+	"setuidgid": Linter{isSetUidOrGidLinter, "This package has a setuid/setgid binary, set `checks: - setuidgid' to disable this"},
+}
+
+var isUsrLocalRegex = regexp.MustCompile("usr/local/")
+var isCompatPackage = regexp.MustCompile("-compat$")
+
+func usrLocalLinter(lctx LinterContext, path string, _ fs.DirEntry) error {
+	// If this is already a compat package, do nothing.
+	if isCompatPackage.MatchString(lctx.pkgname) {
+		return nil
+	}
+
+	if isUsrLocalRegex.MatchString(path) {
+		return fmt.Errorf("/usr/local path found in non-compat package")
+	}
+
+	return nil
+}
+
+func isSetUidOrGidLinter(lctx LinterContext, path string, d fs.DirEntry) error {
+	info, err := d.Info()
+	if err != nil {
+		return err
+	}
+
+	mode := info.Mode()
+	fmt.Printf("%s %o\n", path, mode)
+	if mode&fs.ModeSetuid != 0 {
+		return fmt.Errorf("File is setuid")
+	} else if mode&fs.ModeSetgid != 0 {
+		return fmt.Errorf("File is setgid")
+	}
+
+	return nil
+}
+
+func lintPackageFs(lctx LinterContext, fsys fs.FS, linters []string) error {
+	walkCb := func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return fmt.Errorf("Error traversing tree at %s: %w", path, err)
+		}
+
+		for _, linterName := range linters {
+			linter, present := Linters[linterName]
+			if !present {
+				return fmt.Errorf("Linter %s is unknown", linterName)
+			}
+
+			err = linter.LinterFunc(lctx, path, d)
+			if err != nil {
+				return fmt.Errorf("Linter %s failed at path %s: %w; suggest: %s", linterName, path, err, linter.Explain)
+			}
+		}
+
+		return nil
+	}
+
+	err := fs.WalkDir(fsys, ".", walkCb)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/build/linter.go
+++ b/pkg/build/linter.go
@@ -63,7 +63,6 @@ func isSetUidOrGidLinter(lctx LinterContext, path string, d fs.DirEntry) error {
 	}
 
 	mode := info.Mode()
-	fmt.Printf("%s %o\n", path, mode)
 	if mode&fs.ModeSetuid != 0 {
 		return fmt.Errorf("File is setuid")
 	} else if mode&fs.ModeSetgid != 0 {

--- a/pkg/build/linter.go
+++ b/pkg/build/linter.go
@@ -28,18 +28,18 @@ type LinterContext struct {
 	chk     *config.Checks
 }
 
-type LinterFunc func(lctx LinterContext, path string, d fs.DirEntry) error
+type linterFunc func(lctx LinterContext, path string, d fs.DirEntry) error
 
-type Linter struct {
-	LinterFunc LinterFunc
+type linter struct {
+	LinterFunc linterFunc
 	Explain    string
 }
 
-var linterMap = map[string]Linter{
-	"setuidgid": Linter{isSetUidOrGidLinter, "Unset the setuid/setgid bit on the relevant files, or remove this linter"},
-	"tempdir":   Linter{tempDirLinter, "Remove any offending files in temporary dirs in the pipeline"},
-	"usrlocal":  Linter{usrLocalLinter, "This package should be a -compat package"},
-	"varempty":  Linter{varEmptyLinter, "Remove any offending files in /var/empty in the pipeline"},
+var linterMap = map[string]linter{
+	"setuidgid": linter{isSetUidOrGidLinter, "Unset the setuid/setgid bit on the relevant files, or remove this linter"},
+	"tempdir":   linter{tempDirLinter, "Remove any offending files in temporary dirs in the pipeline"},
+	"usrlocal":  linter{usrLocalLinter, "This package should be a -compat package"},
+	"varempty":  linter{varEmptyLinter, "Remove any offending files in /var/empty in the pipeline"},
 }
 
 var isUsrLocalRegex = regexp.MustCompile("^usr/local/")

--- a/pkg/build/linter.go
+++ b/pkg/build/linter.go
@@ -35,7 +35,7 @@ type Linter struct {
 	Explain    string
 }
 
-var Linters = map[string]Linter{
+var linterMap = map[string]Linter{
 	"setuidgid": Linter{isSetUidOrGidLinter, "Unset the setuid/setgid bit on the relevant files, or remove this linter"},
 	"tempdir":   Linter{tempDirLinter, "Remove any offending files in temporary dirs in the pipeline"},
 	"usrlocal":  Linter{usrLocalLinter, "This package should be a -compat package"},
@@ -99,7 +99,7 @@ func lintPackageFs(lctx LinterContext, fsys fs.FS, linters []string) error {
 		}
 
 		for _, linterName := range linters {
-			linter, present := Linters[linterName]
+			linter, present := linterMap[linterName]
 			if !present {
 				return fmt.Errorf("Linter %s is unknown", linterName)
 			}

--- a/pkg/build/linter_test.go
+++ b/pkg/build/linter_test.go
@@ -1,0 +1,122 @@
+// Copyright 2023 Chainguard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"chainguard.dev/melange/pkg/config"
+)
+
+func Test_usrLocalLinter(t *testing.T) {
+	dir, err := os.MkdirTemp("", "melange.XXXXX")
+	defer os.RemoveAll(dir)
+	assert.NoError(t, err)
+
+	cfg := config.Configuration{
+		Package: config.Package{
+			Name:    "test",
+			Version: "4.2.0",
+			Epoch:   0,
+			Checks: config.Checks{
+				Enabled:  []string{"usrlocal"},
+				Disabled: []string{"setuidgid"},
+			},
+		},
+	}
+
+	err = os.MkdirAll(filepath.Join(dir, "usr", "local"), 0700)
+	assert.NoError(t, err)
+	_, err = os.Create(filepath.Join(dir, "usr", "local", "test.txt"))
+	assert.NoError(t, err)
+
+	linters := cfg.Package.Checks.GetLinters()
+	assert.Equal(t, linters, []string{"usrlocal"})
+	fsys := os.DirFS(dir)
+	lctx := LinterContext{cfg.Package.Name, &cfg, &cfg.Package.Checks}
+	assert.Error(t, lintPackageFs(lctx, fsys, linters))
+}
+
+func Test_setUidGidLinter(t *testing.T) {
+	dir, err := os.MkdirTemp("", "melange.XXXXX")
+	defer os.RemoveAll(dir)
+	assert.NoError(t, err)
+
+	cfg := config.Configuration{
+		Package: config.Package{
+			Name:    "test",
+			Version: "4.2.0",
+			Epoch:   0,
+			Checks: config.Checks{
+				Enabled:  []string{"setuidgid"},
+				Disabled: []string{"usrlocal"},
+			},
+		},
+	}
+
+	usrLocalDirPath := filepath.Join(dir, "usr", "local")
+	filePath := filepath.Join(usrLocalDirPath, "test.txt")
+
+	err = os.MkdirAll(usrLocalDirPath, 0770)
+	assert.NoError(t, err)
+
+	_, err = os.Create(filepath.Join(filePath))
+	assert.NoError(t, err)
+
+	err = os.Chmod(filePath, 0770|fs.ModeSetuid|fs.ModeSetgid)
+	assert.NoError(t, err)
+
+	linters := cfg.Package.Checks.GetLinters()
+	assert.Equal(t, linters, []string{"setuidgid"})
+	fsys := os.DirFS(dir)
+	lctx := LinterContext{cfg.Package.Name, &cfg, &cfg.Package.Checks}
+	assert.Error(t, lintPackageFs(lctx, fsys, linters))
+}
+
+func Test_disableDefaultLinter(t *testing.T) {
+	dir, err := os.MkdirTemp("", "melange.XXXXX")
+	defer os.RemoveAll(dir)
+	assert.NoError(t, err)
+
+	cfg := config.Configuration{
+		Package: config.Package{
+			Name:    "test",
+			Version: "4.2.0",
+			Epoch:   0,
+			Checks: config.Checks{
+				Disabled: []string{"usrlocal"},
+			},
+		},
+	}
+
+	usrLocalDirPath := filepath.Join(dir, "usr", "local")
+	filePath := filepath.Join(usrLocalDirPath, "test.txt")
+
+	err = os.MkdirAll(usrLocalDirPath, 0770)
+	assert.NoError(t, err)
+
+	_, err = os.Create(filepath.Join(filePath))
+	assert.NoError(t, err)
+
+	linters := cfg.Package.Checks.GetLinters()
+	fsys := os.DirFS(dir)
+	lctx := LinterContext{cfg.Package.Name, &cfg, &cfg.Package.Checks}
+	assert.NoError(t, lintPackageFs(lctx, fsys, linters))
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -339,7 +339,9 @@ func (cfg Configuration) Name() string {
 
 var defaultLinters = []string{
 	"setuidgid",
+	"tempdir",
 	"usrlocal",
+	"varempty",
 }
 
 type VarTransforms struct {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -77,6 +78,13 @@ type PackageOption struct {
 	NoCommands bool `yaml:"no-commands"`
 }
 
+type Checks struct {
+	// Optional: enable these linters that are not enabled by default.
+	Enabled []string `yaml:"enabled,omitempty"`
+	// Optional: disable these linters that are not enabled by default.
+	Disabled []string `yaml:"disabled,omitempty"`
+}
+
 type Package struct {
 	// The name of the package
 	Name string `yaml:"name"`
@@ -101,6 +109,8 @@ type Package struct {
 	// Optional: Executable scripts that run at various stages of the package
 	// lifecycle, triggered by configurable events
 	Scriptlets Scriptlets `yaml:"scriptlets,omitempty"`
+	// Optional: enabling, disabling, and configuration of build checks
+	Checks Checks `yaml:"checks,omitempty"`
 }
 
 // PackageURL returns the package URL ("purl") for the package. For more
@@ -171,6 +181,25 @@ func (p *Package) FullCopyright() string {
 		copyright += cp.Attestation + "\n"
 	}
 	return copyright
+}
+
+// Computes the list of package or subpackage linters, taking into account default linters.
+// This includes the default linters as well, unless disabled.
+func (chk *Checks) GetLinters() []string {
+	linters := defaultLinters
+
+	// Enable non-default linters
+	for _, v := range chk.Enabled {
+		// Ensure we don't get duplicate values
+		if !slices.Contains(linters, v) {
+			linters = append(linters, v)
+		}
+	}
+
+	// Filter linters
+	linters = slices.DeleteFunc(linters, func(n string) bool { return slices.Contains(chk.Disabled, n) })
+
+	return linters
 }
 
 type Needs struct {
@@ -244,6 +273,8 @@ type Subpackage struct {
 	URL string `yaml:"url,omitempty"`
 	// Optional: The git commit of the subpackage build configuration
 	Commit string `yaml:"commit,omitempty"`
+	// Optional: enabling, disabling, and configuration of build checks
+	Checks Checks `yaml:"checks,omitempty"`
 }
 
 // PackageURL returns the package URL ("purl") for the subpackage. For more
@@ -304,6 +335,11 @@ type Configuration struct {
 // Name returns a name for the configuration, using the package name.
 func (cfg Configuration) Name() string {
 	return cfg.Package.Name
+}
+
+var defaultLinters = []string{
+	"setuidgid",
+	"usrlocal",
 }
 
 type VarTransforms struct {


### PR DESCRIPTION
This implements binary package linting per the spec, as found [here](https://inky.wtf/linterdesign).

A few things I want looked at:
- Is the linter context part ok? It hasn't been reviewed in the doc yet, but I went ahead and did it.
- Should more linters be added? If so, what? So far there is a setuid/setgid linter, a linter for checking for packages writing files in temp dirs, a linter for checking if /var/empty is being written to, and a check for /usr/local.
- ~~Should [chainguard-dev/go-apk#117](https://github.com/chainguard-dev/go-apk/issues/117) be fixed first or should I not bother?~~ **EDIT:** Decided not to bother for now.