### PR TITLE
improve 'melange convert python' to remove manual steps

### DIFF
--- a/pkg/convert/python/python.go
+++ b/pkg/convert/python/python.go
@@ -339,23 +339,12 @@ func (c *PythonContext) generateEnvironment(pack Package) apkotypes.ImageConfigu
 		"wolfi-base",
 		"busybox",
 		"build-base",
-		"python-" + c.PythonVersion,            // Set the python version requested
-		"py" + c.PythonVersion + "-setuptools", // Set the specific python set up tools
-
 	}
 
 	env := apkotypes.ImageConfiguration{
 		Contents: apkotypes.ImageContents{
 			Packages: pythonStandard,
 		},
-	}
-
-	if len(c.AdditionalRepositories) > 0 {
-		env.Contents.Repositories = append(env.Contents.Repositories, c.AdditionalRepositories...)
-	}
-
-	if len(c.AdditionalKeyrings) > 0 {
-		env.Contents.Keyring = append(env.Contents.Keyring, c.AdditionalKeyrings...)
 	}
 
 	return env
@@ -400,11 +389,9 @@ func (c *PythonContext) generatePipeline(ctx context.Context, pack Package, vers
 
 		releaseURL := release.URL
 		uri := strings.ReplaceAll(releaseURL, version, "${{package.version}}")
-		readme := fmt.Sprintf("CONFIRM WITH: curl -L %s | sha256sum", releaseURL)
 		if strings.Contains(release.URL, "https://files.pythonhosted.org") {
 			packageName := strings.TrimPrefix(pack.Info.Name, fmt.Sprintf("py%s", release.PythonVersion))
 			releaseURL = fmt.Sprintf("https://files.pythonhosted.org/packages/source/%c/%s/%s-%s.tar.gz", packageName[0], packageName, packageName, version)
-			readme = fmt.Sprintf("CONFIRM WITH: curl -L %s | sha256sum", releaseURL)
 
 			uri = strings.ReplaceAll(releaseURL, version, "${{package.version}}")
 		}
@@ -425,7 +412,6 @@ func (c *PythonContext) generatePipeline(ctx context.Context, pack Package, vers
 			Uses: "fetch",
 			With: map[string]string{
 				"uri":             uri,
-				"README":          readme,
 				"expected-sha256": artifact256SHA,
 			},
 		}

--- a/pkg/convert/python/python_test.go
+++ b/pkg/convert/python/python_test.go
@@ -159,15 +159,11 @@ func TestGenerateManifest(t *testing.T) {
 		assert.Equal(t, got.Package.Copyright[0].License, "Apache License 2.0")
 
 		// Check Environment
-		assert.Equal(t, []string{"https://packages.wolfi.dev/os"}, got.Environment.Contents.Repositories)
-		assert.Equal(t, []string{"https://packages.wolfi.dev/os/wolfi-signing.rsa.pub"}, got.Environment.Contents.Keyring)
 		assert.Equal(t, got.Environment.Contents.Packages, []string{
 			"ca-certificates-bundle",
 			"wolfi-base",
 			"busybox",
 			"build-base",
-			"python-" + pythonctx.PythonVersion,
-			"py" + pythonctx.PythonVersion + "-setuptools",
 		})
 
 		// Check Pipeline
@@ -192,7 +188,6 @@ func TestGenerateManifest(t *testing.T) {
 
 		tempURI := fmt.Sprintf("https://files.pythonhosted.org/packages/source/%c/%s/%s-%s.tar.gz", pythonctx.PackageName[0], pythonctx.PackageName, pythonctx.PackageName, pythonctx.PackageVersion)
 		assert.Equal(t, got.Pipeline[0].With, map[string]string{
-			"README":          fmt.Sprintf("CONFIRM WITH: curl -L %s | sha256sum", tempURI),
 			"expected-sha256": "2bee6ed037590ef1e4884d944486232871513915f12a8590c63e3bb6046479bf",
 			"uri":             strings.ReplaceAll(tempURI, pythonctx.PackageVersion, "${{package.version}}"),
 		})
@@ -316,15 +311,11 @@ func TestGenerateEnvironment(t *testing.T) {
 
 	expected310 := apkotypes.ImageConfiguration{
 		Contents: apkotypes.ImageContents{
-			Repositories: []string{"https://packages.wolfi.dev/os"},
-			Keyring:      []string{"https://packages.wolfi.dev/os/wolfi-signing.rsa.pub"},
 			Packages: []string{
 				"ca-certificates-bundle",
 				"wolfi-base",
 				"busybox",
 				"build-base",
-				"python-" + pythonctx.PythonVersion,
-				"py" + pythonctx.PythonVersion + "-setuptools",
 			},
 		},
 	}
@@ -343,15 +334,11 @@ func TestGenerateEnvironment(t *testing.T) {
 
 	expected311 := apkotypes.ImageConfiguration{
 		Contents: apkotypes.ImageContents{
-			Repositories: []string{"https://packages.wolfi.dev/os"},
-			Keyring:      []string{"https://packages.wolfi.dev/os/wolfi-signing.rsa.pub"},
 			Packages: []string{
 				"ca-certificates-bundle",
 				"wolfi-base",
 				"busybox",
 				"build-base",
-				"python-" + pythonctx.PythonVersion,
-				"py" + pythonctx.PythonVersion + "-setuptools",
 			},
 		},
 	}


### PR DESCRIPTION
- don't specify `python-3` or `py3.12-setuptools` since they get picked up by the dep on `python/build-wheel` automagically (I don't think we actually need a dep on `setuptools`?)
- drop `repositories` and `keyring` since we don't need them in wolfi (we pass them in via flags to `melange build`)
- drop manual `README` step since running the pipeline checks the digest for you