### PR TITLE
validate pipeline fields together

### DIFF
--- a/examples/options.yaml
+++ b/examples/options.yaml
@@ -4,10 +4,7 @@ package:
   epoch: 3
   description: "URL retrieval utility and library"
   copyright:
-    - paths:
-        - "*"
-      attestation: TODO
-      license: MIT
+    - license: MIT
 
 environment:
   contents:


### PR DESCRIPTION
I spent an embarrassing amount of time trying to debug why this failed:

```
- runs: autoconf/make
  with:
    opts: operator
```

When I figured it out, I wanted an error to stop me from making that mistake again.

This is incomplete, there are other combinations of pipeline fields that should be an error, but this is a start at least.