### PR TITLE
fix the dir name as we already expect dir to be set explicit

### DIFF
--- a/pkg/build/pipelines/goreleaser/build.yaml
+++ b/pkg/build/pipelines/goreleaser/build.yaml
@@ -45,7 +45,7 @@ pipeline:
       goreleaser_flags="--clean --skip-docker --skip-ko --skip-publish ${{inputs.args}}"
 
       DIR="$(dirname '${{inputs.output}}')"
-      mkdir -p "${{targets.contextdir}}"/$DIR
+      mkdir -p $DIR
       BASENAME="$(basename '${{inputs.output}}')"
 
       # if working-dir is rather than "." cd into that directory

--- a/pkg/build/pipelines/goreleaser/build.yaml
+++ b/pkg/build/pipelines/goreleaser/build.yaml
@@ -63,4 +63,10 @@ pipeline:
     
       goreleaser release $goreleaser_flags
       echo "Copying binary to ${{inputs.output}}"
-      install -Dm755 ./dist/${BASENAME}_linux_*/* "${{inputs.output}}"
+      build_arch="${{build.arch}}"
+      if [ "$build_arch" = "aarch64" ]; then
+        build_arch="arm64"
+      elif [ "$build_arch" = "x86_64" ]; then
+        build_arch="amd64"
+      fi
+      install -Dm755 ./dist/${BASENAME}_linux_$build_arch*/* "${{inputs.output}}"


### PR DESCRIPTION
We expect from end users to set the output dir as an explicit way so we just need to grab the dir name and create that dir without adding ${{targets.contextdir}} in front of it.

Also, we noticed an error for file format while stripping the binary, so, this PR also aims to fix that as well: #693 