### PR TITLE
default --use-github=true

### DIFF
--- a/docs/md/melange_convert.md
+++ b/docs/md/melange_convert.md
@@ -25,7 +25,7 @@ Convert is an EXPERIMENTAL COMMAND - Attempts to convert packages/gems/apkbuild 
       --additional-repositories stringArray   additional repositories to be added to convert environment config
   -h, --help                                  help for convert
   -o, --out-dir string                        directory where convert config will be output (default ".")
-      --use-github                            **experimental** if true, tries to use github to figure out the release commit details (python only for now). To prevent rate limiting, you can set the GITHUB_TOKEN env variable to a github token.
+      --use-github                            **experimental** if true, tries to use github to figure out the release commit details (python only for now). To prevent rate limiting, you can set the GITHUB_TOKEN env variable to a github token. (default true)
       --use-relmon                            **experimental** if true, tries to use release-monitoring to fetch release monitoring data.
       --wolfi-defaults                        if true, adds wolfi repo, and keyring to config (default true)
 ```

--- a/docs/md/melange_convert_apkbuild.md
+++ b/docs/md/melange_convert_apkbuild.md
@@ -39,7 +39,7 @@ melange convert apkbuild [flags]
       --additional-keyrings stringArray       additional repositories to be added to convert environment config
       --additional-repositories stringArray   additional repositories to be added to convert environment config
   -o, --out-dir string                        directory where convert config will be output (default ".")
-      --use-github                            **experimental** if true, tries to use github to figure out the release commit details (python only for now). To prevent rate limiting, you can set the GITHUB_TOKEN env variable to a github token.
+      --use-github                            **experimental** if true, tries to use github to figure out the release commit details (python only for now). To prevent rate limiting, you can set the GITHUB_TOKEN env variable to a github token. (default true)
       --use-relmon                            **experimental** if true, tries to use release-monitoring to fetch release monitoring data.
       --wolfi-defaults                        if true, adds wolfi repo, and keyring to config (default true)
 ```

--- a/docs/md/melange_convert_gem.md
+++ b/docs/md/melange_convert_gem.md
@@ -41,7 +41,7 @@ convert gem fluentd
       --additional-keyrings stringArray       additional repositories to be added to convert environment config
       --additional-repositories stringArray   additional repositories to be added to convert environment config
   -o, --out-dir string                        directory where convert config will be output (default ".")
-      --use-github                            **experimental** if true, tries to use github to figure out the release commit details (python only for now). To prevent rate limiting, you can set the GITHUB_TOKEN env variable to a github token.
+      --use-github                            **experimental** if true, tries to use github to figure out the release commit details (python only for now). To prevent rate limiting, you can set the GITHUB_TOKEN env variable to a github token. (default true)
       --use-relmon                            **experimental** if true, tries to use release-monitoring to fetch release monitoring data.
       --wolfi-defaults                        if true, adds wolfi repo, and keyring to config (default true)
 ```

--- a/docs/md/melange_convert_python.md
+++ b/docs/md/melange_convert_python.md
@@ -42,7 +42,7 @@ convert python botocore
       --additional-keyrings stringArray       additional repositories to be added to convert environment config
       --additional-repositories stringArray   additional repositories to be added to convert environment config
   -o, --out-dir string                        directory where convert config will be output (default ".")
-      --use-github                            **experimental** if true, tries to use github to figure out the release commit details (python only for now). To prevent rate limiting, you can set the GITHUB_TOKEN env variable to a github token.
+      --use-github                            **experimental** if true, tries to use github to figure out the release commit details (python only for now). To prevent rate limiting, you can set the GITHUB_TOKEN env variable to a github token. (default true)
       --use-relmon                            **experimental** if true, tries to use release-monitoring to fetch release monitoring data.
       --wolfi-defaults                        if true, adds wolfi repo, and keyring to config (default true)
 ```

--- a/pkg/cli/convert.go
+++ b/pkg/cli/convert.go
@@ -72,7 +72,7 @@ func Convert() *cobra.Command {
 
 	// Experimental flag to see if we can fetch github repo details and use that
 	// in pipeline to fetch instead of the ftp.
-	cmd.PersistentFlags().BoolVar(&c.useGithub, "use-github", false, "**experimental** if true, tries to use github to figure out the release commit details (python only for now). To prevent rate limiting, you can set the GITHUB_TOKEN env variable to a github token.")
+	cmd.PersistentFlags().BoolVar(&c.useGithub, "use-github", true, "**experimental** if true, tries to use github to figure out the release commit details (python only for now). To prevent rate limiting, you can set the GITHUB_TOKEN env variable to a github token.")
 
 	cmd.AddCommand(
 		ApkBuild(),

--- a/pkg/cli/python.go
+++ b/pkg/cli/python.go
@@ -48,6 +48,7 @@ func PythonBuild() *cobra.Command {
 convert python botocore`,
 		Args: cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
 			if len(args) != 1 {
 				return errors.New("too many arguments, expected only 1")
 			}
@@ -60,7 +61,7 @@ convert python botocore`,
 			if err != nil {
 				return err
 			}
-			o.ghClient, err = getGithubClient(context.TODO(), cmd)
+			o.ghClient, err = getGithubClient(ctx, cmd)
 			if err != nil {
 				return err
 			}

--- a/pkg/convert/python/python.go
+++ b/pkg/convert/python/python.go
@@ -433,7 +433,6 @@ func (c *PythonContext) generatePipeline(ctx context.Context, pack Package, vers
 			With: map[string]string{
 				"repository":      ghVersion.Repo,
 				"tag":             ghVersion.TagPrefix + "${{package.version}}",
-				"README":          fmt.Sprintf("for version %s, if you use this, update the package.version above to this version", ghVersion.Tag),
 				"expected-commit": ghVersion.SHA,
 			}})
 	}


### PR DESCRIPTION
This only does anything interesting for `melange convert python` but this opts us in to using `git-checkout` instead of `fetch`.

Also drop some unnecessary additions to the package.