### PR TITLE
Bypass warning about detached head

### DIFF
--- a/pkg/build/pipelines/git-checkout.yaml
+++ b/pkg/build/pipelines/git-checkout.yaml
@@ -68,6 +68,7 @@ pipeline:
       if [ -z "${{inputs.expected-commit}}" ]; then
         echo "Warning (git-checkout): no expected-commit"
       elif [ -n '${{inputs.branch}}' ]; then
+        git config --global advice.detachedHead false
         remote_commit=$(git rev-parse --verify --end-of-options "refs/heads/${{inputs.branch}}")
         if [[ '${{inputs.expected-commit}}' != "$remote_commit" ]]; then
           echo "Error (git-checkout): expect commit ${{inputs.expected-commit}}, got $remote_commit"


### PR DESCRIPTION
This avoids log spam like this:

```
⚠️  aarch64   | Cloning into '/tmp/tmp.Dvzsqj'...
⚠️  aarch64   | Note: switching to 'ec85d900b413d3d9d6f60cece3fb5bc665275087'.
⚠️  aarch64   | 
⚠️  aarch64   | You are in 'detached HEAD' state. You can look around, make experimental
⚠️  aarch64   | changes and commit them, and you can discard any commits you make in this
⚠️  aarch64   | state without impacting any branches by switching back to a branch.
⚠️  aarch64   | 
⚠️  aarch64   | If you want to create a new branch to retain commits you create, you may
⚠️  aarch64   | do so (now or later) by using -c with the switch command. Example:
⚠️  aarch64   | 
⚠️  aarch64   |   git switch -c <new-branch-name>
⚠️  aarch64   | 
⚠️  aarch64   | Or undo this operation with:
⚠️  aarch64   | 
⚠️  aarch64   |   git switch -
⚠️  aarch64   | 
⚠️  aarch64   | Turn off this advice by setting config variable advice.detachedHead to false
⚠️  aarch64   | 
Updating files: 100% (48253/48253), done./48253)
```