### PR TITLE
Add --test-package-append that you can specify extra test packages for each test.

### DIFF
--- a/.github/workflows/melange-test-pipelines.yaml
+++ b/.github/workflows/melange-test-pipelines.yaml
@@ -47,6 +47,13 @@ jobs:
         package:
           - php-8.2-msgpack
           - py3-pandas
+          # The ones with -nopkg are packages which do not specify test
+          # packages, and they are added to the test environment by using flags.
+          # They make sure the flag `--test-package-append` works.
+          # We also do not specify the test package in the test file, so that
+          # we test that the main package gets correctly pulled from the file.
+          - php-8.2-msgpack-test-nopkg
+          - py3-pandas-test-nopkg
 
     steps:
       # Grab the melange we uploaded above, and install it.
@@ -67,8 +74,33 @@ jobs:
       # Make sure we have our tests files here.
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
-      - run: |
+      - name: Run without additional test packages.
+        # Any package ending with -nopkg will fail if we do not add the
+        # extra test packages to it, so test in a separate leg.
+        if: ${{ !endsWith( ${{ matrix.package }}, '-nopkg' ) }}
+        run: |
           testfile="${{ matrix.package }}-test.yaml"
           echo "Testing $testfile"
 
-          melange test --arch x86_64 --source-dir ./e2e-tests/test-fixtures ./e2e-tests/$testfile ${{ matrix.package }} --repository-append https://packages.wolfi.dev/os --keyring-append https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+          melange test --arch x86_64 --source-dir ./e2e-tests/test-fixtures \
+          ./e2e-tests/$testfile ${{ matrix.package }} \
+          --repository-append https://packages.wolfi.dev/os \
+          --keyring-append https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+
+      - name: Run with additional test packages (--test-package-append).
+        # Any package ending with -nopkg will need to have test packages
+        # added to it. Note that we do not add a package to test either, pull
+        # that from the test file.
+        if: endsWith( ${{ matrix.package }}, '-nopkg.yaml' )
+        run: |
+          testfile="${{ matrix.package }}-test.yaml"
+          echo "Testing $testfile"
+
+          melange test --arch x86_64 --source-dir ./e2e-tests/test-fixtures \
+          ./e2e-tests/$testfile \
+          --repository-append https://packages.wolfi.dev/os \
+          --keyring-append https://packages.wolfi.dev/os/wolfi-signing.rsa.pub \
+          --test-package-append wolfi-base \
+          --test-package-append busybox \
+          --test-package-append python-3
+

--- a/.github/workflows/melange-test-pipelines.yaml
+++ b/.github/workflows/melange-test-pipelines.yaml
@@ -77,7 +77,7 @@ jobs:
       - name: Run without additional test packages.
         # Any package ending with -nopkg will fail if we do not add the
         # extra test packages to it, so test in a separate leg.
-        if: false == endsWith( ${{ matrix.package }}, '-nopkg' )
+        if: ${{ ! endsWith( matrix.package, '-nopkg' ) }}
         run: |
           testfile="${{ matrix.package }}-test.yaml"
           echo "Testing $testfile"
@@ -91,7 +91,7 @@ jobs:
         # Any package ending with -nopkg will need to have test packages
         # added to it. Note that we do not add a package to test either, pull
         # that from the test file.
-        if: endsWith( ${{ matrix.package }}, '-nopkg.yaml' )
+        if: endsWith( matrix.package, '-nopkg.yaml' )
         run: |
           testfile="${{ matrix.package }}-test.yaml"
           echo "Testing $testfile"

--- a/.github/workflows/melange-test-pipelines.yaml
+++ b/.github/workflows/melange-test-pipelines.yaml
@@ -77,7 +77,7 @@ jobs:
       - name: Run without additional test packages.
         # Any package ending with -nopkg will fail if we do not add the
         # extra test packages to it, so test in a separate leg.
-        if: ${{ !endsWith( ${{ matrix.package }}, '-nopkg' ) }}
+        if: ${{ ! endsWith( ${{ matrix.package }}, '-nopkg' ) }}
         run: |
           testfile="${{ matrix.package }}-test.yaml"
           echo "Testing $testfile"

--- a/.github/workflows/melange-test-pipelines.yaml
+++ b/.github/workflows/melange-test-pipelines.yaml
@@ -52,8 +52,8 @@ jobs:
           # They make sure the flag `--test-package-append` works.
           # We also do not specify the test package in the test file, so that
           # we test that the main package gets correctly pulled from the file.
-          - php-8.2-msgpack-test-nopkg
-          - py3-pandas-test-nopkg
+          - php-8.2-msgpack-nopkg
+          - py3-pandas-nopkg
 
     steps:
       # Grab the melange we uploaded above, and install it.

--- a/.github/workflows/melange-test-pipelines.yaml
+++ b/.github/workflows/melange-test-pipelines.yaml
@@ -91,7 +91,7 @@ jobs:
         # Any package ending with -nopkg will need to have test packages
         # added to it. Note that we do not add a package to test either, pull
         # that from the test file.
-        if: endsWith( matrix.package, '-nopkg.yaml' )
+        if: endsWith( matrix.package, '-nopkg' )
         run: |
           testfile="${{ matrix.package }}-test.yaml"
           echo "Testing $testfile"

--- a/.github/workflows/melange-test-pipelines.yaml
+++ b/.github/workflows/melange-test-pipelines.yaml
@@ -77,7 +77,7 @@ jobs:
       - name: Run without additional test packages.
         # Any package ending with -nopkg will fail if we do not add the
         # extra test packages to it, so test in a separate leg.
-        if: ${{ ! endsWith( ${{ matrix.package }}, '-nopkg' ) }}
+        if: false == endsWith( ${{ matrix.package }}, '-nopkg' )
         run: |
           testfile="${{ matrix.package }}-test.yaml"
           echo "Testing $testfile"

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -115,6 +115,14 @@ way (build a local copy, and it will be picked up by APK resolver). This is very
 similar to how we build/test images with local versions of packages, so again,
 this should feel very natural.
 
+### Execution environmnent, specifying extra test packages
+
+If you want to have a minimal test specification, and tests need a package, you
+can specify `--test-package-append` (you can specify multiple times), so that
+you don't need to include those in your `test.environment.contents.packages`.
+Note that these packages are added to each test environment (including
+subpackages).
+
 ### Where to define the tests?
 
 So, this is one open question, but the short answer is that you can add these

--- a/docs/md/melange_test.md
+++ b/docs/md/melange_test.md
@@ -28,23 +28,24 @@ melange test [flags]
 ### Options
 
 ```
-      --apk-cache-dir string        directory used for cached apk packages (default is system-defined cache directory)
-      --arch strings                architectures to build for (e.g., x86_64,ppc64le,arm64) -- default is all, unless specified in config
-      --cache-dir string            directory used for cached inputs
-      --cache-source string         directory or bucket used for preloading the cache
-      --debug                       enables debug logging of test pipelines (sets -x for steps)
-      --debug-runner                when enabled, the builder pod will persist after the build succeeds or fails
-      --guest-dir string            directory used for the build environment guest
-  -h, --help                        help for test
-  -k, --keyring-append strings      path to extra keys to include in the build environment keyring
-      --log-policy strings          logging policy to use (default [builtin:stderr])
-      --overlay-binsh string        use specified file as /bin/sh overlay in build environment
-      --pipeline-dirs strings       directories used to extend defined built-in pipelines
-  -r, --repository-append strings   path to extra repositories to include in the build environment
-      --runner string               which runner to use to enable running commands, default is based on your platform. Options are ["bubblewrap" "docker" "lima" "kubernetes"] (default "bubblewrap")
-      --source-dir string           directory used for included sources
-      --test-option strings         build options to enable
-      --workspace-dir string        directory used for the workspace at /home/build
+      --apk-cache-dir string          directory used for cached apk packages (default is system-defined cache directory)
+      --arch strings                  architectures to build for (e.g., x86_64,ppc64le,arm64) -- default is all, unless specified in config
+      --cache-dir string              directory used for cached inputs
+      --cache-source string           directory or bucket used for preloading the cache
+      --debug                         enables debug logging of test pipelines (sets -x for steps)
+      --debug-runner                  when enabled, the builder pod will persist after the build succeeds or fails
+      --guest-dir string              directory used for the build environment guest
+  -h, --help                          help for test
+  -k, --keyring-append strings        path to extra keys to include in the build environment keyring
+      --log-policy strings            logging policy to use (default [builtin:stderr])
+      --overlay-binsh string          use specified file as /bin/sh overlay in build environment
+      --pipeline-dirs strings         directories used to extend defined built-in pipelines
+  -r, --repository-append strings     path to extra repositories to include in the build environment
+      --runner string                 which runner to use to enable running commands, default is based on your platform. Options are ["bubblewrap" "docker" "lima" "kubernetes"] (default "bubblewrap")
+      --source-dir string             directory used for included sources
+      --test-option strings           build options to enable
+      --test-package-append strings   extra packages to install for each of the test environments
+      --workspace-dir string          directory used for the workspace at /home/build
 ```
 
 ### SEE ALSO

--- a/e2e-tests/php-8.2-msgpack-nopkg-test.yaml
+++ b/e2e-tests/php-8.2-msgpack-nopkg-test.yaml
@@ -1,0 +1,38 @@
+# This is an example test file that shows how 'melange test' works.
+# It has been pulled into its own file, to try to clearly show what the
+# test file looks like.
+# Note, that these tests can also be baked into the package file itself.
+#
+package:
+  name: php-8.2-msgpack
+  version: 2.2.0
+  epoch: 0
+  description: "Tests for PHP extension msgpack"
+  copyright:
+    - license: BSD-3-Clause
+
+# This is mandatory, so just put an empty one there. Otherwise, config parsing
+# will fail.
+pipeline:
+
+test:
+  pipeline:
+    - runs: |
+        # Make sure msgpack is correctly loaded and listed by modules
+        php -m | grep msgpack
+
+subpackages:
+  - name: ${{package.name}}-config
+    description: PHP 8.2 msgpack tests
+    test:
+      pipeline:
+        - runs: |
+            grep msgpack.so /etc/php/conf.d/msgpack.ini
+
+  - name: ${{package.name}}-dev
+    description: PHP 8.2 msgpack development headers tests
+    test:
+      pipeline:
+        - runs: |
+            # Just make sure this define is there.
+            grep PHP_MSGPACK_VERSION /usr/include/php/ext/msgpack/php_msgpack.h

--- a/e2e-tests/py3-pandas-nopkg-test.yaml
+++ b/e2e-tests/py3-pandas-nopkg-test.yaml
@@ -1,0 +1,19 @@
+package:
+  name: py3-pandas
+  version: 2.1.3
+  epoch: 1
+  description: Tests for py3-pandas
+  copyright:
+    - license: 'BSD-3-Clause'
+
+pipeline:
+
+test:
+  environment:
+    contents:
+      packages:
+        - busybox
+        - python-3
+  pipeline:
+    - runs: |
+        python3 ./py3-pandas-test.py

--- a/pkg/cli/test.go
+++ b/pkg/cli/test.go
@@ -44,6 +44,7 @@ func Test() *cobra.Command {
 	var debug bool
 	var debugRunner bool
 	var runner string
+	var extraTestPackages []string
 
 	cmd := &cobra.Command{
 		Use:     "test",
@@ -61,6 +62,7 @@ func Test() *cobra.Command {
 				build.WithTestGuestDir(guestDir),
 				build.WithTestExtraKeys(extraKeys),
 				build.WithTestExtraRepos(extraRepos),
+				build.WithExtraTestPackages(extraTestPackages),
 				build.WithTestBinShOverlay(overlayBinSh),
 				build.WithTestRunner(runner),
 				build.WithTestDebug(debug),
@@ -103,6 +105,7 @@ func Test() *cobra.Command {
 	cmd.Flags().BoolVar(&debug, "debug", false, "enables debug logging of test pipelines (sets -x for steps)")
 	cmd.Flags().BoolVar(&debugRunner, "debug-runner", false, "when enabled, the builder pod will persist after the build succeeds or fails")
 	cmd.Flags().StringSliceVarP(&extraRepos, "repository-append", "r", []string{}, "path to extra repositories to include in the build environment")
+	cmd.Flags().StringSliceVar(&extraTestPackages, "test-package-append", []string{}, "extra packages to install for each of the test environments")
 
 	return cmd
 }


### PR DESCRIPTION
Add a new flag `--test-package-append` that allows you to omit specifying packages in the `yaml` file, and instead specify
them from the command line. They are handy if you have a common package that all tests require so that you don't have
to keep specifying them in your yaml.


## Melange Pull Request Template

<!--
*** PULL REQUEST CHECKLIST: PLEASE START HERE ***

The single most important feature of melange is that we can build Wolfi.

Many changes to melange introduce a risk of breaking the build, and sometimes
these are not flushed out until a package is changed (much) later.  This
pertains to basic execution, SCA changes, linter changes, and more.
-->

### Functional Changes

- [ ] This change can build all of Wolfi without errors (describe results in notes)

Notes:

### SCA Changes

- [ ] Examining several representative APKs show no regression / the desired effect (details in notes)

Notes:

### Linter

- [ ] The new check is clean across Wolfi
- [ ] The new check is opt-in or a warning

Notes:
