### PR TITLE
Set a default env var for GOMODCACHE.

### DIFF
--- a/pkg/build/build_test.go
+++ b/pkg/build/build_test.go
@@ -193,8 +193,9 @@ func TestConfiguration_Load(t *testing.T) {
 				},
 				Environment: apko_types.ImageConfiguration{
 					Environment: map[string]string{
-						"HOME":   "/home/build/special-case",
-						"GOPATH": "/var/cache/melange/go",
+						"GOMODCACHE": "/var/cache/melange/gomodcache",
+						"HOME":       "/home/build/special-case",
+						"GOPATH":     "/var/cache/melange/go",
 					},
 					Accounts: apko_types.ImageAccounts{
 						Users:  []apko_types.User{{UserName: "build", UID: 1000, GID: 1000}},
@@ -282,8 +283,9 @@ package:
 		Members:   []string{"build"},
 	}}
 	expected.Environment.Environment = map[string]string{
-		"HOME":   "/home/build",
-		"GOPATH": "/home/build/.cache/go",
+		"HOME":       "/home/build",
+		"GOPATH":     "/home/build/.cache/go",
+		"GOMODCACHE": "/var/cache/melange/gomodcache",
 	}
 
 	f := filepath.Join(t.TempDir(), "config")

--- a/pkg/build/pipelines/go/build.yaml
+++ b/pkg/build/pipelines/go/build.yaml
@@ -79,6 +79,9 @@ pipeline:
 
       BASE_PATH="${{inputs.prefix}}/${{inputs.install-dir}}/${{inputs.output}}"
 
+      # Take advantage of melange's buid cache for downloaded modules
+      export GOMODCACHE=/var/cache/melange/gomodcache
+
       cd "${{inputs.modroot}}"
 
       # Install any specified dependencies

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -841,16 +841,20 @@ func ParseConfiguration(configurationFilePath string, opts ...ConfigurationParsi
 	}
 
 	const (
-		defaultEnvVarHOME   = "/home/build"
-		defaultEnvVarGOPATH = "/home/build/.cache/go"
+		defaultEnvVarHOME       = "/home/build"
+		defaultEnvVarGOPATH     = "/home/build/.cache/go"
+		defaultEnvVarGOMODCACHE = "/var/cache/melange/gomodcache"
 	)
 
-	if cfg.Environment.Environment["HOME"] == "" {
-		cfg.Environment.Environment["HOME"] = defaultEnvVarHOME
+	var setIfEmpty = func(key, value string) {
+		if cfg.Environment.Environment[key] == "" {
+			cfg.Environment.Environment[key] = value
+		}
 	}
-	if cfg.Environment.Environment["GOPATH"] == "" {
-		cfg.Environment.Environment["GOPATH"] = defaultEnvVarGOPATH
-	}
+
+	setIfEmpty("HOME", defaultEnvVarHOME)
+	setIfEmpty("GOPATH", defaultEnvVarGOPATH)
+	setIfEmpty("GOMODCACHE", defaultEnvVarGOMODCACHE)
 
 	// If a variables file was defined, merge it into the variables block.
 	if varsFile := options.varsFilePath; varsFile != "" {


### PR DESCRIPTION
Melange supports a filesystem based cache, but it's not used anywhere AFAICT. To use it for Go, we've documented how to set this env var. Instead of making everyone set it in every pipeline and build, let's just set it to the correct path by default in melange itself.

This dramatically improves build times for me.

## Melange Pull Request Template

### Functional Changes

- [X] This change can build all of Wolfi without errors (describe results in notes)

Notes: