### PR TITLE
Fix a bug where substitutions were not done for runtime.

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -17,6 +17,9 @@ package:
   epoch: 7
   description: example using a replacement in provides
   dependencies:
+    runtime:
+      - ${{package.name}}-config
+      - ${{vars.bar}}
     provides:
       - replacement-provides-version=${{package.version}}
       - replacement-provides-foo=${{vars.foo}}
@@ -30,6 +33,9 @@ vars:
 subpackages:
   - name: subpackage
     dependencies:
+      runtime:
+        - ${{package.name}}-config-${{package.version}}
+        - ${{vars.foo}}
       provides:
         - subpackage-version=${{package.version}}
         - subpackage-foo=${{vars.foo}}
@@ -53,6 +59,16 @@ subpackages:
 		"subpackage-foo=FOO",
 		"subpackage-bar=BAR",
 	}, cfg.Subpackages[0].Dependencies.Provides)
+
+	require.Equal(t, []string{
+		"replacement-provides-config",
+		"BAR",
+	}, cfg.Package.Dependencies.Runtime)
+
+	require.Equal(t, []string{
+		"replacement-provides-config-0.0.1",
+		"FOO",
+	}, cfg.Subpackages[0].Dependencies.Runtime)
 }
 
 func Test_propagatePipelines(t *testing.T) {


### PR DESCRIPTION
## Melange Pull Request Template

Fix a bug where substitutions were not done for `runtime`.

<!--
*** PULL REQUEST CHECKLIST: PLEASE START HERE ***

The single most important feature of melange is that we can build Wolfi.

Many changes to melange introduce a risk of breaking the build, and sometimes
these are not flushed out until a package is changed (much) later.  This
pertains to basic execution, SCA changes, linter changes, and more.
-->

### Functional Changes

- [ ] This change can build all of Wolfi without errors (describe results in notes)

Notes:

### SCA Changes

- [ ] Examining several representative APKs show no regression / the desired effect (details in notes)

Notes:

### Linter

- [ ] The new check is clean across Wolfi
- [ ] The new check is opt-in or a warning

Notes:
