### PR TITLE
GithubReleaseMonitor: add tagprefix and tagcontains to be used in git…

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -413,7 +413,12 @@ type GitHubMonitor struct {
 	// If the version in GitHub contains a suffix which should be ignored
 	StripSuffix string `json:"strip-suffix,omitempty" yaml:"strip-suffix,omitempty"`
 	// Filter to apply when searching tags on a GitHub repository
+	// Deprecated: Use TagFilterPrefix instead
 	TagFilter string `json:"tag-filter,omitempty" yaml:"tag-filter,omitempty"`
+	// Filter to apply when searching tags on a GitHub repository
+	TagFilterPrefix string `json:"tag-filter-prefix,omitempty" yaml:"tag-filter-prefix,omitempty"`
+	// Filter to search tags on the Github tag results
+	TagFilterContains string `json:"tag-filter-contains,omitempty" yaml:"tag-filter-contains,omitempty"`
 	// Override the default of using a GitHub release to identify related tag to
 	// fetch.  Not all projects use GitHub releases but just use tags
 	UseTags bool `json:"use-tag,omitempty" yaml:"use-tag,omitempty"`

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -415,7 +415,7 @@ type GitHubMonitor struct {
 	// Filter to apply when searching tags on a GitHub repository
 	// Deprecated: Use TagFilterPrefix instead
 	TagFilter string `json:"tag-filter,omitempty" yaml:"tag-filter,omitempty"`
-	// Filter to apply when searching tags on a GitHub repository
+	// Prefix filter to apply when searching tags on a GitHub repository
 	TagFilterPrefix string `json:"tag-filter-prefix,omitempty" yaml:"tag-filter-prefix,omitempty"`
 	// Filter to search tags on the Github tag results
 	TagFilterContains string `json:"tag-filter-contains,omitempty" yaml:"tag-filter-contains,omitempty"`

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -417,7 +417,7 @@ type GitHubMonitor struct {
 	TagFilter string `json:"tag-filter,omitempty" yaml:"tag-filter,omitempty"`
 	// Prefix filter to apply when searching tags on a GitHub repository
 	TagFilterPrefix string `json:"tag-filter-prefix,omitempty" yaml:"tag-filter-prefix,omitempty"`
-	// Filter to search tags on the Github tag results
+	// Filter to apply when searching tags on a GitHub repository
 	TagFilterContains string `json:"tag-filter-contains,omitempty" yaml:"tag-filter-contains,omitempty"`
 	// Override the default of using a GitHub release to identify related tag to
 	// fetch.  Not all projects use GitHub releases but just use tags


### PR DESCRIPTION
GithubReleaseMonitor: add tagprefix and tagcontains to be used in github tags filtering

## Melange Pull Request Template

<!--
*** PULL REQUEST CHECKLIST: PLEASE START HERE ***

The single most important feature of melange is that we can build Wolfi.

Many changes to melange introduce a risk of breaking the build, and sometimes
these are not flushed out until a package is changed (much) later.  This
pertains to basic execution, SCA changes, linter changes, and more.
-->

### Functional Changes

- [ ] This change can build all of Wolfi without errors (describe results in notes)

Notes:

### SCA Changes

- [ ] Examining several representative APKs show no regression / the desired effect (details in notes)

Notes:

### Linter

- [ ] The new check is clean across Wolfi
- [ ] The new check is opt-in or a warning

Notes:
