### PR TITLE
Allow execable shared objects if name has ".so."

### DIFF
--- a/pkg/sca/sca_test.go
+++ b/pkg/sca/sca_test.go
@@ -135,11 +135,11 @@ func TestAnalyze(t *testing.T) {
 			"so:ld-linux-aarch64.so.1",
 			"so:libc.so.6",
 			"so:libcap.so.2",
-			// TODO: This is wrong but we want the test to pass before we fix it.
 			"so:libpsx.so.2",
 		},
 		Provides: []string{
 			"so:libcap.so.2=2",
+			"so:libpsx.so.2=2",
 		},
 	}
 


### PR DESCRIPTION
Fixes https://github.com/chainguard-dev/melange/issues/920

There are not many shared objects that do this, but it does happen, and checking for ".so." is a little more better than looking for "libc" if we want this to work for any execable shared object (like libcap.so.2).

## Melange Pull Request Template

<!--
*** PULL REQUEST CHECKLIST: PLEASE START HERE ***

The single most important feature of melange is that we can build Wolfi.

Many changes to melange introduce a risk of breaking the build, and sometimes
these are not flushed out until a package is changed (much) later.  This
pertains to basic execution, SCA changes, linter changes, and more.
-->

### Functional Changes

- [ ] This change can build all of Wolfi without errors (describe results in notes)

Notes:

### SCA Changes

- [x] Examining several representative APKs show no regression / the desired effect (details in notes)

```
tar -Oxf packages/aarch64/libcap-2.69-r2.apk .PKGINFO
# Generated by melange.
pkgname = libcap
pkgver = 2.69-r2
arch = aarch64
size = 148643
origin = libcap
pkgdesc = POSIX 1003.1e capabilities
url =
commit = a474f16f202c5672a94c7fac31b7d671f6808908
builddate = 1705015782
license = BSD-3-Clause OR GPL-2.0-only
depend = so:ld-linux-aarch64.so.1
depend = so:libc.so.6
provides = so:libcap.so.2=2
provides = so:libpsx.so.2=2
datahash = ca1db049dc00c838fe2d168fa44cdebeb11f2e42d5e6007f5b76e76f079abe14
```

Looking at `glibc` to make sure I didn't break `provides = so:libc.so.6=6`.

The `r11` package was built with melange before this commit, `r12` was built with this commit:

```
diff <(tar -Oxf packages/aarch64/glibc-2.38-r11.apk .PKGINFO) <(tar -Oxf packages/aarch64/glibc-2.38-r12.apk .PKGINFO)
--- /dev/fd/63
+++ /dev/fd/62
@@ -1,8 +1,8 @@
 # Generated by melange.
 pkgname = glibc
-pkgver = 2.38-r11
+pkgver = 2.38-r12
 arch = aarch64
-size = 5592339
+size = 5592327
 origin = glibc
 pkgdesc = the GNU C library
 url =
@@ -12,7 +12,7 @@
 depend = glibc-locale-posix
 depend = so:ld-linux-aarch64.so.1
 depend = wolfi-baselayout
-provides = cmd:ldconfig=2.38-r11
+provides = cmd:ldconfig=2.38-r12
 provides = so:libBrokenLocale.so.1=1
 provides = so:libanl.so.1=1
 provides = so:libc.so.6=6
@@ -31,4 +31,4 @@
 provides = so:libthread_db.so.1=1
 provides = so:libutil.so.1=1
 triggers = /lib /lib64 /usr/lib /usr/lib64
-datahash = ea86de48a7396e3635cc21c5794d339b3bee8d96336790c06e6310d98638573e
+datahash = f16614cc7022bea215a4012482028588779e8bc54c77f723ec1ff24f1e1e9be4
```

Notes:

### Linter

- [ ] The new check is clean across Wolfi
- [ ] The new check is opt-in or a warning

Notes:
