### PR TITLE
golangci-lint version bump to 1.54

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@639cd343e1d3b897ff35927a75193d57cfcba299 # v3.1.0
         with:
-          version: v1.53
+          version: v1.54
           args: --timeout=5m
 
       - run: make docs-repo


### PR DESCRIPTION
This updates golangci-lint to 1.54. 1.53 seems to have some bugs...