### PR TITLE
Centralize SOURCE_DATE_EPOCH parsing.

### DIFF
--- a/pkg/util/env.go
+++ b/pkg/util/env.go
@@ -1,0 +1,55 @@
+// Copyright 2023 Chainguard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package util
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"chainguard.dev/apko/pkg/log"
+	"chainguard.dev/melange/pkg/logger"
+)
+
+// SourceDateEpoch parses the SOURCE_DATE_EPOCH environment variable.
+// If it is not set, it returns the defaultTime.
+// If it is set, it MUST be an ASCII representation of an integer.
+// If it is malformed, it returns an error.
+func SourceDateEpoch(defaultTime time.Time) (time.Time, error) {
+	return SourceDateEpochWithLogger(logger.NopLogger{}, defaultTime)
+}
+
+// SourceDateEpochWithLogger is the same as SourceDateEpoch but will log warning messages
+// to the provided logger.
+func SourceDateEpochWithLogger(l log.Logger, defaultTime time.Time) (time.Time, error) {
+	v := strings.TrimSpace(os.Getenv("SOURCE_DATE_EPOCH"))
+	if v == "" {
+		l.Warnf("SOURCE_DATE_EPOCH is specified but empty, setting it to %v", defaultTime)
+		return defaultTime, nil
+	}
+
+	// The value MUST be an ASCII representation of an integer
+	// with no fractional component, identical to the output
+	// format of date +%s.
+	sec, err := strconv.ParseInt(v, 10, 64)
+	if err != nil {
+		// If the value is malformed, the build process
+		// SHOULD exit with a non-zero error code.
+		return defaultTime, fmt.Errorf("failed to parse SOURCE_DATE_EPOCH: %w", err)
+	}
+
+	return time.Unix(sec, 0), nil
+}

--- a/pkg/util/env_test.go
+++ b/pkg/util/env_test.go
@@ -1,0 +1,81 @@
+// Copyright 2023 Chainguard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package util
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSourceDateEpoch(t *testing.T) {
+	tests := []struct {
+		name            string
+		sourceDateEpoch string
+		defaultTime     time.Time
+		want            time.Time
+		wantErr         bool
+	}{
+		{
+			name:        "empty",
+			defaultTime: time.Time{},
+			want:        time.Time{},
+		},
+		{
+			name:            "strings",
+			sourceDateEpoch: "    ",
+			defaultTime:     time.Time{},
+			want:            time.Time{},
+		},
+		{
+			name:        "defaultTime",
+			defaultTime: time.Unix(1234567890, 0),
+			want:        time.Unix(1234567890, 0),
+		},
+		{
+			name:            "0",
+			sourceDateEpoch: "0",
+			defaultTime:     time.Unix(1234567890, 0),
+			want:            time.Unix(0, 0),
+		},
+		{
+			name:            "1234567890",
+			sourceDateEpoch: "1234567890",
+			defaultTime:     time.Unix(0, 0),
+			want:            time.Unix(1234567890, 0),
+		},
+		{
+			name:            "invalid date",
+			sourceDateEpoch: "tacocat",
+			defaultTime:     time.Unix(0, 0),
+			wantErr:         true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.sourceDateEpoch != "" {
+				t.Setenv("SOURCE_DATE_EPOCH", tt.sourceDateEpoch)
+			}
+			got, err := SourceDateEpoch(tt.defaultTime)
+			if err != nil {
+				if !tt.wantErr {
+					t.Fatalf("SourceDateEpoch() error = %v, wantErr %v", err, tt.wantErr)
+				}
+				return
+			}
+			if !got.Equal(tt.want) {
+				t.Errorf("SourceDateEpoch() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Before we could get into weird situations where `SOURCE_DATE_EPOCH=""` particularly with Makefiles doing conditional setting. os.LookupEnv will treat "" as the env being set (https://go.dev/play/p/sOI08BfjdhV) which means that we can get inconsistent behavior where the melanage build will default SOURCE_DATE_EPOCH to 0, but the SBOM generation would not.

This consolidates the parsing behavior so we are consistent everywhere we are parsing the environment var.

## Melange Pull Request Template

<!--
*** PULL REQUEST CHECKLIST: PLEASE START HERE ***

The single most important feature of melange is that we can build Wolfi.

Many changes to melange introduce a risk of breaking the build, and sometimes
these are not flushed out until a package is changed (much) later.  This
pertains to basic execution, SCA changes, linter changes, and more.
-->

### Functional Changes

- [ ] This change can build all of Wolfi without errors (describe results in notes)

Notes:

### SCA Changes

- [ ] Examining several representative APKs show no regression / the desired effect (details in notes)

Notes:

### Linter

- [ ] The new check is clean across Wolfi
- [ ] The new check is opt-in or a warning

Notes:
