### PR TITLE
Enable linters to warn (via callback) instead of just failing.

### DIFF
--- a/docs/md/melange_build.md
+++ b/docs/md/melange_build.md
@@ -42,6 +42,7 @@ melange build [flags]
       --dependency-log string       log dependencies to a specified file
       --empty-workspace             whether the build workspace should be empty
       --env-file string             file to use for preloaded environment variables
+      --fail-on-lint-warning        turns linter warnings into failures
       --generate-index              whether to generate APKINDEX.tar.gz (default true)
       --guest-dir string            directory used for the build environment guest
   -h, --help                        help for build

--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -60,6 +60,7 @@ func Build() *cobra.Command {
 	var debug bool
 	var debugRunner bool
 	var runner string
+	var failOnLintWarning bool
 
 	cmd := &cobra.Command{
 		Use:     "build",
@@ -97,6 +98,7 @@ func Build() *cobra.Command {
 				build.WithDebugRunner(debugRunner),
 				build.WithLogPolicy(logPolicy),
 				build.WithRunner(runner),
+				build.WithFailOnLintWarning(failOnLintWarning),
 			}
 
 			if len(args) > 0 {
@@ -144,6 +146,7 @@ func Build() *cobra.Command {
 	cmd.Flags().BoolVar(&createBuildLog, "create-build-log", false, "creates a package.log file containing a list of packages that were built by the command")
 	cmd.Flags().BoolVar(&debug, "debug", false, "enables debug logging of build pipelines")
 	cmd.Flags().BoolVar(&debugRunner, "debug-runner", false, "when enabled, the builder pod will persist after the build succeeds or fails")
+	cmd.Flags().BoolVar(&failOnLintWarning, "fail-on-lint-warning", false, "turns linter warnings into failures")
 
 	return cmd
 }

--- a/pkg/linter/linter_test.go
+++ b/pkg/linter/linter_test.go
@@ -46,7 +46,11 @@ func Test_emptyLinter(t *testing.T) {
 	assert.Equal(t, linters, []string{"empty"})
 	fsys := os.DirFS(dir)
 	lctx := NewLinterContext(cfg.Package.Name, fsys, &cfg, &cfg.Package.Checks)
-	assert.Error(t, lctx.LintPackageFs(fsys, linters))
+	called := false
+	assert.NoError(t, lctx.LintPackageFs(fsys, func(err error) {
+		called = true
+	}, linters))
+	assert.True(t, called)
 }
 
 func Test_usrLocalLinter(t *testing.T) {
@@ -75,7 +79,11 @@ func Test_usrLocalLinter(t *testing.T) {
 	assert.Equal(t, linters, []string{"usrlocal"})
 	fsys := os.DirFS(dir)
 	lctx := NewLinterContext(cfg.Package.Name, fsys, &cfg, &cfg.Package.Checks)
-	assert.Error(t, lctx.LintPackageFs(fsys, linters))
+	called := false
+	assert.NoError(t, lctx.LintPackageFs(fsys, func(err error) {
+		called = true
+	}, linters))
+	assert.True(t, called)
 }
 
 func Test_varEmptyLinter(t *testing.T) {
@@ -105,7 +113,11 @@ func Test_varEmptyLinter(t *testing.T) {
 	assert.Equal(t, linters, []string{"varempty"})
 	fsys := os.DirFS(dir)
 	lctx := NewLinterContext(cfg.Package.Name, fsys, &cfg, &cfg.Package.Checks)
-	assert.Error(t, lctx.LintPackageFs(fsys, linters))
+	called := false
+	assert.NoError(t, lctx.LintPackageFs(fsys, func(err error) {
+		called = true
+	}, linters))
+	assert.True(t, called)
 }
 
 func Test_devLinter(t *testing.T) {
@@ -135,7 +147,11 @@ func Test_devLinter(t *testing.T) {
 	assert.Equal(t, linters, []string{"dev"})
 	fsys := os.DirFS(dir)
 	lctx := NewLinterContext(cfg.Package.Name, fsys, &cfg, &cfg.Package.Checks)
-	assert.Error(t, lctx.LintPackageFs(fsys, linters))
+	called := false
+	assert.NoError(t, lctx.LintPackageFs(fsys, func(err error) {
+		called = true
+	}, linters))
+	assert.True(t, called)
 }
 
 func Test_optLinter(t *testing.T) {
@@ -165,7 +181,11 @@ func Test_optLinter(t *testing.T) {
 	assert.Equal(t, linters, []string{"opt"})
 	fsys := os.DirFS(dir)
 	lctx := NewLinterContext(cfg.Package.Name, fsys, &cfg, &cfg.Package.Checks)
-	assert.Error(t, lctx.LintPackageFs(fsys, linters))
+	called := false
+	assert.NoError(t, lctx.LintPackageFs(fsys, func(err error) {
+		called = true
+	}, linters))
+	assert.True(t, called)
 }
 
 func Test_srvLinter(t *testing.T) {
@@ -195,7 +215,11 @@ func Test_srvLinter(t *testing.T) {
 	assert.Equal(t, linters, []string{"srv"})
 	fsys := os.DirFS(dir)
 	lctx := NewLinterContext(cfg.Package.Name, fsys, &cfg, &cfg.Package.Checks)
-	assert.Error(t, lctx.LintPackageFs(fsys, linters))
+	called := false
+	assert.NoError(t, lctx.LintPackageFs(fsys, func(err error) {
+		called = true
+	}, linters))
+	assert.True(t, called)
 }
 
 func Test_tempDirLinter(t *testing.T) {
@@ -237,7 +261,11 @@ func Test_tempDirLinter(t *testing.T) {
 	_, err = os.Create(filename)
 	assert.NoError(t, err)
 	lctx := NewLinterContext(cfg.Package.Name, fsys, &cfg, &cfg.Package.Checks)
-	assert.Error(t, lctx.LintPackageFs(fsys, linters))
+	called := false
+	assert.NoError(t, lctx.LintPackageFs(fsys, func(err error) {
+		called = true
+	}, linters))
+	assert.True(t, called)
 	os.Remove(filename)
 
 	// Test /var/tmp check
@@ -292,7 +320,11 @@ func Test_setUidGidLinter(t *testing.T) {
 	assert.Equal(t, linters, []string{"setuidgid"})
 	fsys := os.DirFS(dir)
 	lctx := NewLinterContext(cfg.Package.Name, fsys, &cfg, &cfg.Package.Checks)
-	assert.Error(t, lctx.LintPackageFs(fsys, linters))
+	called := false
+	assert.NoError(t, lctx.LintPackageFs(fsys, func(err error) {
+		called = true
+	}, linters))
+	assert.True(t, called)
 }
 
 func Test_worldWriteLinter(t *testing.T) {
@@ -321,7 +353,11 @@ func Test_worldWriteLinter(t *testing.T) {
 	assert.Equal(t, linters, []string{"worldwrite"})
 	fsys := os.DirFS(dir)
 	lctx := NewLinterContext(cfg.Package.Name, fsys, &cfg, &cfg.Package.Checks)
-	assert.NoError(t, lctx.LintPackageFs(fsys, linters))
+	called := false
+	assert.NoError(t, lctx.LintPackageFs(fsys, func(err error) {
+		called = true
+	}, linters))
+	assert.False(t, called)
 
 	// Create test file
 	filePath := filepath.Join(usrLocalDirPath, "test.txt")
@@ -333,21 +369,33 @@ func Test_worldWriteLinter(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Linter should not trigger
-	assert.NoError(t, lctx.LintPackageFs(fsys, linters))
+	called = false
+	assert.NoError(t, lctx.LintPackageFs(fsys, func(err error) {
+		called = true
+	}, linters))
+	assert.False(t, called)
 
 	// Set writeable bit (but not executable bit)
 	err = os.Chmod(filePath, 0776)
 	assert.NoError(t, err)
 
 	// Linter should trigger
-	assert.Error(t, lctx.LintPackageFs(fsys, linters))
+	called = false
+	assert.NoError(t, lctx.LintPackageFs(fsys, func(err error) {
+		called = true
+	}, linters))
+	assert.True(t, called)
 
 	// Set writeable and executable bit
 	err = os.Chmod(filePath, 0777)
 	assert.NoError(t, err)
 
 	// Linter should trigger
-	assert.Error(t, lctx.LintPackageFs(fsys, linters))
+	called = false
+	assert.NoError(t, lctx.LintPackageFs(fsys, func(err error) {
+		called = true
+	}, linters))
+	assert.True(t, called)
 }
 
 func Test_disableDefaultLinter(t *testing.T) {
@@ -378,5 +426,9 @@ func Test_disableDefaultLinter(t *testing.T) {
 	linters := cfg.Package.Checks.GetLinters()
 	fsys := os.DirFS(dir)
 	lctx := NewLinterContext(cfg.Package.Name, fsys, &cfg, &cfg.Package.Checks)
-	assert.NoError(t, lctx.LintPackageFs(fsys, linters))
+	called := false
+	assert.NoError(t, lctx.LintPackageFs(fsys, func(err error) {
+		called = true
+	}, linters))
+	assert.False(t, called)
 }


### PR DESCRIPTION
This also adds the flag `--fail-on-lint-warning` to force all active linters to error instead of simply printing their message.

## Melange Pull Request Template

### Functional Changes

- [x] This change can build all of Wolfi without errors (describe results in notes)

Notes:

All linters are now warn-only.

### SCA Changes

- [N/A] Examining several representative APKs show no regression / the desired effect (details in notes)

Notes:

This doesn't touch APK generation at all.

### Linter

- [x] The new check is clean across Wolfi
- [x] The new check is opt-in or a warning

Notes:

All checks are warnings.