### PR TITLE
Bump k8s test workflows to Go 1.21

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -49,6 +49,11 @@ jobs:
     steps:
     - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
 
+    - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
+      with:
+        go-version: '1.21'
+        check-latest: true
+
     - name: Setup melange
       run: |
         make melange


### PR DESCRIPTION
I missed this in #682. Exactly what it says on the tin.