### PR TITLE
Track vendored deps for .PKGINFO

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -436,6 +436,10 @@ type Dependencies struct {
 	// Optional: An integer compared against other equal package provides used to
 	// determine priority
 	ProviderPriority int `yaml:"provider-priority,omitempty"`
+
+	// List of self-provided dependencies found outside of lib directories
+	// ("lib", "usr/lib", "lib64", or "usr/lib64").
+	Vendored []string `yaml:"-"`
 }
 
 type ConfigurationParsingOption func(*configOptions)


### PR DESCRIPTION
If we discover a vendored dependency (outside of libdirs), we will use that to self-satisfy any generated runtime dependencies. Notably, we will not use these vendored dependencies to satisfy any explicitly configured runtime dependencies so that we have an escape hatch for overriding the SCA.

This also adds `# vendored = ...` comments to .PKGINFO so that we can debug cases that would otherwise appear as a missing runtime dependency.

(Draft for now because I would like to do a dry run of this new logic against existing packages to see if there are any unexpected diffs.)