### PR TITLE
Bump go tests to 1.21

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
         with:
-          go-version: '1.20'
+          go-version: '1.21'
           check-latest: true
 
       - name: build

--- a/.github/workflows/go-tests.yaml
+++ b/.github/workflows/go-tests.yaml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
         with:
-          go-version: '1.20'
+          go-version: '1.21'
           check-latest: true
 
       - name: Checkout code

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
         with:
-          go-version: '1.20'
+          go-version: '1.21'
           check-latest: true
 
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
@@ -55,7 +55,7 @@ jobs:
     steps:
       - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
         with:
-          go-version: '1.20'
+          go-version: '1.21'
           check-latest: true
 
       - uses: ko-build/setup-ko@ace48d793556083a76f1e3e6068850c1f4a369aa # v0.6

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
         with:
-          go-version: '1.20'
+          go-version: '1.21'
           check-latest: true
 
       - name: golangci-lint

--- a/.github/workflows/wolfi-presubmit.yaml
+++ b/.github/workflows/wolfi-presubmit.yaml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
         with:
-          go-version: '1.20'
+          go-version: '1.21'
           check-latest: true
 
       - name: build


### PR DESCRIPTION
This bumps the Go tests to 1.21. Blocking #680 because slices is a 1.21 package.