### PR TITLE
meson/configure: don't download subprojects by default

### DIFF
--- a/pkg/build/pipelines/meson/configure.yaml
+++ b/pkg/build/pipelines/meson/configure.yaml
@@ -18,4 +18,9 @@ pipeline:
   - runs: |
       meson setup . ${{inputs.output-dir}} \
         --prefix=/usr \
+        # Don't download subprojects by default. We want to use only the source
+        # provided by the project, and if any subprojects are needed we should
+        # provide them ourselves.
+        # Ref: https://mesonbuild.com/Subprojects.html#commandline-options
+        --wrap-mode=nodownload \
         ${{inputs.opts}}

--- a/pkg/build/pipelines/meson/configure.yaml
+++ b/pkg/build/pipelines/meson/configure.yaml
@@ -15,12 +15,12 @@ inputs:
       Compile options for the Meson build.
 
 pipeline:
+  # Don't download subprojects by default. We want to use only the source
+  # provided by the project, and if any subprojects are needed we should
+  # provide them ourselves.
+  # Ref: https://mesonbuild.com/Subprojects.html#commandline-options
   - runs: |
       meson setup . ${{inputs.output-dir}} \
         --prefix=/usr \
-        # Don't download subprojects by default. We want to use only the source
-        # provided by the project, and if any subprojects are needed we should
-        # provide them ourselves.
-        # Ref: https://mesonbuild.com/Subprojects.html#commandline-options
         --wrap-mode=nodownload \
         ${{inputs.opts}}


### PR DESCRIPTION
https://mesonbuild.com/Subprojects.html#commandline-options

> * **--wrap-mode=nodownload**
> Meson will not use the network to download any subprojects or fetch any wrap information. Only preexisting sources will be used. This is useful (mostly for distros) when you want to only use the sources provided by a software release, and want to manually handle or provide missing dependencies.