### PR TITLE
chore: remove CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,0 @@
-# Each line is a file pattern followed by one or more owners.
-*       @chainguard-dev/images-maintainers


### PR DESCRIPTION
It doesn't serve a practical purpose, and notifies maintainers excessively on each pull request.

cc: @pdeslaur 