### PR TITLE
Add regression tests for workdir propagation, fix long-standing bug with propagation across referenced pipelines

### DIFF
--- a/pkg/build/pipeline.go
+++ b/pkg/build/pipeline.go
@@ -234,11 +234,11 @@ func (pctx *PipelineContext) evalUse(ctx context.Context, pb *PipelineBuild) err
 	if err != nil {
 		return err
 	}
-	spctx.Pipeline.WorkDir = pctx.Pipeline.WorkDir
 
 	if err := spctx.loadUse(pb, pctx.Pipeline.Uses, pctx.Pipeline.With); err != nil {
 		return err
 	}
+	spctx.Pipeline.WorkDir = pctx.Pipeline.WorkDir
 
 	pctx.logger.Printf("  using %s", pctx.Pipeline.Uses)
 	spctx.dumpWith()
@@ -406,6 +406,9 @@ func (pctx *PipelineContext) Run(ctx context.Context, pb *PipelineBuild) (bool, 
 		spctx, err := NewPipelineContext(&sp, pb.Build.Logger)
 		if err != nil {
 			return false, err
+		}
+		if spctx.Pipeline.WorkDir == "" {
+			spctx.Pipeline.WorkDir = pctx.Pipeline.WorkDir
 		}
 
 		ran, err := spctx.Run(ctx, pb)


### PR DESCRIPTION
A melange pipeline can reference other pipelines with the `uses` statement, e.g.

```yaml
pipeline:
  - uses: foo
```

However, a long standing bug has existed where the pipeline settings did not necessarily propagate downstream.  This bug recently became exposed by refactoring of the pipeline code to perform downward propagation at configuration load time rather than runtime.

We also add regression tests for various forms of downward propagation in the config struct.