### PR TITLE
Add Python docs linter

### DIFF
--- a/pkg/linter/defaults/defaults.go
+++ b/pkg/linter/defaults/defaults.go
@@ -21,6 +21,7 @@ var DefaultLinters = []string{
 	"dev",
 	"empty",
 	"opt",
+	"pythondocs",
 	"pythonmultiple",
 	"srv",
 	"setuidgid",


### PR DESCRIPTION
This checks if a doc or docs "package" was left in site-packages. This seems to be a recurring issue, so let's make a lint for it.

Fixes #778

## Melange Pull Request Template

<!--
*** PULL REQUEST CHECKLIST: PLEASE START HERE ***

The single most important feature of melange is that we can build Wolfi.

Many changes to melange introduce a risk of breaking the build, and sometimes
these are not flushed out until a package is changed (much) later.  This
pertains to basic execution, SCA changes, linter changes, and more.
-->

### Functional Changes

- [x] This change can build all of Wolfi without errors (describe results in notes)

Notes:

### Linter

- [ ] The new check is clean across Wolfi
- [x] The new check is opt-in or a warning