### PR TITLE
Add multiple Python packages post-linter

### DIFF
--- a/pkg/linter/defaults/defaults.go
+++ b/pkg/linter/defaults/defaults.go
@@ -21,6 +21,7 @@ var DefaultLinters = []string{
 	"dev",
 	"empty",
 	"opt",
+	"pythonmultiple",
 	"srv",
 	"setuidgid",
 	"strip",

--- a/pkg/linter/linter.go
+++ b/pkg/linter/linter.go
@@ -357,6 +357,11 @@ func pythonMultiplePackagesPostLinter(_ LinterContext, fsys fs.FS) error {
 			// Exclude tests
 			continue
 		}
+		
+		if base == "doc" || base == "docs" {
+			// Exclude docs
+			continue
+		}
 
 		ext := filepath.Ext(base)
 		if ext == ".egg-info" || ext == ".dist-info" || ext == ".pth" || ext == ".so" {

--- a/pkg/linter/linter.go
+++ b/pkg/linter/linter.go
@@ -348,10 +348,18 @@ func pythonMultiplePackagesPostLinter(_ LinterContext, fsys fs.FS) error {
 	pmatches := []string{}
 	for _, m := range matches {
 		base := filepath.Base(m)
-		if base == "__pycache__" || strings.HasSuffix(base, ".egg-info") {
-			// Exclude pycache and egg info
+		if base == "__pycache__" {
+			// Exclude pycache
 			continue
 		}
+
+		ext := filepath.Ext(base)
+		if ext == ".egg-info" || ext == ".dist-info" || ext == ".pth" || ext == ".so" {
+			// Exclude various metadata files and .so files
+			// TODO(Elizafox): Smarter logic for .so files
+			continue
+		}
+
 		pmatches = append(pmatches, fmt.Sprintf("%q", base))
 	}
 

--- a/pkg/linter/linter.go
+++ b/pkg/linter/linter.go
@@ -357,7 +357,7 @@ func pythonMultiplePackagesPostLinter(_ LinterContext, fsys fs.FS) error {
 			// Exclude tests
 			continue
 		}
-		
+
 		if base == "doc" || base == "docs" {
 			// Exclude docs
 			continue

--- a/pkg/linter/linter.go
+++ b/pkg/linter/linter.go
@@ -344,17 +344,20 @@ func pythonMultiplePackagesPostLinter(_ LinterContext, fsys fs.FS) error {
 		return fmt.Errorf("Error checking for Python packages: %w", err)
 	}
 
-	// Exclude __pycache__
+	// Filter matches
 	pmatches := []string{}
 	for _, m := range matches {
-		if filepath.Base(m) == "__pycache__" {
+		base := filepath.Base(m)
+		if base == "__pycache__" || strings.HasSuffix(base, ".egg-info") {
+			// Exclude pycache and egg info
 			continue
 		}
-		pmatches = append(pmatches, m)
+		pmatches = append(pmatches, fmt.Sprintf("%q", base))
 	}
 
 	if len(pmatches) > 1 {
-		return fmt.Errorf("Multiple Python packages detected: %d found", len(matches))
+		smatches := strings.Join(pmatches, ", ")
+		return fmt.Errorf("Multiple Python packages detected: %d found (%s)", len(pmatches), smatches)
 	}
 
 	return nil

--- a/pkg/linter/linter.go
+++ b/pkg/linter/linter.go
@@ -325,7 +325,7 @@ func emptyPostLinter(_ LinterContext, fsys fs.FS) error {
 }
 
 func pythonMultiplePackagesPostLinter(_ LinterContext, fsys fs.FS) error {
-	pythondirs, err := fs.Glob(fsys, filepath.Join("usr", "lib", "python-3.*"))
+	pythondirs, err := fs.Glob(fsys, filepath.Join("usr", "lib", "python3.*"))
 	if err != nil {
 		// Shouldn't get here, per the Go docs.
 		return fmt.Errorf("Error checking for Python site directories: %w", err)
@@ -344,7 +344,16 @@ func pythonMultiplePackagesPostLinter(_ LinterContext, fsys fs.FS) error {
 		return fmt.Errorf("Error checking for Python packages: %w", err)
 	}
 
-	if len(matches) > 1 {
+	// Exclude __pycache__
+	pmatches := []string{}
+	for _, m := range matches {
+		if filepath.Base(m) == "__pycache__" {
+			continue
+		}
+		pmatches = append(pmatches, m)
+	}
+
+	if len(pmatches) > 1 {
 		return fmt.Errorf("Multiple Python packages detected: %d found", len(matches))
 	}
 

--- a/pkg/linter/linter.go
+++ b/pkg/linter/linter.go
@@ -353,6 +353,11 @@ func pythonMultiplePackagesPostLinter(_ LinterContext, fsys fs.FS) error {
 			continue
 		}
 
+		if base == "test" || base == "tests" {
+			// Exclude tests
+			continue
+		}
+
 		ext := filepath.Ext(base)
 		if ext == ".egg-info" || ext == ".dist-info" || ext == ".pth" || ext == ".so" {
 			// Exclude various metadata files and .so files

--- a/pkg/linter/linter.go
+++ b/pkg/linter/linter.go
@@ -365,13 +365,18 @@ func pythonMultiplePackagesPostLinter(_ LinterContext, fsys fs.FS) error {
 		}
 
 		ext := filepath.Ext(base)
-		base = base[:len(ext)]
-
 		if ext == ".egg-info" || ext == ".dist-info" || ext == ".pth" {
 			// Exclude various metadata files and .so files
 			continue
 		}
 
+		if len(ext) > 0 {
+			base = base[:len(ext)]
+			if base == "" {
+				// No empty strings
+				continue
+			}
+		}
 		pmatches[fmt.Sprintf("%q", base)] = struct{}{}
 	}
 
@@ -380,9 +385,10 @@ func pythonMultiplePackagesPostLinter(_ LinterContext, fsys fs.FS) error {
 		slmatches := make([]string, len(pmatches))
 		for k := range pmatches {
 			slmatches[i] = k
+			i++
 		}
 		smatches := strings.Join(slmatches, ", ")
-		return fmt.Errorf("Multiple Python packages detected: %d found (%s)", len(pmatches), smatches)
+		return fmt.Errorf("Multiple Python packages detected: %d found (%s)", len(slmatches), smatches)
 	}
 
 	return nil

--- a/pkg/linter/linter.go
+++ b/pkg/linter/linter.go
@@ -348,8 +348,9 @@ func pythonMultiplePackagesPostLinter(_ LinterContext, fsys fs.FS) error {
 	pmatches := []string{}
 	for _, m := range matches {
 		base := filepath.Base(m)
-		if base == "__pycache__" {
-			// Exclude pycache
+
+		if strings.HasPrefix(base, "_") {
+			// Ignore __pycache__ and internal packages
 			continue
 		}
 

--- a/pkg/linter/linter_test.go
+++ b/pkg/linter/linter_test.go
@@ -210,16 +210,16 @@ func Test_pythonMultiplePackagesLinter(t *testing.T) {
 	// Base dir
 	pythonPathdir := filepath.Join(dir, "usr", "lib", "python3.14", "site-packages")
 
-	// Make one "package"
-	packagedir := filepath.Join(pythonPathdir, "foo")
-	err = os.MkdirAll(packagedir, 0700)
-	assert.NoError(t, err)
-
 	linters := cfg.Package.Checks.GetLinters()
 	assert.Equal(t, linters, []string{"pythonmultiple"})
 
 	fsys := os.DirFS(dir)
 	lctx := NewLinterContext(cfg.Package.Name, fsys)
+
+	// Make one "package"
+	packagedir := filepath.Join(pythonPathdir, "foo")
+	err = os.MkdirAll(packagedir, 0700)
+	assert.NoError(t, err)
 
 	// One package should not trip it
 	called := false
@@ -252,8 +252,8 @@ func Test_pythonMultiplePackagesLinter(t *testing.T) {
 	}, linters))
 	assert.False(t, called)
 
-	// .so files should not count
-	_, err = os.Create(filepath.Join(pythonPathdir, "foopkg.so"))
+	// .so files duplicate with a dir should not count
+	_, err = os.Create(filepath.Join(pythonPathdir, "foo.so"))
 	assert.NoError(t, err)
 	assert.NoError(t, lctx.LintPackageFs(fsys, func(err error) {
 		called = true
@@ -268,7 +268,7 @@ func Test_pythonMultiplePackagesLinter(t *testing.T) {
 	}, linters))
 	assert.False(t, called)
 
-	// Make another "package"
+	// Make another "package" (at this point we should have 2)
 	packagedir = filepath.Join(pythonPathdir, "bar")
 	err = os.MkdirAll(packagedir, 0700)
 	assert.NoError(t, err)

--- a/pkg/linter/linter_test.go
+++ b/pkg/linter/linter_test.go
@@ -228,6 +228,46 @@ func Test_pythonMultiplePackagesLinter(t *testing.T) {
 	}, linters))
 	assert.False(t, called)
 
+	// Egg info files should not count
+	_, err = os.Create(filepath.Join(pythonPathdir, "fooegg-0.1-py3.14.egg-info"))
+	assert.NoError(t, err)
+	assert.NoError(t, lctx.LintPackageFs(fsys, func(err error) {
+		called = true
+	}, linters))
+	assert.False(t, called)
+
+	// dist info files should not count
+	_, err = os.Create(filepath.Join(pythonPathdir, "foodist-0.1-py3.14.dist-info"))
+	assert.NoError(t, err)
+	assert.NoError(t, lctx.LintPackageFs(fsys, func(err error) {
+		called = true
+	}, linters))
+	assert.False(t, called)
+
+	// pth files should not count
+	_, err = os.Create(filepath.Join(pythonPathdir, "foopth-0.1-py3.14.pth"))
+	assert.NoError(t, err)
+	assert.NoError(t, lctx.LintPackageFs(fsys, func(err error) {
+		called = true
+	}, linters))
+	assert.False(t, called)
+
+	// .so files should not count
+	_, err = os.Create(filepath.Join(pythonPathdir, "foopkg.so"))
+	assert.NoError(t, err)
+	assert.NoError(t, lctx.LintPackageFs(fsys, func(err error) {
+		called = true
+	}, linters))
+	assert.False(t, called)
+
+	// __pycache__ dirs should not count
+	err = os.MkdirAll(filepath.Join(pythonPathdir, "__pycache__"), 0700)
+	assert.NoError(t, err)
+	assert.NoError(t, lctx.LintPackageFs(fsys, func(err error) {
+		called = true
+	}, linters))
+	assert.False(t, called)
+
 	// Make another "package"
 	packagedir = filepath.Join(pythonPathdir, "bar")
 	err = os.MkdirAll(packagedir, 0700)

--- a/pkg/linter/linter_test.go
+++ b/pkg/linter/linter_test.go
@@ -208,7 +208,7 @@ func Test_pythonMultiplePackagesLinter(t *testing.T) {
 	}
 
 	// Base dir
-	pythonPathdir := filepath.Join(dir, "usr", "lib", "python-3.14", "site-packages")
+	pythonPathdir := filepath.Join(dir, "usr", "lib", "python3.14", "site-packages")
 
 	// Make one "package"
 	packagedir := filepath.Join(pythonPathdir, "foo")


### PR DESCRIPTION
Take two after resolving git issues.

This implements a lint checking if a package contains multiple Python packages.

It's rather simplistic at the moment but I think this should get the job done.

### Linter

- [x] The new check is clean across Wolfi
- [x] The new check is opt-in or a warning
