### PR TITLE
ruby: add pipeline to install the gemspec defined runtime deps

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -26,6 +26,7 @@ jobs:
         - mbedtls.yaml
         - minimal.yaml
         - sshfs.yaml
+        - build-ruby-gitlab-exporter.yaml
 
     steps:
     - name: Fetch dependencies

--- a/examples/build-ruby-gitlab-exporter.yaml
+++ b/examples/build-ruby-gitlab-exporter.yaml
@@ -19,6 +19,10 @@ package:
 
 environment:
   contents:
+    keyring:
+      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    repositories:
+      - https://packages.wolfi.dev/os
     packages:
       - bash
       - build-base
@@ -39,8 +43,6 @@ pipeline:
       repository: https://gitlab.com/gitlab-org/ruby/gems/gitlab-exporter.git
       tag: v${{package.version}}
       expected-commit: 590c4261bd09b341742ee5249225b3aaac421445
-
-  - uses: ruby/unlock-spec
 
   # GitLab-Exporter Runtime Dependencies
   - uses: ruby/install_runtime_deps

--- a/examples/build-ruby-gitlab-exporter.yaml
+++ b/examples/build-ruby-gitlab-exporter.yaml
@@ -1,0 +1,60 @@
+package:
+  name: gitlab-exporter
+  version: 13.4.1
+  epoch: 0
+  description: GitLab Exporter is a Prometheus Web exporter.
+  copyright:
+    - license: MIT
+  dependencies:
+    runtime:
+      - jemalloc
+      - ruby-3.2
+      - libpq-15
+      - busybox
+      - ruby3.2-webrick
+      - ruby3.2-faraday
+      - ruby3.2-faraday-excon
+      - ruby3.2-rack
+      - ruby3.2-bundler
+
+environment:
+  contents:
+    packages:
+      - bash
+      - build-base
+      - busybox
+      - libpq-15
+      - postgresql-15-dev
+      - ruby-3.2
+      - ruby-3.2-dev
+      - ruby3.2-bundler
+
+vars:
+  gem: gitlab-exporter
+
+pipeline:
+  # GitLab-Exporter
+  - uses: git-checkout
+    with:
+      repository: https://gitlab.com/gitlab-org/ruby/gems/gitlab-exporter.git
+      tag: v${{package.version}}
+      expected-commit: 590c4261bd09b341742ee5249225b3aaac421445
+
+  - uses: ruby/unlock-spec
+
+  # GitLab-Exporter Runtime Dependencies
+  - uses: ruby/install_runtime_deps
+    with:
+      gem: ${{vars.gem}}
+
+  - uses: ruby/build
+    with:
+      gem: ${{vars.gem}}
+
+  - uses: ruby/install
+    with:
+      gem: ${{vars.gem}}
+      version: ${{package.version}}
+
+  - uses: ruby/clean
+

--- a/examples/build-ruby-gitlab-exporter.yaml
+++ b/examples/build-ruby-gitlab-exporter.yaml
@@ -16,7 +16,6 @@ package:
       - ruby3.2-faraday-excon
       - ruby3.2-rack
       - ruby3.2-bundler
-
 environment:
   contents:
     keyring:
@@ -32,10 +31,8 @@ environment:
       - ruby-3.2
       - ruby-3.2-dev
       - ruby3.2-bundler
-
 vars:
   gem: gitlab-exporter
-
 pipeline:
   # GitLab-Exporter
   - uses: git-checkout
@@ -43,20 +40,15 @@ pipeline:
       repository: https://gitlab.com/gitlab-org/ruby/gems/gitlab-exporter.git
       tag: v${{package.version}}
       expected-commit: 590c4261bd09b341742ee5249225b3aaac421445
-
   # GitLab-Exporter Runtime Dependencies
   - uses: ruby/install_runtime_deps
     with:
       gem: ${{vars.gem}}
-
   - uses: ruby/build
     with:
       gem: ${{vars.gem}}
-
   - uses: ruby/install
     with:
       gem: ${{vars.gem}}
       version: ${{package.version}}
-
   - uses: ruby/clean
-

--- a/pkg/build/pipelines/ruby/install_runtime_deps.yaml
+++ b/pkg/build/pipelines/ruby/install_runtime_deps.yaml
@@ -1,0 +1,62 @@
+name: Install a ruby gem runtime dependencies
+needs:
+  packages:
+    - busybox
+    - ca-certificates-bundle
+inputs:
+  dir:
+    description: |
+      The working directory
+    default: .
+  gem:
+    description: |
+      Gem name
+    required: false
+  gem-file:
+    description: |
+      The full filename of the gem to build
+    required: false
+  opts:
+    description: |
+      Options to pass to the gem install command
+    default: ''
+    required: false
+pipeline:
+  - name: Check ruby
+    runs: |
+      if ! [ -x "$(command -v ruby)" ]; then
+        echo 'ERROR: Ruby is not installed.'
+        exit 1
+      fi
+  - name: Ruby install runtime dependencies
+    runs: |
+      cd ${{inputs.dir}}
+
+      if [ -z "${{inputs.gem}}" ] && [ -z "${{inputs.gem-file}}" ]; then
+        echo "ERROR: You need to specify gem or gem-file"
+        exit 1
+      fi
+
+      [ -n '${{inputs.gem}}' ] && GEM=${{inputs.gem}}.gemspec
+
+       # Replace this with the actual path to your ${{inputs.gemspec}}.gemspec file
+      GEMSPEC_FILE="./${{inputs.gem}}.gemspec"
+
+      # This is your target directory for installing the gems
+      # I'm assuming it's an environment variable, change as needed
+      INSTALL_GEM_DIR=${{targets.contextdir}}$(ruby -e 'puts Gem.default_dir')/
+
+      TARGET_DIR_BIN="${{targets.contextdir}}/usr/bin"
+
+      # Use grep and sed to extract the lines containing runtime dependencies
+      grep 's.add_runtime_dependency' $GEMSPEC_FILE | sed -E 's/s.add_runtime_dependency[[:space:]]+"([^"]+)",[[:space:]]+"([^"]+)"/\1 \2/' | sed -e 's/~> //' -e 's/=> //' -e 's/= //' | while read -r GEM_NAME GEM_VERSION; do
+        # Run the gem install command
+        gem install $GEM_NAME
+          --version $GEM_VERSION \
+          --bindir ${TARGET_DIR_BIN} \
+          --install-dir $INSTALL_GEM_DIR --verbose \
+          --no-document \
+          --verbose \
+          --local \
+          ${{inputs.opts}}
+      done

--- a/pkg/build/pipelines/ruby/install_runtime_deps.yaml
+++ b/pkg/build/pipelines/ruby/install_runtime_deps.yaml
@@ -42,7 +42,7 @@ pipeline:
        # Replace this with the actual path to your ${{inputs.gemspec}}.gemspec file
       GEMSPEC_FILE="./${{inputs.gem}}.gemspec"
 
-      # This is your target directory for installing the gems
+      # This is your target directory for installing the dependecy of the gem
       # I'm assuming it's an environment variable, change as needed
       INSTALL_GEM_DIR=${{targets.contextdir}}$(ruby -e 'puts Gem.default_dir')/
 
@@ -51,12 +51,11 @@ pipeline:
       # Use grep and sed to extract the lines containing runtime dependencies
       grep 's.add_runtime_dependency' $GEMSPEC_FILE | sed -E 's/s.add_runtime_dependency[[:space:]]+"([^"]+)",[[:space:]]+"([^"]+)"/\1 \2/' | sed -e 's/~> //' -e 's/=> //' -e 's/= //' | while read -r GEM_NAME GEM_VERSION; do
         # Run the gem install command
-        gem install $GEM_NAME
+        gem install $GEM_NAME \
           --version $GEM_VERSION \
           --bindir ${TARGET_DIR_BIN} \
           --install-dir $INSTALL_GEM_DIR --verbose \
           --no-document \
           --verbose \
-          --local \
           ${{inputs.opts}}
       done


### PR DESCRIPTION
## Melange Pull Request Template

<!--
*** PULL REQUEST CHECKLIST: PLEASE START HERE ***

The single most important feature of melange is that we can build Wolfi.

Many changes to melange introduce a risk of breaking the build, and sometimes
these are not flushed out until a package is changed (much) later.  This
pertains to basic execution, SCA changes, linter changes, and more.
-->

Fixes #785. This pipeline installs the gem runtime dependencies that are required by a specific ruby project.

### Functional Changes

- [ ] This change can build all of Wolfi without errors (describe results in notes)

Notes:

### SCA Changes

- [ ] Examining several representative APKs show no regression / the desired effect (details in notes)

Notes:

### Linter

- [ ] The new check is clean across Wolfi
- [ ] The new check is opt-in or a warning

Notes:
