### PR TITLE
Add worldwrite linter

### DIFF
--- a/pkg/build/linter.go
+++ b/pkg/build/linter.go
@@ -119,8 +119,8 @@ func varEmptyLinter(_ LinterContext, path string, _ fs.DirEntry) error {
 }
 
 func worldWriteableLinter(_ LinterContext, path string, d fs.DirEntry) error {
-	if d.IsDir() {
-		// Don't worry about directories
+	if !d.Type().IsRegular() {
+		// Don't worry about non-files
 		return nil
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -345,6 +345,7 @@ var defaultLinters = []string{
 	"tempdir",
 	"usrlocal",
 	"varempty",
+	"worldwrite",
 }
 
 type VarTransforms struct {


### PR DESCRIPTION
This checks for world-writeable files in packages, and will warn about them. Especially serious are world-writeable packages that are also executable. This is a security risk.

Directories are skipped on purpose.