### PR TITLE
fail if 'with' is used with 'runs'

### DIFF
--- a/pkg/build/testdata/configuration_load/with-and-runs.melange.yaml
+++ b/pkg/build/testdata/configuration_load/with-and-runs.melange.yaml
@@ -1,0 +1,10 @@
+package:
+  name: cosign
+  version: 2.0.0
+  epoch: 0
+
+pipeline:
+  - with:
+      foo: bar
+    runs: |
+      echo "Can't have both"

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -817,7 +817,7 @@ func ParseConfiguration(configurationFilePath string, opts ...ConfigurationParsi
 
 	// Finally, validate the configuration we ended up with before returning it for use downstream.
 	if err = cfg.validate(); err != nil {
-		return nil, fmt.Errorf("validating configuration: %w", err)
+		return nil, fmt.Errorf("validating configuration %q: %w", cfg.Package.Name, err)
 	}
 
 	return &cfg, nil
@@ -872,7 +872,11 @@ func (cfg Configuration) validate() error {
 func validatePipelines(ps []Pipeline) error {
 	for _, p := range ps {
 		if p.Uses != "" && p.Runs != "" {
-			return fmt.Errorf("pipeline cannot contain both uses %q and runs %q", p.Uses, p.Runs)
+			return fmt.Errorf("pipeline cannot contain both uses %q and runs", p.Uses)
+		}
+
+		if len(p.With) > 0 && p.Runs != "" {
+			return fmt.Errorf("pipeline cannot contain both with and runs")
 		}
 
 		if err := validatePipelines(p.Pipeline); err != nil {


### PR DESCRIPTION
`with` has no effect in this case, so it's likely a bug to specify it.

There's one example of this in Wolfi, which I'm cleaning up in https://github.com/wolfi-dev/os/pull/8067

(This PR is draft until that PR is merged)