### PR TITLE
git-checkout: Allow tags to matched annotated tag SHAs, don't allow

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -21,6 +21,7 @@ jobs:
     strategy:
       matrix:
         example:
+        - git-checkout.yaml
         - gnu-hello.yaml
         - mbedtls.yaml
         - minimal.yaml

--- a/examples/git-checkout.yaml
+++ b/examples/git-checkout.yaml
@@ -1,0 +1,39 @@
+---
+# SPDX-FileCopyrightText: 2023 Chainguard, Inc
+# SPDX-License-Identifier: Apache-2.0
+
+package:
+  name: git-checkout
+  version: v0.0.1
+  epoch: 0
+  description: "A project that will checkout the same repo different ways"
+environment:
+  contents:
+    keyring:
+      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    repositories:
+      - https://packages.wolfi.dev/os
+    packages:
+      - wolfi-base
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/puerco/hello.git
+      destination: default
+  - uses: git-checkout
+    with:
+      repository: https://github.com/puerco/hello.git
+      destination: branch
+      branch: main
+  - uses: git-checkout
+    with:
+      repository: https://github.com/puerco/hello.git
+      destination: tag
+      tag: v0.0.1
+      expected-commit: a73c4feb284dc6ed1e5758740f717f99dcd4c9d7
+  - uses: git-checkout
+    with:
+      repository: https://github.com/puerco/hello.git
+      destination: tag-unpeeled
+      tag: v0.0.1
+      expected-commit: fed9b28e2973bee65bcc503c6ab6522e8bfdd3d1

--- a/pkg/build/pipelines/git-checkout.yaml
+++ b/pkg/build/pipelines/git-checkout.yaml
@@ -67,12 +67,32 @@ pipeline:
 
       if [ -z "${{inputs.expected-commit}}" ]; then
         echo "Warning (git-checkout): no expected-commit"
-      else
-        [ -n '${{inputs.branch}}' ] && remote_commit=$(git rev-list -1 origin/"${{inputs.branch}}")
-        [ -n '${{inputs.tag}}' ] && remote_commit=$(git rev-list -1 "${{inputs.tag}}")
-
+      elif [ -n '${{inputs.branch}}' ]; then
+        remote_commit=$(git rev-parse --verify --end-of-options "refs/heads/${{inputs.branch}}")
         if [[ '${{inputs.expected-commit}}' != "$remote_commit" ]]; then
           echo "Error (git-checkout): expect commit ${{inputs.expected-commit}}, got $remote_commit"
           exit 1
         fi
+      elif [ -n '${{inputs.tag}}' ]; then
+        # If it's a tag, then it could be a lightweight or annotated tag.
+        # Lightweight tags point directly to the commit and do not have any messages, signatures, or other data.
+        # Annotated tags point to its own git object containing the tag data, with a reference to the underlying commit.
+        # We expect most tags to be using annotated tags.
+
+        # Compare direct tag value
+        remote_commit=$(git rev-parse --verify --end-of-options "refs/tags/${{inputs.tag}}")
+        if [[ '${{inputs.expected-commit}}' == "$remote_commit" ]]; then
+          exit 0
+        fi
+
+        # Try to unpeel the tag and compare the underlying value.
+        echo "Warning (git-checkout): expected commit ${{inputs.expected-commit}}, does not match tag ${remote_commit}. Attempting to unpeel tag."
+
+        unpeeled_commit=$(git rev-parse --verify --end-of-options "refs/tags/${{inputs.tag}}^{}")
+        if [[ '${{inputs.expected-commit}}' != "${unpeeled_commit}" ]]; then
+          echo "Error (git-checkout): expect commit ${{inputs.expected-commit}}, got ${unpeeled_commit}"
+          exit 1
+        fi
+      else
+        echo "Error (git-checkout): no branch or tag provided"
       fi


### PR DESCRIPTION
fuzzy matching of refs.

Previously, we were somewhat loose with allowed revisions - the branch check for origin/foo could technically match a tag named origin/foo, and vice-versa for tag names. This changes the behavior to use rev-parse --verify to guarantee that we are looking up by the intended branch/tag name.

This also looses the allowed revisions for tags to allow the true SHA for an annotated tag. Previously we only allowed the unpeeled values and would reject the true SHA.

Fixes https://github.com/chainguard-dev/melange/issues/685