### PR TITLE
Do not delete extensions and plugins directories with ruby/clean

### DIFF
--- a/pkg/build/pipelines/ruby/clean.yaml
+++ b/pkg/build/pipelines/ruby/clean.yaml
@@ -14,6 +14,4 @@ pipeline:
   - runs: |
       INSTALL_DIR=${{targets.destdir}}/$(ruby -e 'puts Gem.default_dir')
       rm -rf ${INSTALL_DIR}/build_info \
-             ${INSTALL_DIR}/cache \
-             ${INSTALL_DIR}/extensions \
-             ${INSTALL_DIR}/plugins
+             ${INSTALL_DIR}/cache


### PR DESCRIPTION
These directories were previously being deleted but they contain metadata necessary for gem native extensions and plugins. They should only contain files when they are required so we should keep them around.