### PR TITLE
Additional Go Build flags in `go/build` pipeline

### DIFF
--- a/pkg/build/pipelines/go/build.yaml
+++ b/pkg/build/pipelines/go/build.yaml
@@ -55,6 +55,10 @@ inputs:
     description:
       List of [pattern=]arg to pass to the go compiler with -ldflags
 
+  flags:
+    description: |
+      List of any aditional go build flags e.g: -mod=vendor -gcflags="-m=2",  etc.
+
   install-dir:
     description: |
       Directory where binaries will be installed
@@ -68,6 +72,7 @@ pipeline:
   - runs: |
       TAGS=""
       LDFLAGS=""
+      FLAGS=""
 
       if [ ! "${{inputs.tags}}" == "" ]; then
         TAGS="${{inputs.tags}}"
@@ -75,6 +80,10 @@ pipeline:
 
       if [ ! "${{inputs.ldflags}}" == "" ]; then
         LDFLAGS="${{inputs.ldflags}}"
+      fi
+
+      if [ ! "${{inputs.flags}}" == "" ]; then
+        FLAGS="${{inputs.flags}}"
       fi
 
       BASE_PATH="${{inputs.prefix}}/${{inputs.install-dir}}/${{inputs.output}}"
@@ -90,4 +99,4 @@ pipeline:
         # If vendor is specified, update the vendor directory
         "${{inputs.vendor}}" && go mod vendor
       fi
-      go build -o "${{targets.contextdir}}"/${BASE_PATH} -tags "${TAGS}" -ldflags "${LDFLAGS}" -trimpath ${{inputs.packages}}
+      go build -o "${{targets.contextdir}}"/${BASE_PATH} -tags "${TAGS}" -ldflags "${LDFLAGS}" ${FLAGS} -trimpath ${{inputs.packages}}


### PR DESCRIPTION
Fixes: #474 
cc @developer-guy 

This provides an additional option for go/build pipeline. as described in issue #474, If we want to pass additional flags like `-gcflags` for memory optimization or `-mod=vendor` or `-mod=mod` etc we can't do that via current pipeline.

Uses:
```yaml
  - uses: go/build
    with:
      modroot: build-dir
      tags: enterprise
      packages: ./main.go
      output: hello
      flags: -mod=vendor -gcflags="-m=2"  # <-- additional any custom options we want to specify for go build.
```


<!--
*** PULL REQUEST CHECKLIST: PLEASE START HERE ***

The single most important feature of melange is that we can build Wolfi.

Many changes to melange introduce a risk of breaking the build, and sometimes
these are not flushed out until a package is changed (much) later.  This
pertains to basic execution, SCA changes, linter changes, and more.
-->

### Functional Changes

- [x] This change can build all of Wolfi without errors (describe results in notes)

Notes:
It will not affect any previous build but just going to give more flexibility in using go/build pipeline

### SCA Changes

- [ ] Examining several representative APKs show no regression / the desired effect (details in notes)

Notes:

### Linter

- [ ] The new check is clean across Wolfi
- [ ] The new check is opt-in or a warning

