### PR TITLE
add `*_config` pattern to split/dev pipeline

### DIFF
--- a/pkg/build/pipelines/split/dev.yaml
+++ b/pkg/build/pipelines/split/dev.yaml
@@ -10,7 +10,7 @@ pipeline:
       [ -d lib/ ] && libdirs="lib/ $libdirs"
       for i in usr/include usr/lib/pkgconfig usr/share/pkgconfig \
         usr/share/aclocal usr/share/gettext \
-        usr/bin/*-config usr/share/vala/vapi \
+        usr/bin/*-config usr/bin/*_config usr/share/vala/vapi \
         usr/share/gir-[0-9]* usr/share/qt*/mkspecs \
         usr/lib/qt*/mkspecs usr/lib/cmake \
         usr/lib/glade/modules usr/share/glade/catalogs \


### PR DESCRIPTION


## Melange Pull Request Template

<!--
*** PULL REQUEST CHECKLIST: PLEASE START HERE ***

The single most important feature of melange is that we can build Wolfi.

Many changes to melange introduce a risk of breaking the build, and sometimes
these are not flushed out until a package is changed (much) later.  This
pertains to basic execution, SCA changes, linter changes, and more.
-->
This will aid in developing mysql package `-dev` variants. MySQL ships with `mysql_config` for its pkgconfig-style tool.

### Functional Changes

- [ ] This change can build all of Wolfi without errors (describe results in notes)

Notes:

### SCA Changes

- [ ] Examining several representative APKs show no regression / the desired effect (details in notes)

Notes:

### Linter

- [ ] The new check is clean across Wolfi
- [ ] The new check is opt-in or a warning

Notes:
