### PR TITLE
Add .apko.lock.json to APK control section

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -94,6 +94,8 @@ type Build struct {
 	FailOnLintWarning  bool
 
 	EnabledBuildOptions []string
+
+	resolvedApkoConfig apko_types.ImageConfiguration
 }
 
 var ErrSkipThisArch = errors.New("error: skip this arch")
@@ -538,6 +540,26 @@ func WithPackageCacheDir(apkCacheDir string) Option {
 	}
 }
 
+func (b *Build) resolveConfig(ctx context.Context, bc *apko_build.Context) error {
+	ic := bc.ImageConfiguration()
+	pkgs, _, err := bc.BuildPackageList(ctx)
+	if err != nil {
+		return fmt.Errorf("resolving package versions: %w", err)
+	}
+	resolved := make([]string, 0, len(pkgs))
+	for _, pkg := range pkgs {
+		resolved = append(resolved, fmt.Sprintf("%s=%s", pkg.Name, pkg.Version))
+	}
+	ic.Contents.Packages = resolved
+	ic.Archs = []apko_types.Architecture{b.Arch}
+	ic.Contents.Repositories = append(ic.Contents.Repositories, b.ExtraRepos...)
+	ic.Contents.Keyring = append(ic.Contents.Keyring, b.ExtraKeys...)
+
+	b.resolvedApkoConfig = ic
+
+	return nil
+}
+
 // BuildGuest invokes apko to build the guest environment.
 func (b *Build) BuildGuest(ctx context.Context) error {
 	ctx, span := otel.Tracer("melange").Start(ctx, "BuildGuest")
@@ -570,6 +592,10 @@ func (b *Build) BuildGuest(ctx context.Context) error {
 	}
 
 	bc.Summarize()
+
+	if err := b.resolveConfig(ctx, bc); err != nil {
+		return fmt.Errorf("locking apko config: %w", err)
+	}
 
 	// lay out the contents for the image in a directory.
 	if err := bc.BuildImage(ctx); err != nil {

--- a/pkg/build/package.go
+++ b/pkg/build/package.go
@@ -243,6 +243,14 @@ func (pc *PackageBuild) generateControlSection(ctx context.Context) ([]byte, err
 		return nil, fmt.Errorf("unable to build control FS: %w", err)
 	}
 
+	locked, err := json.Marshal(pc.Build.resolvedApkoConfig)
+	if err != nil {
+		return nil, fmt.Errorf("unable to marshal apko config: %w", err)
+	}
+	if err := fsys.WriteFile(".apko.lock.json", locked, 0644); err != nil {
+		return nil, fmt.Errorf("unable to write .apko.lock.json: %w", err)
+	}
+
 	if pc.Scriptlets.Trigger.Script != "" {
 		// #nosec G306 -- scriptlets must be executable
 		if err := fsys.WriteFile(".trigger", []byte(pc.Scriptlets.Trigger.Script), 0755); err != nil {


### PR DESCRIPTION
This generates the locked apko config for the guest container image that is used to build the APK and puts writes it as .apko.lock.json in the APK's control section.

We could alternatively stick this in the (or another) SBOM, but that has triggered false positives with security scanners in the past.

## Melange Pull Request Template

<!--
*** PULL REQUEST CHECKLIST: PLEASE START HERE ***

The single most important feature of melange is that we can build Wolfi.

Many changes to melange introduce a risk of breaking the build, and sometimes
these are not flushed out until a package is changed (much) later.  This
pertains to basic execution, SCA changes, linter changes, and more.
-->

### Functional Changes

- [ ] This change can build all of Wolfi without errors (describe results in notes)

Notes:

### SCA Changes

- [ ] Examining several representative APKs show no regression / the desired effect (details in notes)

Notes:

### Linter

- [ ] The new check is clean across Wolfi
- [ ] The new check is opt-in or a warning

Notes:
