### PR TITLE
Make "unable to detect git commit" a debug message

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -562,7 +562,7 @@ func detectCommit(ctx context.Context, dirPath string) string {
 	// TODO: figure out how to use an abstract FS
 	repo, err := git.PlainOpen(dirPath)
 	if err != nil {
-		log.Warnf("unable to detect git commit for build configuration: %v", err)
+		log.Debugf("unable to detect git commit for build configuration: %v", err)
 		return ""
 	}
 


### PR DESCRIPTION
This was promoted from an Info here: https://github.com/chainguard-dev/melange/commit/6d6fdc0225094a4a86a9e0cd7346c1f3e70af8bb#diff-a3d824da3c42420cd5cbb0a4a2c0e7b5bfddd819652788a0596d195dc6e31fa5R565

But it's not that useful, especially when parsing lots and lots and lots of configs from the same git-commit-less filesystem.