### PR TITLE
Fix the lint warnings in pkg/linter

### DIFF
--- a/pkg/linter/linter_test.go
+++ b/pkg/linter/linter_test.go
@@ -516,7 +516,7 @@ func Test_setUidGidLinter(t *testing.T) {
 	err = os.MkdirAll(usrLocalDirPath, 0770)
 	assert.NoError(t, err)
 
-	_, err = os.Create(filepath.Join(filePath))
+	_, err = os.Create(filePath)
 	assert.NoError(t, err)
 
 	err = os.Chmod(filePath, 0770|fs.ModeSetuid|fs.ModeSetgid)
@@ -560,7 +560,7 @@ func Test_worldWriteLinter(t *testing.T) {
 
 	// Create test file
 	filePath := filepath.Join(usrLocalDirPath, "test.txt")
-	_, err = os.Create(filepath.Join(filePath))
+	_, err = os.Create(filePath)
 	assert.NoError(t, err)
 
 	// Set writeable and executable bits for non-world
@@ -619,7 +619,7 @@ func Test_disableDefaultLinter(t *testing.T) {
 	err = os.MkdirAll(usrLocalDirPath, 0770)
 	assert.NoError(t, err)
 
-	_, err = os.Create(filepath.Join(filePath))
+	_, err = os.Create(filePath)
 	assert.NoError(t, err)
 
 	linters := cfg.Package.Checks.GetLinters()


### PR DESCRIPTION
## Melange Pull Request Template

Fix the linter warnings. Left one about stuttering include, as we can fix that if we want to or silence it.

<!--
*** PULL REQUEST CHECKLIST: PLEASE START HERE ***

The single most important feature of melange is that we can build Wolfi.

Many changes to melange introduce a risk of breaking the build, and sometimes
these are not flushed out until a package is changed (much) later.  This
pertains to basic execution, SCA changes, linter changes, and more.
-->

### Functional Changes

- [ ] This change can build all of Wolfi without errors (describe results in notes)

Notes:

### SCA Changes

- [ ] Examining several representative APKs show no regression / the desired effect (details in notes)

Notes:

### Linter

- [ ] The new check is clean across Wolfi
- [ ] The new check is opt-in or a warning

Notes:
