### PR TITLE
fix test.environment jsonschema struct tag

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -385,7 +385,7 @@ type Test struct {
 	// Environment.Contents.Packages automatically get
 	// package.dependencies.runtime added to it. So, if your test needs
 	// no additional packages, you can leave it blank.
-	Environment apko_types.ImageConfiguration
+	Environment apko_types.ImageConfiguration `json:"environment" yaml:"environment"`
 
 	// Required: The list of pipelines that test the produced package.
 	Pipeline []Pipeline `json:"pipeline" yaml:"pipeline"`
@@ -846,7 +846,7 @@ func ParseConfiguration(configurationFilePath string, opts ...ConfigurationParsi
 		defaultEnvVarGOMODCACHE = "/var/cache/melange/gomodcache"
 	)
 
-	var setIfEmpty = func(key, value string) {
+	setIfEmpty := func(key, value string) {
 		if cfg.Environment.Environment[key] == "" {
 			cfg.Environment.Environment[key] = value
 		}

--- a/pkg/config/schema.json
+++ b/pkg/config/schema.json
@@ -831,7 +831,7 @@
     },
     "Test": {
       "properties": {
-        "Environment": {
+        "environment": {
           "$ref": "#/$defs/ImageConfiguration",
           "description": "Additional Environment necessary for test.\nEnvironment.Contents.Packages automatically get\npackage.dependencies.runtime added to it. So, if your test needs\nno additional packages, you can leave it blank."
         },
@@ -846,7 +846,7 @@
       "additionalProperties": false,
       "type": "object",
       "required": [
-        "Environment",
+        "environment",
         "pipeline"
       ]
     },


### PR DESCRIPTION
the default for the jsonschema we use calls this `test.Environment`, but the schema itself is actually `test.environment`