### PR TITLE
Refactor the package linter into a submodule

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -47,6 +47,7 @@ import (
 	"chainguard.dev/melange/pkg/config"
 	"chainguard.dev/melange/pkg/container"
 	"chainguard.dev/melange/pkg/index"
+	"chainguard.dev/melange/pkg/linter"
 	"chainguard.dev/melange/pkg/sbom"
 )
 
@@ -1053,8 +1054,8 @@ func (b *Build) BuildPackage(ctx context.Context) error {
 
 		fsys := os.DirFS(b.WorkspaceDir)
 
-		lctx := LinterContext{b.Configuration.Package.Name, &b.Configuration, &chk}
-		err = lintPackageFs(lctx, fsys, linters)
+		lctx := linter.NewLinterContext(b.Configuration.Package.Name, &b.Configuration, &chk)
+		err = lctx.LintPackageFs(fsys, linters)
 		if err != nil {
 			return fmt.Errorf("Error with package linter:\n%w", err)
 		}
@@ -1114,8 +1115,8 @@ func (b *Build) BuildPackage(ctx context.Context) error {
 		// TODO(Elizafox): getting the workspace dir path should be refactored.
 		path := filepath.Join(b.WorkspaceDir, "melange-out", sp.Name)
 		fsys := os.DirFS(path)
-		lctx := LinterContext{sp.Name, &b.Configuration, &chk}
-		err = lintPackageFs(lctx, fsys, linters)
+		lctx := linter.NewLinterContext(sp.Name, &b.Configuration, &chk)
+		err = lctx.LintPackageFs(fsys, linters)
 		if err != nil {
 			return fmt.Errorf("Error with package linter:\n%w", err)
 		}

--- a/pkg/linter/linter.go
+++ b/pkg/linter/linter.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package build
+package linter
 
 import (
 	"fmt"
@@ -26,6 +26,10 @@ type LinterContext struct {
 	pkgname string
 	cfg     *config.Configuration
 	chk     *config.Checks
+}
+
+func NewLinterContext(name string, cfg *config.Configuration, chk *config.Checks) LinterContext {
+	return LinterContext{name, cfg, chk}
 }
 
 type linterFunc func(lctx LinterContext, path string, d fs.DirEntry) error
@@ -181,7 +185,7 @@ func emptyPostLinter(_ LinterContext, fsys fs.FS) error {
 	return fmt.Errorf("Package is empty but no-provides is not set")
 }
 
-func lintPackageFs(lctx LinterContext, fsys fs.FS, linters []string) error {
+func (lctx LinterContext) LintPackageFs(fsys fs.FS, linters []string) error {
 	// If this is a compat package, do nothing.
 	if isCompatPackage.MatchString(lctx.pkgname) {
 		return nil

--- a/pkg/linter/linter_test.go
+++ b/pkg/linter/linter_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package build
+package linter
 
 import (
 	"io/fs"
@@ -45,8 +45,8 @@ func Test_emptyLinter(t *testing.T) {
 	linters := cfg.Package.Checks.GetLinters()
 	assert.Equal(t, linters, []string{"empty"})
 	fsys := os.DirFS(dir)
-	lctx := LinterContext{cfg.Package.Name, &cfg, &cfg.Package.Checks}
-	assert.Error(t, lintPackageFs(lctx, fsys, linters))
+	lctx := NewLinterContext(cfg.Package.Name, &cfg, &cfg.Package.Checks)
+	assert.Error(t, lctx.LintPackageFs(fsys, linters))
 }
 
 func Test_usrLocalLinter(t *testing.T) {
@@ -74,8 +74,8 @@ func Test_usrLocalLinter(t *testing.T) {
 	linters := cfg.Package.Checks.GetLinters()
 	assert.Equal(t, linters, []string{"usrlocal"})
 	fsys := os.DirFS(dir)
-	lctx := LinterContext{cfg.Package.Name, &cfg, &cfg.Package.Checks}
-	assert.Error(t, lintPackageFs(lctx, fsys, linters))
+	lctx := NewLinterContext(cfg.Package.Name, &cfg, &cfg.Package.Checks)
+	assert.Error(t, lctx.LintPackageFs(fsys, linters))
 }
 
 func Test_varEmptyLinter(t *testing.T) {
@@ -104,8 +104,8 @@ func Test_varEmptyLinter(t *testing.T) {
 	linters := cfg.Package.Checks.GetLinters()
 	assert.Equal(t, linters, []string{"varempty"})
 	fsys := os.DirFS(dir)
-	lctx := LinterContext{cfg.Package.Name, &cfg, &cfg.Package.Checks}
-	assert.Error(t, lintPackageFs(lctx, fsys, linters))
+	lctx := NewLinterContext(cfg.Package.Name, &cfg, &cfg.Package.Checks)
+	assert.Error(t, lctx.LintPackageFs(fsys, linters))
 }
 
 func Test_devLinter(t *testing.T) {
@@ -134,8 +134,8 @@ func Test_devLinter(t *testing.T) {
 	linters := cfg.Package.Checks.GetLinters()
 	assert.Equal(t, linters, []string{"dev"})
 	fsys := os.DirFS(dir)
-	lctx := LinterContext{cfg.Package.Name, &cfg, &cfg.Package.Checks}
-	assert.Error(t, lintPackageFs(lctx, fsys, linters))
+	lctx := NewLinterContext(cfg.Package.Name, &cfg, &cfg.Package.Checks)
+	assert.Error(t, lctx.LintPackageFs(fsys, linters))
 }
 
 func Test_optLinter(t *testing.T) {
@@ -164,8 +164,8 @@ func Test_optLinter(t *testing.T) {
 	linters := cfg.Package.Checks.GetLinters()
 	assert.Equal(t, linters, []string{"opt"})
 	fsys := os.DirFS(dir)
-	lctx := LinterContext{cfg.Package.Name, &cfg, &cfg.Package.Checks}
-	assert.Error(t, lintPackageFs(lctx, fsys, linters))
+	lctx := NewLinterContext(cfg.Package.Name, &cfg, &cfg.Package.Checks)
+	assert.Error(t, lctx.LintPackageFs(fsys, linters))
 }
 
 func Test_srvLinter(t *testing.T) {
@@ -194,8 +194,8 @@ func Test_srvLinter(t *testing.T) {
 	linters := cfg.Package.Checks.GetLinters()
 	assert.Equal(t, linters, []string{"srv"})
 	fsys := os.DirFS(dir)
-	lctx := LinterContext{cfg.Package.Name, &cfg, &cfg.Package.Checks}
-	assert.Error(t, lintPackageFs(lctx, fsys, linters))
+	lctx := NewLinterContext(cfg.Package.Name, &cfg, &cfg.Package.Checks)
+	assert.Error(t, lctx.LintPackageFs(fsys, linters))
 }
 
 func Test_tempDirLinter(t *testing.T) {
@@ -236,8 +236,8 @@ func Test_tempDirLinter(t *testing.T) {
 	assert.NoError(t, err)
 	_, err = os.Create(filename)
 	assert.NoError(t, err)
-	lctx := LinterContext{cfg.Package.Name, &cfg, &cfg.Package.Checks}
-	assert.Error(t, lintPackageFs(lctx, fsys, linters))
+	lctx := NewLinterContext(cfg.Package.Name, &cfg, &cfg.Package.Checks)
+	assert.Error(t, lctx.LintPackageFs(fsys, linters))
 	os.Remove(filename)
 
 	// Test /var/tmp check
@@ -291,8 +291,8 @@ func Test_setUidGidLinter(t *testing.T) {
 	linters := cfg.Package.Checks.GetLinters()
 	assert.Equal(t, linters, []string{"setuidgid"})
 	fsys := os.DirFS(dir)
-	lctx := LinterContext{cfg.Package.Name, &cfg, &cfg.Package.Checks}
-	assert.Error(t, lintPackageFs(lctx, fsys, linters))
+	lctx := NewLinterContext(cfg.Package.Name, &cfg, &cfg.Package.Checks)
+	assert.Error(t, lctx.LintPackageFs(fsys, linters))
 }
 
 func Test_worldWriteLinter(t *testing.T) {
@@ -320,8 +320,8 @@ func Test_worldWriteLinter(t *testing.T) {
 	linters := cfg.Package.Checks.GetLinters()
 	assert.Equal(t, linters, []string{"worldwrite"})
 	fsys := os.DirFS(dir)
-	lctx := LinterContext{cfg.Package.Name, &cfg, &cfg.Package.Checks}
-	assert.NoError(t, lintPackageFs(lctx, fsys, linters))
+	lctx := NewLinterContext(cfg.Package.Name, &cfg, &cfg.Package.Checks)
+	assert.NoError(t, lctx.LintPackageFs(fsys, linters))
 
 	// Create test file
 	filePath := filepath.Join(usrLocalDirPath, "test.txt")
@@ -333,21 +333,21 @@ func Test_worldWriteLinter(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Linter should not trigger
-	assert.NoError(t, lintPackageFs(lctx, fsys, linters))
+	assert.NoError(t, lctx.LintPackageFs(fsys, linters))
 
 	// Set writeable bit (but not executable bit)
 	err = os.Chmod(filePath, 0776)
 	assert.NoError(t, err)
 
 	// Linter should trigger
-	assert.Error(t, lintPackageFs(lctx, fsys, linters))
+	assert.Error(t, lctx.LintPackageFs(fsys, linters))
 
 	// Set writeable and executable bit
 	err = os.Chmod(filePath, 0777)
 	assert.NoError(t, err)
 
 	// Linter should trigger
-	assert.Error(t, lintPackageFs(lctx, fsys, linters))
+	assert.Error(t, lctx.LintPackageFs(fsys, linters))
 }
 
 func Test_disableDefaultLinter(t *testing.T) {
@@ -377,6 +377,6 @@ func Test_disableDefaultLinter(t *testing.T) {
 
 	linters := cfg.Package.Checks.GetLinters()
 	fsys := os.DirFS(dir)
-	lctx := LinterContext{cfg.Package.Name, &cfg, &cfg.Package.Checks}
-	assert.NoError(t, lintPackageFs(lctx, fsys, linters))
+	lctx := NewLinterContext(cfg.Package.Name, &cfg, &cfg.Package.Checks)
+	assert.NoError(t, lctx.LintPackageFs(fsys, linters))
 }


### PR DESCRIPTION
I intend to write an interface that mounts an APK as a filesystem and scans it with the file linter. This is preliminary work in that direction.