### PR TITLE
cleanup: don't use pkg/errors

### DIFF
--- a/pkg/cli/apkbuild.go
+++ b/pkg/cli/apkbuild.go
@@ -67,7 +67,7 @@ func ApkBuild() *cobra.Command {
 func (o apkbuildOptions) ApkBuildCmd(ctx context.Context, packageName string) error {
 	context, err := apkbuild.New(ctx)
 	if err != nil {
-		return errors.Wrap(err, "initialising convert command")
+		return fmt.Errorf("initialising convert command: %w", err)
 	}
 
 	context.AdditionalRepositories = o.additionalRepositories
@@ -80,7 +80,7 @@ func (o apkbuildOptions) ApkBuildCmd(ctx context.Context, packageName string) er
 
 	err = context.Generate(ctx, configFilename, packageName)
 	if err != nil {
-		return errors.Wrap(err, "generating convert configuration")
+		return fmt.Errorf("generating convert configuration: %w", err)
 	}
 
 	return nil

--- a/pkg/cli/gem.go
+++ b/pkg/cli/gem.go
@@ -78,7 +78,7 @@ convert gem fluentd`,
 func (o gemOptions) gemBuild(ctx context.Context, packageName string) error {
 	context, err := gem.New()
 	if err != nil {
-		return errors.Wrap(err, "initialising gem command")
+		return fmt.Errorf("initialising gem command: %w", err)
 	}
 
 	context.RubyVersion = o.rubyVersion

--- a/pkg/cli/python.go
+++ b/pkg/cli/python.go
@@ -16,6 +16,7 @@ package cli
 
 import (
 	"context"
+	"fmt"
 
 	"chainguard.dev/melange/pkg/convert/python"
 	"chainguard.dev/melange/pkg/convert/relmon"
@@ -85,7 +86,7 @@ convert python botocore`,
 func (o pythonOptions) pythonBuild(ctx context.Context, packageName string) error {
 	pythonContext, err := python.New(packageName)
 	if err != nil {
-		return errors.Wrap(err, "initialising python command")
+		return fmt.Errorf("initialising python command: %w", err)
 	}
 
 	pythonContext.AdditionalRepositories = o.additionalRepositories

--- a/pkg/config/vars.go
+++ b/pkg/config/vars.go
@@ -18,8 +18,6 @@ import (
 	"fmt"
 	"regexp"
 
-	"github.com/pkg/errors"
-
 	"chainguard.dev/melange/pkg/util"
 )
 
@@ -68,7 +66,7 @@ func (cfg Configuration) PerformVarSubstitutions(nw map[string]string) error {
 
 		re, err := regexp.Compile(v.Match)
 		if err != nil {
-			return errors.Wrapf(err, "match value: %s string does not compile into a regex", v.Match)
+			return fmt.Errorf("match value: %s string does not compile into a regex: %w: %w", v.Match, err)
 		}
 
 		output := re.ReplaceAllString(from, v.Replace)

--- a/pkg/config/vars.go
+++ b/pkg/config/vars.go
@@ -66,7 +66,7 @@ func (cfg Configuration) PerformVarSubstitutions(nw map[string]string) error {
 
 		re, err := regexp.Compile(v.Match)
 		if err != nil {
-			return fmt.Errorf("match value: %s string does not compile into a regex: %w: %w", v.Match, err)
+			return fmt.Errorf("match value: %s string does not compile into a regex: %w", v.Match, err)
 		}
 
 		output := re.ReplaceAllString(from, v.Replace)

--- a/pkg/convert/gem/gem.go
+++ b/pkg/convert/gem/gem.go
@@ -30,7 +30,6 @@ import (
 	rlhttp "chainguard.dev/melange/pkg/http"
 	"chainguard.dev/melange/pkg/manifest"
 
-	"github.com/pkg/errors"
 	"golang.org/x/time/rate"
 )
 
@@ -195,29 +194,29 @@ func (c *GemContext) findDependencies(ctx context.Context) error {
 func (c *GemContext) getGemMeta(ctx context.Context, gemURI string) (GemMeta, error) {
 	req, err := http.NewRequestWithContext(ctx, "GET", gemURI, nil)
 	if err != nil {
-		return GemMeta{}, errors.Wrapf(err, "creating request for %s", gemURI)
+		return GemMeta{}, fmt.Errorf("creating request for %s: %w", gemURI, err)
 	}
 
 	resp, err := c.Client.Do(req)
 	if err != nil {
-		return GemMeta{}, errors.Wrapf(err, "getting %s", gemURI)
+		return GemMeta{}, fmt.Errorf("getting %s: %w", gemURI, err)
 	}
 
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return GemMeta{}, errors.Wrapf(err, "%d when getting %s", resp.StatusCode, gemURI)
+		return GemMeta{}, fmt.Errorf("%d when getting %s: %w", resp.StatusCode, gemURI, err)
 	}
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return GemMeta{}, errors.Wrap(err, "reading body")
+		return GemMeta{}, fmt.Errorf("reading body: %w", err)
 	}
 
 	var g GemMeta
 	err = json.Unmarshal(body, &g)
 	if err != nil {
-		return GemMeta{}, errors.Wrap(err, "unmarshaling gem metadata")
+		return GemMeta{}, fmt.Errorf("unmarshaling gem metadata: %w", err)
 	}
 
 	// Try to set the right Uri to the repo, sometimes gems use homepage instead of source code.
@@ -365,12 +364,12 @@ func (c *GemContext) generatePipeline(ctx context.Context, g GemMeta) []config.P
 func (c *GemContext) getGemArtifactSHA(ctx context.Context, artifactURI string) (string, error) {
 	req, err := http.NewRequestWithContext(ctx, "GET", artifactURI, nil)
 	if err != nil {
-		return "", errors.Wrapf(err, "creating request for %s", artifactURI)
+		return "", fmt.Errorf("creating request for %s: %w", artifactURI, err)
 	}
 
 	resp, err := c.Client.Do(req)
 	if err != nil {
-		return "", errors.Wrapf(err, "getting %s", artifactURI)
+		return "", fmt.Errorf("getting %s: %w", artifactURI, err)
 	}
 
 	defer resp.Body.Close()
@@ -381,7 +380,7 @@ func (c *GemContext) getGemArtifactSHA(ctx context.Context, artifactURI string) 
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return "", errors.Wrap(err, "reading body")
+		return "", fmt.Errorf("reading body: %w", err)
 	}
 
 	h256 := sha256.New()

--- a/pkg/convert/python/pypi.go
+++ b/pkg/convert/python/pypi.go
@@ -152,7 +152,7 @@ func (p *PackageIndex) packageReq(ctx context.Context, endpoint string) (*Packag
 
 	if resp.StatusCode != http.StatusOK {
 		cause := errors.New("http status return was not 200")
-		err := errors.Wrapf(cause, "%d when getting %s", resp.StatusCode, url)
+		err := fmt.Errorf("%d when getting %s: %w", resp.StatusCode, url, cause)
 		return nil, err
 	}
 	data, err := io.ReadAll(resp.Body)

--- a/pkg/convert/relmon/release_monitoring.go
+++ b/pkg/convert/relmon/release_monitoring.go
@@ -54,7 +54,7 @@ func (mf *MonitorFinder) FindMonitor(ctx context.Context, pkg string) (*Item, er
 
 	if resp.StatusCode != http.StatusOK {
 		cause := errors.New("http status return was not 200")
-		err := errors.Wrapf(cause, "%d when getting %s", resp.StatusCode, url)
+		err := fmt.Errorf("%d when getting %s: %w", resp.StatusCode, url, cause)
 		return nil, err
 	}
 	data, err := io.ReadAll(resp.Body)

--- a/pkg/http/http.go
+++ b/pkg/http/http.go
@@ -7,8 +7,6 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/pkg/errors"
-
 	"golang.org/x/time/rate"
 )
 
@@ -48,13 +46,13 @@ func NewClient(rl *rate.Limiter) *RLHTTPClient {
 func (c *RLHTTPClient) GetArtifactSHA256(ctx context.Context, artifactURI string) (string, error) {
 	req, err := http.NewRequestWithContext(ctx, "GET", artifactURI, nil)
 	if err != nil {
-		return "", errors.Wrapf(err, "creating request for %s", artifactURI)
+		return "", fmt.Errorf("creating request for %s: %w", artifactURI, err)
 	}
 	var client http.Client
 
 	resp, err := client.Do(req)
 	if err != nil {
-		return "", errors.Wrapf(err, "getting %s", artifactURI)
+		return "", fmt.Errorf("getting %s: %w", artifactURI, err)
 	}
 
 	defer resp.Body.Close()
@@ -65,7 +63,7 @@ func (c *RLHTTPClient) GetArtifactSHA256(ctx context.Context, artifactURI string
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return "", errors.Wrap(err, "reading body")
+		return "", fmt.Errorf("reading body: %w", err)
 	}
 
 	h256 := sha256.New()

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -9,7 +9,6 @@ import (
 	apkotypes "chainguard.dev/apko/pkg/build/types"
 	"chainguard.dev/melange/pkg/config"
 	"github.com/chainguard-dev/yam/pkg/yam/formatted"
-	"github.com/pkg/errors"
 	"gopkg.in/yaml.v3"
 )
 
@@ -43,28 +42,28 @@ func (m *GeneratedMelangeConfig) Write(dir string) error {
 	if _, err := os.Stat(dir); os.IsNotExist(err) {
 		err = os.MkdirAll(dir, os.ModePerm)
 		if err != nil {
-			return errors.Wrapf(err, "creating output directory %s", dir)
+			return fmt.Errorf("creating output directory %s: %w", dir, err)
 		}
 	}
 
 	manifestPath := filepath.Join(dir, fmt.Sprintf("%s.yaml", m.Package.Name))
 	f, err := os.Create(manifestPath)
 	if err != nil {
-		return errors.Wrapf(err, "creating file %s", manifestPath)
+		return fmt.Errorf("creating file %s: %w", manifestPath, err)
 	}
 	defer f.Close()
 
 	if _, err := f.WriteString(fmt.Sprintf("# Generated from %s\n", m.GeneratedFromComment)); err != nil {
-		return errors.Wrapf(err, "creating writing to file %s", manifestPath)
+		return fmt.Errorf("creating writing to file %s: %w", manifestPath, err)
 	}
 
 	var n yaml.Node
 	if err := n.Encode(m); err != nil {
-		return errors.Wrapf(err, "encoding YAML to node %s", manifestPath)
+		return fmt.Errorf("encoding YAML to node %s: %w", manifestPath, err)
 	}
 
 	if err := formatted.NewEncoder(f).AutomaticConfig().Encode(&n); err != nil {
-		return errors.Wrapf(err, "encoding YAML to file %s", manifestPath)
+		return fmt.Errorf("encoding YAML to file %s: %w", manifestPath, err)
 	}
 
 	if m.Logger != nil {


### PR DESCRIPTION
https://github.com/pkg/errors is deprecated and archived for more than two years, since `fmt.Errorf` added support for `%w` in Go 1.13, [~three years ago](https://go.dev/blog/go1.13-errors).

This removes our usage of `pkg/errors` using this analyzer: https://github.com/zchee/go-analyzer/tree/main/pkgerrors