### PR TITLE
convert python: don't overwrite existing files

### DIFF
--- a/docs/md/melange_convert.md
+++ b/docs/md/melange_convert.md
@@ -24,7 +24,7 @@ Convert is an EXPERIMENTAL COMMAND - Attempts to convert packages/gems/apkbuild 
       --additional-keyrings stringArray       additional repositories to be added to convert environment config
       --additional-repositories stringArray   additional repositories to be added to convert environment config
   -h, --help                                  help for convert
-  -o, --out-dir string                        directory where convert config will be output (default "./generated")
+  -o, --out-dir string                        directory where convert config will be output (default ".")
       --use-github                            **experimental** if true, tries to use github to figure out the release commit details (python only for now). To prevent rate limiting, you can set the GITHUB_TOKEN env variable to a github token.
       --use-relmon                            **experimental** if true, tries to use release-monitoring to fetch release monitoring data.
       --wolfi-defaults                        if true, adds wolfi repo, and keyring to config (default true)

--- a/docs/md/melange_convert_apkbuild.md
+++ b/docs/md/melange_convert_apkbuild.md
@@ -38,7 +38,7 @@ melange convert apkbuild [flags]
 ```
       --additional-keyrings stringArray       additional repositories to be added to convert environment config
       --additional-repositories stringArray   additional repositories to be added to convert environment config
-  -o, --out-dir string                        directory where convert config will be output (default "./generated")
+  -o, --out-dir string                        directory where convert config will be output (default ".")
       --use-github                            **experimental** if true, tries to use github to figure out the release commit details (python only for now). To prevent rate limiting, you can set the GITHUB_TOKEN env variable to a github token.
       --use-relmon                            **experimental** if true, tries to use release-monitoring to fetch release monitoring data.
       --wolfi-defaults                        if true, adds wolfi repo, and keyring to config (default true)

--- a/docs/md/melange_convert_gem.md
+++ b/docs/md/melange_convert_gem.md
@@ -40,7 +40,7 @@ convert gem fluentd
 ```
       --additional-keyrings stringArray       additional repositories to be added to convert environment config
       --additional-repositories stringArray   additional repositories to be added to convert environment config
-  -o, --out-dir string                        directory where convert config will be output (default "./generated")
+  -o, --out-dir string                        directory where convert config will be output (default ".")
       --use-github                            **experimental** if true, tries to use github to figure out the release commit details (python only for now). To prevent rate limiting, you can set the GITHUB_TOKEN env variable to a github token.
       --use-relmon                            **experimental** if true, tries to use release-monitoring to fetch release monitoring data.
       --wolfi-defaults                        if true, adds wolfi repo, and keyring to config (default true)

--- a/docs/md/melange_convert_python.md
+++ b/docs/md/melange_convert_python.md
@@ -41,7 +41,7 @@ convert python botocore
 ```
       --additional-keyrings stringArray       additional repositories to be added to convert environment config
       --additional-repositories stringArray   additional repositories to be added to convert environment config
-  -o, --out-dir string                        directory where convert config will be output (default "./generated")
+  -o, --out-dir string                        directory where convert config will be output (default ".")
       --use-github                            **experimental** if true, tries to use github to figure out the release commit details (python only for now). To prevent rate limiting, you can set the GITHUB_TOKEN env variable to a github token.
       --use-relmon                            **experimental** if true, tries to use release-monitoring to fetch release monitoring data.
       --wolfi-defaults                        if true, adds wolfi repo, and keyring to config (default true)

--- a/pkg/cli/convert.go
+++ b/pkg/cli/convert.go
@@ -51,7 +51,7 @@ func Convert() *cobra.Command {
 	}
 	// Add out-dir, as well as additional-repos and additiona-keyrings flag to
 	// all subcommands
-	cmd.PersistentFlags().StringVarP(&c.outDir, "out-dir", "o", "./generated", "directory where convert config will be output")
+	cmd.PersistentFlags().StringVarP(&c.outDir, "out-dir", "o", ".", "directory where convert config will be output")
 	cmd.PersistentFlags().StringArray(
 		"additional-repositories", []string{},
 		"additional repositories to be added to convert environment config",


### PR DESCRIPTION
This bails early before re-generating a melange config if we already have it.

We still crawl the package's deps in case we need to, but we won't overwrite existing files.

This also updates `-o` to default to the pwd, which is normally the wolfi-dev/os repo, where files generally already exist.

Ideally this _would_ overwrite the config if it could determine it had originally been generated and hadn't been updated since. This would let us account for package updates that bring in new runtime deps, if `melange convert` was integrated in the update/renovate workflow. In that case, we can workaround by deleting the file and regenerating it.