### PR TITLE
Fix deduplication of strings because slices.Compact doesn't sort the input

### DIFF
--- a/pkg/build/package.go
+++ b/pkg/build/package.go
@@ -29,8 +29,6 @@ import (
 	"strings"
 	"text/template"
 
-	"golang.org/x/exp/slices"
-
 	apko_types "chainguard.dev/apko/pkg/build/types"
 
 	"github.com/klauspost/compress/gzip"
@@ -38,6 +36,7 @@ import (
 
 	"chainguard.dev/melange/pkg/config"
 	"chainguard.dev/melange/pkg/sca"
+	"chainguard.dev/melange/pkg/util"
 
 	"chainguard.dev/apko/pkg/log"
 	"github.com/chainguard-dev/go-apk/pkg/tarball"
@@ -364,10 +363,10 @@ func (pc *PackageBuild) GenerateDependencies() error {
 	unvendored := removeSelfProvidedDeps(generated.Runtime, generated.Vendored)
 
 	newruntime := append(pc.Dependencies.Runtime, unvendored...)
-	pc.Dependencies.Runtime = slices.Compact(newruntime)
+	pc.Dependencies.Runtime = util.Dedup(newruntime)
 
 	newprovides := append(pc.Dependencies.Provides, generated.Provides...)
-	pc.Dependencies.Provides = slices.Compact(newprovides)
+	pc.Dependencies.Provides = util.Dedup(newprovides)
 
 	pc.Dependencies.Runtime = removeSelfProvidedDeps(pc.Dependencies.Runtime, pc.Dependencies.Provides)
 

--- a/pkg/build/pipeline.go
+++ b/pkg/build/pipeline.go
@@ -23,8 +23,6 @@ import (
 	"strconv"
 	"strings"
 
-	"golang.org/x/exp/slices"
-
 	"go.opentelemetry.io/otel"
 
 	"gopkg.in/yaml.v3"
@@ -478,7 +476,7 @@ func (pctx *PipelineContext) ApplyNeeds(pb *PipelineBuild) error {
 		}
 	}
 
-	ic.Contents.Packages = slices.Compact(ic.Contents.Packages)
+	ic.Contents.Packages = util.Dedup(ic.Contents.Packages)
 
 	for _, sp := range pctx.Pipeline.Pipeline {
 		spctx, err := NewPipelineContext(&sp, pb.Build.Logger)

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -15,6 +15,7 @@
 package util
 
 import (
+	"cmp"
 	"context"
 	"encoding/hex"
 	"fmt"
@@ -22,6 +23,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"slices"
 	"sort"
 )
 
@@ -114,4 +116,10 @@ func Contains[T comparable](s []T, e T) bool {
 		}
 	}
 	return false
+}
+
+// Dedup wraps slices.Sort and slices.Compact to deduplicate a slice.
+func Dedup[S ~[]E, E cmp.Ordered](s S) S {
+	slices.Sort(s)
+	return slices.Compact(s)
 }

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -1,0 +1,14 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDedup(t *testing.T) {
+	a := []int{0, 1, 2, 3, 1, 4, 5, 9, 16, 9, 12, 9, 9, 9, 13, 12, 15, 17, 15}
+	b := Dedup(a)
+
+	require.Equal(t, len(b), 12, "the deduplicated list should have 12 elements")
+}


### PR DESCRIPTION
`slices.Compact` requires the input to be sorted in order to deduplicate the list.