### PR TITLE
Delete no-op sbom code

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -269,8 +269,6 @@ type Pipeline struct {
 	//
 	// This defaults to the guests' build workspace (/home/build)
 	WorkDir string `json:"working-directory,omitempty" yaml:"working-directory,omitempty"`
-	// Optional: Configuration for the generated SBOM
-	SBOM SBOM `json:"sbom,omitempty" yaml:"sbom,omitempty"`
 	// Optional: environment variables to override the apko environment
 	Environment map[string]string `json:"environment,omitempty" yaml:"environment,omitempty"`
 }


### PR DESCRIPTION
This indirection isn't used to test anything, and all the generator options are hardcoded. Some of the methods that don't do anything were also removed and the corresponding sbom config removed because it's misleading.

I've kept NewGenerator around to hold the same logger across calls to GenerateSBOM.