### PR TITLE
Add python/test linter

### DIFF
--- a/pkg/linter/defaults/defaults.go
+++ b/pkg/linter/defaults/defaults.go
@@ -23,6 +23,7 @@ var DefaultLinters = []string{
 	"opt",
 	"python/docs",
 	"python/multiple",
+	"python/test",
 	"srv",
 	"setuidgid",
 	"strip",

--- a/pkg/linter/linter.go
+++ b/pkg/linter/linter.go
@@ -119,6 +119,11 @@ var postLinterMap = map[string]postLinter{
 		FailOnError: false,
 		Explain:     "Split this package up into multiple packages and verify you are not improperly using pip install",
 	},
+	"python/test": postLinter{
+		LinterFunc:  pythonTestPostLinter,
+		FailOnError: false,
+		Explain:     "Remove all test directories from the package",
+	},
 }
 
 var isDevRegex = regexp.MustCompile("^dev/")
@@ -364,7 +369,7 @@ func pythonDocsPostLinter(_ LinterContext, fsys fs.FS) error {
 	for _, m := range packages {
 		base := filepath.Base(m)
 		if base == "doc" || base == "docs" {
-			return fmt.Errorf("Docs diretory encountered in Python directory")
+			return fmt.Errorf("Docs directory encountered in Python site-packages directory")
 		}
 	}
 
@@ -422,6 +427,22 @@ func pythonMultiplePackagesPostLinter(_ LinterContext, fsys fs.FS) error {
 		}
 		smatches := strings.Join(slmatches, ", ")
 		return fmt.Errorf("Multiple Python packages detected: %d found (%s)", len(slmatches), smatches)
+	}
+
+	return nil
+}
+
+func pythonTestPostLinter(_ LinterContext, fsys fs.FS) error {
+	packages, err := getPythonSitePackages(fsys)
+	if err != nil {
+		return err
+	}
+
+	for _, m := range packages {
+		base := filepath.Base(m)
+		if base == "test" || base == "tests" {
+			return fmt.Errorf("Tests directory encountered in Python site-packages directory")
+		}
 	}
 
 	return nil


### PR DESCRIPTION
This checks if tests are in the Python site-packages directory. This has been encountered in the wild.

## Melange Pull Request Template

<!--
*** PULL REQUEST CHECKLIST: PLEASE START HERE ***

The single most important feature of melange is that we can build Wolfi.

Many changes to melange introduce a risk of breaking the build, and sometimes
these are not flushed out until a package is changed (much) later.  This
pertains to basic execution, SCA changes, linter changes, and more.
-->

### Linter

- [x] The new check is clean across Wolfi
- [x] The new check is opt-in or a warning