### PR TITLE
add `package.metadata` to help enrich melange yamls with metadata tha…

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -118,6 +118,13 @@ type Package struct {
 	Timeout time.Duration `json:"timeout,omitempty" yaml:"timeout,omitempty"`
 	// Optional: Resources to allocate to the build.
 	Resources *Resources `json:"resources,omitempty" yaml:"resources,omitempty"`
+
+	// Metadata can hold various types of information related to the package.
+	// It is flexible to accommodate different data structures:
+	// - It can be a slice of strings, often representing paths or identifiers.
+	// - Alternatively, it can hold custom structs or slices of pointers to represent more complex data.
+	// The exact type of Metadata should be determined at runtime using type assertions.
+	Metadata interface{} `json:"metadata,omitempty" yaml:"metadata,omitempty"`
 }
 
 type Resources struct {

--- a/pkg/config/schema.json
+++ b/pkg/config/schema.json
@@ -538,6 +538,9 @@
         "resources": {
           "$ref": "#/$defs/Resources",
           "description": "Optional: Resources to allocate to the build."
+        },
+        "metadata": {
+          "description": "Metadata can hold various types of information related to the package.\nIt is flexible to accommodate different data structures:\n- It can be a slice of strings, often representing paths or identifiers.\n- Alternatively, it can hold custom structs or slices of pointers to represent more complex data.\nThe exact type of Metadata should be determined at runtime using type assertions."
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
…t can be a struct or a list of pointers

This metadata can be useful to add context to melange yaml files or provide links to related data in the form of a URI for example, 

i.e.  
```
package:
  name: foo-1
  version: 0.0.1
  epoch: 0
  metadata:
    - git://github.com/wolfi-dev/versions/foo.json
```
