### PR TITLE
UTC-ify source date epoch when set

### DIFF
--- a/pkg/util/env.go
+++ b/pkg/util/env.go
@@ -51,5 +51,5 @@ func SourceDateEpochWithLogger(l log.Logger, defaultTime time.Time) (time.Time, 
 		return defaultTime, fmt.Errorf("failed to parse SOURCE_DATE_EPOCH: %w", err)
 	}
 
-	return time.Unix(sec, 0), nil
+	return time.Unix(sec, 0).UTC(), nil
 }


### PR DESCRIPTION
Without this, SBOM timestamps derived from `SOURCE_DATE_EPOCH` aren't UTC, and so aren't valid according to the NTIA checker.