### PR TITLE
drop sirupsen logger

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,6 @@ require (
 	github.com/package-url/packageurl-go v0.1.1
 	github.com/pkg/errors v0.9.1
 	github.com/psanford/memfs v0.0.0-20230130182539-4dbf7e3e865e
-	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.7.0
 	github.com/stretchr/testify v1.8.4
 	github.com/yookoala/realpath v1.0.0
@@ -140,6 +139,7 @@ require (
 	github.com/sigstore/cosign/v2 v2.2.0 // indirect
 	github.com/sigstore/rekor v1.2.2 // indirect
 	github.com/sigstore/sigstore v1.7.2 // indirect
+	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/skeema/knownhosts v1.2.0 // indirect
 	github.com/spf13/afero v1.9.5 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect

--- a/pkg/cli/commands.go
+++ b/pkg/cli/commands.go
@@ -17,10 +17,7 @@ package cli
 import (
 	"fmt"
 	"net/http"
-	"os"
 
-	apko_log "chainguard.dev/apko/pkg/log"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/release-utils/version"
 )
@@ -55,13 +52,4 @@ type userAgentTransport struct{ t http.RoundTripper }
 func (u userAgentTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	req.Header.Set("User-Agent", fmt.Sprintf("melange/%s", version.GetVersionInfo().GitVersion))
 	return u.t.RoundTrip(req)
-}
-
-func LogDefault() *logrus.Logger {
-	return &logrus.Logger{
-		Out:       os.Stderr,
-		Formatter: &apko_log.Formatter{},
-		Hooks:     make(logrus.LevelHooks),
-		Level:     logrus.InfoLevel,
-	}
 }

--- a/pkg/cli/sign.go
+++ b/pkg/cli/sign.go
@@ -65,10 +65,8 @@ func SignIndex() *cobra.Command {
 }
 
 func (o signIndexOpts) SignIndex(ctx context.Context, indexFile string) error {
-	logger := LogDefault()
-
 	if !o.Force {
-		return sign.SignIndex(ctx, logger, o.Key, indexFile)
+		return sign.SignIndex(ctx, nil, o.Key, indexFile)
 	}
 
 	idx, err := parseIndexWithoutSignature(ctx, indexFile)
@@ -93,11 +91,11 @@ func (o signIndexOpts) SignIndex(ctx context.Context, indexFile string) error {
 		return err
 	}
 
-	if err := sign.SignIndex(ctx, logger, o.Key, t.Name()); err != nil {
+	if err := sign.SignIndex(ctx, nil, o.Key, t.Name()); err != nil {
 		return err
 	}
 
-	logger.Printf("Replacing existing signed index (%s) with signed index with key %s", indexFile, o.Key)
+	log.Printf("Replacing existing signed index (%s) with signed index with key %s", indexFile, o.Key)
 	return os.Rename(t.Name(), indexFile)
 }
 


### PR DESCRIPTION
We moved to our own logger implementation around https://github.com/chainguard-dev/melange/pull/399 in April. This was one remaining vestige, which resulted in logs being written to stderr when the log policy disallowed it.

If this looks good we should probably remove sirupsen/logger from go-apk too, and not bother passing the `nil` logger. I checked that passing a `nil` logger to `SignIndex` doesn't result in a panic, and does log the lines.