### PR TITLE
readlinkfs: ignore security.selinux xattrs

### DIFF
--- a/pkg/build/readlinkfs.go
+++ b/pkg/build/readlinkfs.go
@@ -93,6 +93,7 @@ func stringsFromByteSlice(buf []byte) []string {
 var xattrIgnoreList = map[string]bool{
 	"com.apple.provenance": true,
 	"security.csm":         true,
+	"security.selinux":     true,
 }
 
 func (f *rlfs) ListXattrs(path string) (map[string][]byte, error) {


### PR DESCRIPTION
Packages built on a host with selinux enabled will inherit filesytem xattr labels from the host and result in 'operation not permitted' errors when installed in an unpriv'd docker container.

fixes #787

## Melange Pull Request Template

<!--
*** PULL REQUEST CHECKLIST: PLEASE START HERE ***

The single most important feature of melange is that we can build Wolfi.

Many changes to melange introduce a risk of breaking the build, and sometimes
these are not flushed out until a package is changed (much) later.  This
pertains to basic execution, SCA changes, linter changes, and more.
-->

### Functional Changes

- [ ] This change can build all of Wolfi without errors (describe results in notes)

Notes:

### SCA Changes

- [ ] Examining several representative APKs show no regression / the desired effect (details in notes)

Notes:

### Linter

- [ ] The new check is clean across Wolfi
- [ ] The new check is opt-in or a warning

Notes:
