### PR TITLE
linter: fix a typo in package linting function

### DIFF
--- a/pkg/linter/linter.go
+++ b/pkg/linter/linter.go
@@ -357,7 +357,7 @@ func LintApk(ctx context.Context, path string, warn func(error), linters []strin
 	}
 
 	// Get the package name
-	f, err := apkfs.Open("PKGINFO")
+	f, err := apkfs.Open("./.PKGINFO")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
It's `.PKGINFO` not `PKGINFO` 😅 