### PR TITLE
exa is dead, use mdbook as a rust CI test instead.

### DIFF
--- a/.github/workflows/wolfi-presubmit.yaml
+++ b/.github/workflows/wolfi-presubmit.yaml
@@ -53,7 +53,7 @@ jobs:
           - gdk-pixbuf
           - gitsign
           - guac
-          - exa
+          - mdbook
           - s3cmd
           - perl-yaml-syck
           - xmlto


### PR DESCRIPTION
This package for our purposes is more or less morally equivalent to exa.