### PR TITLE
melange bump: only reset the epoch if version changes, else increment it

### DIFF
--- a/pkg/renovate/bump/bump.go
+++ b/pkg/renovate/bump/bump.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strconv"
 
 	"github.com/dprotaso/go-yit"
 	"gopkg.in/yaml.v3"
@@ -83,6 +84,11 @@ func New(opts ...Option) renovate.Renovator {
 		if err != nil {
 			return err
 		}
+
+		resetEpoch := true
+		if versionNode.Value == bcfg.TargetVersion {
+			resetEpoch = false
+		}
 		versionNode.Value = bcfg.TargetVersion
 		versionNode.Style = yaml.FlowStyle
 		versionNode.Tag = "!!str"
@@ -94,7 +100,18 @@ func New(opts ...Option) renovate.Renovator {
 		if err != nil {
 			return err
 		}
-		epochNode.Value = "0"
+
+		// if the version is changing then reset the epoch to 0 else if the version is the same then increment the epoch by 1
+		if resetEpoch {
+			epochNode.Value = "0"
+		} else {
+			epoch, err := strconv.Atoi(epochNode.Value)
+			if err != nil {
+				return err
+			}
+			epochNode.Value = fmt.Sprintf("%d", epoch+1)
+		}
+
 		rc.Vars[config.SubstitutionPackageEpoch] = epochNode.Value
 
 		// Recompute variable transforms


### PR DESCRIPTION
This can happen when an upstream deletes a tag and re-uses it with a different commit, so we need to bump the epoch rather than reset it. Example https://github.com/wolfi-dev/os/pull/6126/commits/4a7ae4002985401afaab03b50f9cff8073462ec8

If there are no version or expected commit changes we still expect the epoch to be bumped 