### PR TITLE
Remove impossible errors

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -974,10 +974,7 @@ func (b *Build) BuildPackage(ctx context.Context) error {
 
 	b.Logger.Printf("evaluating pipelines for package requirements")
 	for _, p := range b.Configuration.Pipeline {
-		pctx, err := NewPipelineContext(&p, b.Logger)
-		if err != nil {
-			return fmt.Errorf("unable to make pipeline context: %w", err)
-		}
+		pctx := NewPipelineContext(&p, b.Logger)
 
 		if err := pctx.ApplyNeeds(&pb); err != nil {
 			return fmt.Errorf("unable to apply pipeline requirements: %w", err)
@@ -991,10 +988,7 @@ func (b *Build) BuildPackage(ctx context.Context) error {
 		}
 		pb.Subpackage = spkgctx
 		for _, p := range spkgctx.Subpackage.Pipeline {
-			pctx, err := NewPipelineContext(&p, b.Logger)
-			if err != nil {
-				return fmt.Errorf("invalid pipeline context: %w", err)
-			}
+			pctx := NewPipelineContext(&p, b.Logger)
 			if err := pctx.ApplyNeeds(&pb); err != nil {
 				return fmt.Errorf("unable to apply pipeline requirements: %w", err)
 			}
@@ -1045,10 +1039,7 @@ func (b *Build) BuildPackage(ctx context.Context) error {
 		// run the main pipeline
 		b.Logger.Printf("running the main pipeline")
 		for _, p := range b.Configuration.Pipeline {
-			pctx, err := NewPipelineContext(&p, b.Logger)
-			if err != nil {
-				return fmt.Errorf("invalid pipeline context: %w", err)
-			}
+			pctx := NewPipelineContext(&p, b.Logger)
 			if _, err := pctx.Run(ctx, &pb); err != nil {
 				return fmt.Errorf("unable to run pipeline: %w", err)
 			}
@@ -1093,10 +1084,7 @@ func (b *Build) BuildPackage(ctx context.Context) error {
 			}
 
 			for _, p := range spctx.Subpackage.Pipeline {
-				pctx, err := NewPipelineContext(&p, b.Logger)
-				if err != nil {
-					return fmt.Errorf("invalid pipeline context: %w", err)
-				}
+				pctx := NewPipelineContext(&p, b.Logger)
 				if _, err := pctx.Run(ctx, &pb); err != nil {
 					return fmt.Errorf("unable to run pipeline: %w", err)
 				}

--- a/pkg/build/pipeline_test.go
+++ b/pkg/build/pipeline_test.go
@@ -135,9 +135,7 @@ func Test_substitutionNeedPackages(t *testing.T) {
 		},
 	}
 
-	log := logger.NopLogger{}
-	pctx, err := NewPipelineContext(p, log)
-	require.NoError(t, err)
+	pctx := NewPipelineContext(p, logger.NopLogger{})
 
 	pb := &PipelineBuild{
 		Package: pkgctx,
@@ -168,9 +166,7 @@ func Test_buildEvalRunCommand(t *testing.T) {
 		Environment: map[string]string{"FOO": "bar"},
 	}
 
-	log := logger.NopLogger{}
-	pctx, err := NewPipelineContext(p, log)
-	require.NoError(t, err)
+	pctx := NewPipelineContext(p, logger.NopLogger{})
 
 	debugOption := ' '
 	sysPath := "/foo"


### PR DESCRIPTION
Some of these constructors are redundant and/or have error return types that don't ever actually return an error.