### PR TITLE
build: refactor package linter invocation

### DIFF
--- a/examples/git-checkout.yaml
+++ b/examples/git-checkout.yaml
@@ -7,6 +7,9 @@ package:
   version: v0.0.1
   epoch: 0
   description: "A project that will checkout the same repo different ways"
+  checks:
+    disabled:
+      - empty
 environment:
   contents:
     keyring:


### PR DESCRIPTION
Add package lints to a queue rather than running them at the end of the pipeline, this allows linting to be deferred until after the pipelines complete and the workspace is retrieved from the Kubernetes environment.