### PR TITLE
Add linters for documentation and object files

### DIFF
--- a/pkg/linter/defaults/defaults.go
+++ b/pkg/linter/defaults/defaults.go
@@ -32,8 +32,10 @@ const (
 // Default linters run regardless of whether we are dealing with an APK or build
 var defaultLinters = []string{
 	"dev",
+	"documentation",
 	"empty",
 	"opt",
+	"object",
 	"python/docs",
 	"python/multiple",
 	"python/test",

--- a/pkg/linter/linter_test.go
+++ b/pkg/linter/linter_test.go
@@ -178,6 +178,64 @@ func Test_optLinter(t *testing.T) {
 	assert.True(t, called)
 }
 
+func Test_objectLinter(t *testing.T) {
+	dir, err := os.MkdirTemp("", "melange.XXXXX")
+	defer os.RemoveAll(dir)
+	assert.NoError(t, err)
+
+	cfg := config.Configuration{
+		Package: config.Package{
+			Name:    "testobject",
+			Version: "4.2.0",
+			Epoch:   0,
+			Checks:  checksOnly("object"),
+		},
+	}
+
+	pathdir := filepath.Join(dir, "")
+	err = os.MkdirAll(pathdir, 0700)
+	assert.NoError(t, err)
+	_, err = os.Create(filepath.Join(pathdir, "test.o"))
+	assert.NoError(t, err)
+
+	linters := cfg.Package.Checks.GetLinters()
+	assert.Equal(t, linters, []string{"object"})
+	called := false
+	assert.NoError(t, LintBuild(cfg.Package.Name, dir, func(err error) {
+		called = true
+	}, linters))
+	assert.True(t, called)
+}
+
+func Test_documentationLinter(t *testing.T) {
+	dir, err := os.MkdirTemp("", "melange.XXXXX")
+	defer os.RemoveAll(dir)
+	assert.NoError(t, err)
+
+	cfg := config.Configuration{
+		Package: config.Package{
+			Name:    "testobject",
+			Version: "4.2.0",
+			Epoch:   0,
+			Checks:  checksOnly("documentation"),
+		},
+	}
+
+	pathdir := filepath.Join(dir, "")
+	err = os.MkdirAll(pathdir, 0700)
+	assert.NoError(t, err)
+	_, err = os.Create(filepath.Join(pathdir, "test.md"))
+	assert.NoError(t, err)
+
+	linters := cfg.Package.Checks.GetLinters()
+	assert.Equal(t, linters, []string{"documentation"})
+	called := false
+	assert.NoError(t, LintBuild(cfg.Package.Name, dir, func(err error) {
+		called = true
+	}, linters))
+	assert.True(t, called)
+}
+
 func Test_pythonDocsLinter(t *testing.T) {
 	dir, err := os.MkdirTemp("", "melange.XXXXX")
 	defer os.RemoveAll(dir)


### PR DESCRIPTION
The documentation linter checks for the presence of documentation files in non-documentation packages.

The object linter checks for the presence of intermediate object files in the generated packages.


### Functional Changes

- [ ] This change can build all of Wolfi without errors (describe results in notes)


Notes:
No breaking changes

### SCA Changes

- [ ] Examining several representative APKs show no regression / the desired effect (details in notes)

Notes:
No breaking changes

### Linter

- [ ] The new check is clean across Wolfi
- [x] The new check is opt-in or a warning

Notes:

