### PR TITLE
support resource requests and timeouts

### DIFF
--- a/docs/md/melange_build.md
+++ b/docs/md/melange_build.md
@@ -36,6 +36,7 @@ melange build [flags]
       --cache-dir string            directory used for cached inputs (default "./melange-cache/")
       --cache-source string         directory or bucket used for preloading the cache
       --continue-label string       continue build execution at the specified label
+      --cpu string                  default CPU resources to use for builds
       --create-build-log            creates a package.log file containing a list of packages that were built by the command
       --debug                       enables debug logging of build pipelines
       --debug-runner                when enabled, the builder pod will persist after the build succeeds or fails
@@ -48,6 +49,7 @@ melange build [flags]
   -h, --help                        help for build
   -k, --keyring-append strings      path to extra keys to include in the build environment keyring
       --log-policy strings          logging policy to use (default [builtin:stderr])
+      --memory string               default memory resources to use for builds
       --namespace string            namespace to use in package URLs in SBOM (eg wolfi, alpine) (default "unknown")
       --out-dir string              directory where packages will be output (default "./packages/")
       --overlay-binsh string        use specified file as /bin/sh overlay in build environment
@@ -57,6 +59,7 @@ melange build [flags]
       --signing-key string          key to use for signing
       --source-dir string           directory used for included sources
       --strip-origin-name           whether origin names should be stripped (for bootstrap)
+      --timeout duration            default timeout for builds
       --vars-file string            file to use for preloaded build configuration variables
       --workspace-dir string        directory used for the workspace at /home/build
 ```

--- a/examples/simple-hello/melange.yaml
+++ b/examples/simple-hello/melange.yaml
@@ -4,13 +4,11 @@ package:
   epoch: 0
   description: "a hello world program"
   copyright:
-    - paths:
-      - "*"
-      attestation: |
-        This program is in the public domain.
+    - attestation: This program is in the public domain.
       license: CC-PDDC
-  dependencies:
-    runtime:
+  resources:
+    cpu: .5
+    memory: 128Mi
 
 environment:
   contents:
@@ -25,7 +23,7 @@ environment:
       - ca-certificates-bundle
 
 pipeline:
+  - runs: sleep 60
   - uses: autoconf/make
   - uses: autoconf/make-install
   - uses: strip
-

--- a/examples/simple-hello/melange.yaml
+++ b/examples/simple-hello/melange.yaml
@@ -23,7 +23,6 @@ environment:
       - ca-certificates-bundle
 
 pipeline:
-  - runs: sleep 60
   - uses: autoconf/make
   - uses: autoconf/make-install
   - uses: strip

--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"log"
 	"path/filepath"
+	"time"
 
 	apko_types "chainguard.dev/apko/pkg/build/types"
 	"chainguard.dev/melange/pkg/build"
@@ -61,6 +62,8 @@ func Build() *cobra.Command {
 	var debugRunner bool
 	var runner string
 	var failOnLintWarning bool
+	var cpu, memory string
+	var timeout time.Duration
 
 	cmd := &cobra.Command{
 		Use:     "build",
@@ -103,6 +106,9 @@ func Build() *cobra.Command {
 				build.WithLogPolicy(logPolicy),
 				build.WithRunner(runner),
 				build.WithFailOnLintWarning(failOnLintWarning),
+				build.WithCPU(cpu),
+				build.WithMemory(memory),
+				build.WithTimeout(timeout),
 			}
 
 			if len(args) > 0 {
@@ -151,6 +157,9 @@ func Build() *cobra.Command {
 	cmd.Flags().BoolVar(&debug, "debug", false, "enables debug logging of build pipelines")
 	cmd.Flags().BoolVar(&debugRunner, "debug-runner", false, "when enabled, the builder pod will persist after the build succeeds or fails")
 	cmd.Flags().BoolVar(&failOnLintWarning, "fail-on-lint-warning", false, "turns linter warnings into failures")
+	cmd.Flags().StringVar(&cpu, "cpu", "", "default CPU resources to use for builds")
+	cmd.Flags().StringVar(&memory, "memory", "", "default memory resources to use for builds")
+	cmd.Flags().DurationVar(&timeout, "timeout", 0, "default timeout for builds")
 
 	return cmd
 }

--- a/pkg/container/config.go
+++ b/pkg/container/config.go
@@ -15,6 +15,8 @@
 package container
 
 import (
+	"time"
+
 	apko_types "chainguard.dev/apko/pkg/build/types"
 	"chainguard.dev/apko/pkg/log"
 )
@@ -46,4 +48,6 @@ type Config struct {
 	ImgRef       string
 	PodID        string
 	Arch         apko_types.Architecture
+	CPU, Memory  string
+	Timeout      time.Duration
 }

--- a/pkg/container/kubernetes_runner_test.go
+++ b/pkg/container/kubernetes_runner_test.go
@@ -195,14 +195,14 @@ func Test_k8s_StartPod(t *testing.T) {
 			},
 		},
 		{
-			name:   "should override resources",
-			pkgCfg: &Config{PackageName: "donkey", Arch: types.Architecture("arm64")},
-			k8sCfg: &KubernetesRunnerConfig{
-				Resources: corev1.ResourceList{
-					corev1.ResourceCPU:    resource.MustParse("1"),
-					corev1.ResourceMemory: resource.MustParse("9001"),
-				},
+			name: "should override resources",
+			pkgCfg: &Config{
+				PackageName: "donkey",
+				Arch:        types.Architecture("arm64"),
+				CPU:         "1",
+				Memory:      "9001",
 			},
+			k8sCfg: &KubernetesRunnerConfig{},
 			wanter: func(got corev1.Pod) bool {
 				return got.Spec.Containers[0].Resources.Requests.Cpu().Equal(resource.MustParse("1")) && got.Spec.Containers[0].Resources.Requests.Memory().Equal(resource.MustParse("9001"))
 			},

--- a/pkg/util/env.go
+++ b/pkg/util/env.go
@@ -51,5 +51,5 @@ func SourceDateEpochWithLogger(l log.Logger, defaultTime time.Time) (time.Time, 
 		return defaultTime, fmt.Errorf("failed to parse SOURCE_DATE_EPOCH: %w", err)
 	}
 
-	return time.Unix(sec, 0), nil
+	return time.Unix(sec, 0).UTC(), nil
 }


### PR DESCRIPTION
This adds config values and flags to configure resource requests and timeouts for build pipelines.

```
package:
  name: hello
  ...
  resources:
    cpu: .5
    memory: 128Mi
```

This is used by the docker and k8s runners to start containers with these requests. This also adds flags that override these values on a per-run basis:

```
melange build hello.yaml --cpu=10 --memory=40Gi
```

For the k8s runner only, if no resources are requested, it defaults to 2 CPU and 4 Gi to satisfy GKE autopilot requirements.

Likewise, this adds a `timeout:` field and `--timeout` flag, which enforces a build pipeline timeout (NB: time to fetch packages and setup the environment is not counted in this timeout, only the build steps)

```
$ melange build examples/simple-hello/melange.yaml --timeout=1s
2023/12/01 10:23:42 error during command execution: failed to build package: unable to build guest: unable to generate image: installing apk packages: installing packages: context deadline exceeded
```

By default there is no timeout, as today.