### PR TITLE
Error early if uses and runs are both present

### DIFF
--- a/pkg/build/build_test.go
+++ b/pkg/build/build_test.go
@@ -164,6 +164,12 @@ func TestConfiguration_Load(t *testing.T) {
 			expected:            nil,
 		},
 		{
+			name:                "uses-and-runs",
+			skipConfigCleanStep: true,
+			requireErr:          requireErrInvalidConfiguration,
+			expected:            nil,
+		},
+		{
 			name:                "invalid-package-name",
 			skipConfigCleanStep: true,
 			requireErr:          requireErrInvalidConfiguration,

--- a/pkg/build/testdata/configuration_load/uses-and-runs.melange.yaml
+++ b/pkg/build/testdata/configuration_load/uses-and-runs.melange.yaml
@@ -1,0 +1,9 @@
+package:
+  name: cosign
+  version: 2.0.0
+  epoch: 0
+
+pipeline:
+  - uses: go/build
+    runs: |
+      echo "Can't have both"


### PR DESCRIPTION
We ignore "runs" if "uses" is present, so specifying both should fail.