### PR TITLE
Add a new go pipeline to only manage deps

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -26,6 +26,7 @@ jobs:
         - mbedtls.yaml
         - minimal.yaml
         - sshfs.yaml
+        - go-build.yaml
 
     steps:
     - name: Fetch dependencies

--- a/examples/go-build.yaml
+++ b/examples/go-build.yaml
@@ -4,7 +4,7 @@
 #
 # This is a sample configuration file to demonstrate how to build a software
 # project using melange's built-in go/build pipeline.
-# 
+#
 # For more information about melange's built-in golang support check out:
 # https://github.com/chainguard-dev/melange/blob/main/docs/PIPELINES-GO.md
 #
@@ -27,11 +27,16 @@ pipeline:
     with:
       repository: https://github.com/puerco/hello.git
       destination: build-dir
-  - runs: |
-      git checkout ${{package.version}}
+      tag: ${{package.version}}
+      expected-commit: fed9b28e2973bee65bcc503c6ab6522e8bfdd3d1
+  - uses: go/deps
+    with:
+      modroot: build-dir
+      deps: github.com/sirupsen/logrus@v1.9.1
   - uses: go/build
     with:
       modroot: build-dir
       tags: enterprise
       packages: ./main.go
       output: hello
+      deps: github.com/sirupsen/logrus@v1.9.3

--- a/pkg/build/pipelines/go/build.yaml
+++ b/pkg/build/pipelines/go/build.yaml
@@ -1,70 +1,68 @@
 name: Run a build using the go compiler
-
 needs:
   packages:
     - ${{inputs.go-package}}
     - busybox
     - ca-certificates-bundle
-
 inputs:
   go-package:
     description: |
       The go package to install
     default: go
-
   packages:
     description: |
       List of space-separated packages to compile. Files con also be specified.
       This value is passed as an argument to go build. All paths are relative
       to inputs.modroot.
     required: true
-
   tags:
     description: |
       A comma-separated list of build tags to pass to the go compiler
-
   output:
     description: |
       Filename to use when writing the binary. The final install location inside
       the apk will be in prefix / install-dir / output
     required: true
-
   vendor:
     description: |
       If true, the go mod command will also update the vendor directory
     default: "false"
-
   subpackage:
     description: |
       Indicates that the build will write to a subpackage target folder
     default: "false"
-
   modroot:
     default: "."
     required: false
     description: |
       Top directory of the go module, this is where go.mod lives. Before buiding
       the go pipeline wil cd into this directory.
-
   prefix:
     description: |
       Prefix to relocate binaries
     default: usr
-
   ldflags:
-    description:
-      List of [pattern=]arg to pass to the go compiler with -ldflags
-
+    description: List of [pattern=]arg to pass to the go compiler with -ldflags
   install-dir:
     description: |
       Directory where binaries will be installed
     default: bin
-
   deps:
     description: |
       space separated list of go modules to update before building. example: github.com/foo/bar@v1.2.3
-
 pipeline:
+  - runs: |
+      cd "${{inputs.modroot}}"
+
+      # Install any specified dependencies
+      if [ ! "${{inputs.deps}}" == "" ]; then
+        for dep in ${{inputs.deps}}; do
+          go get $dep
+        done
+        go mod tidy
+        # If vendor is specified, update the vendor directory
+        "${{inputs.vendor}}" && go mod vendor
+      fi
   - runs: |
       TAGS=""
       LDFLAGS=""
@@ -80,14 +78,4 @@ pipeline:
       BASE_PATH="${{inputs.prefix}}/${{inputs.install-dir}}/${{inputs.output}}"
 
       cd "${{inputs.modroot}}"
-
-      # Install any specified dependencies
-      if [ ! "${{inputs.deps}}" == "" ]; then
-        for dep in ${{inputs.deps}}; do
-          go get $dep
-        done
-        go mod tidy
-        # If vendor is specified, update the vendor directory
-        "${{inputs.vendor}}" && go mod vendor
-      fi
       go build -o "${{targets.contextdir}}"/${BASE_PATH} -tags "${TAGS}" -ldflags "${LDFLAGS}" -trimpath ${{inputs.packages}}

--- a/pkg/build/pipelines/go/deps.yaml
+++ b/pkg/build/pipelines/go/deps.yaml
@@ -1,0 +1,37 @@
+name: Run go mod tidy and vendor dependencies
+needs:
+  packages:
+    - "${{inputs.go-package}}"
+    - busybox
+    - ca-certificates-bundle
+inputs:
+  go-package:
+    description: |
+      The go package to install
+    default: go
+  vendor:
+    description: |
+      If true, the go mod command will also update the vendor directory
+    default: "false"
+  modroot:
+    default: "."
+    required: false
+    description: |
+      Top directory of the go module, this is where go.mod lives. Before buiding
+      the go pipeline wil cd into this directory.
+  deps:
+    description: |
+      space separated list of go modules to update before building. example: github.com/foo/bar@v1.2.3
+pipeline:
+  - runs: |
+      cd "${{inputs.modroot}}"
+
+      # Install any specified dependencies
+      if [ ! "${{inputs.deps}}" == "" ]; then
+        for dep in ${{inputs.deps}}; do
+          go get $dep
+        done
+        go mod tidy
+        # If vendor is specified, update the vendor directory
+        "${{inputs.vendor}}" && go mod vendor
+      fi


### PR DESCRIPTION
## Melange Pull Request Template

<!--
*** PULL REQUEST CHECKLIST: PLEASE START HERE ***

The single most important feature of melange is that we can build Wolfi.

Many changes to melange introduce a risk of breaking the build, and sometimes
these are not flushed out until a package is changed (much) later.  This
pertains to basic execution, SCA changes, linter changes, and more.
-->

This PR creates a separate go pipeline to manage golang dependencies keeping the current go/build compatible with the initial logic. With this new go pipeline, we can now separate the treatment of go dependencies from the go build commands that many times is handled in a different way depending of the project, e.g. using make targets.

### Functional Changes

- [x] This change can build all of Wolfi without errors (describe results in notes)


Notes:

### SCA Changes

- [ ] Examining several representative APKs show no regression / the desired effect (details in notes)

Notes:

### Linter

- [ ] The new check is clean across Wolfi
- [ ] The new check is opt-in or a warning

Notes:
