### PR TITLE
Fail if unknown variable is used in substitution

### DIFF
--- a/pkg/build/pipeline.go
+++ b/pkg/build/pipeline.go
@@ -189,7 +189,7 @@ func validateWith(data map[string]string, inputs map[string]config.Input) (map[s
 	}
 
 	for k, v := range inputs {
-		if data[k] == "" && v.Default != "" {
+		if data[k] == "" {
 			data[k] = v.Default
 		}
 

--- a/pkg/build/pipeline_test.go
+++ b/pkg/build/pipeline_test.go
@@ -35,10 +35,9 @@ func Test_mutateStringFromMap(t *testing.T) {
 	}
 
 	input1 := "${{inputs.foo}} ${{inputs.baz-bah-boom}}"
-	output1, err := util.MutateStringFromMap(keys, input1)
+	_, err := util.MutateStringFromMap(keys, input1)
 
-	require.NoError(t, err)
-	require.Equal(t, output1, "foo ", "bogus variable substitution not deleted")
+	require.Error(t, err)
 }
 
 func Test_substitutionMap(t *testing.T) {

--- a/pkg/build/pipelines/autoconf/configure.yaml
+++ b/pkg/build/pipelines/autoconf/configure.yaml
@@ -16,6 +16,11 @@ inputs:
       The GNU triplet which describes the build system.
     default: ${{host.triplet.gnu}}
 
+  opts:
+    description: |
+      Options to pass to the ./configure command.
+    default: ''
+
 pipeline:
   - runs: |
       cd ${{inputs.dir}}


### PR DESCRIPTION
Tested this with this diff to crane.yaml:

```
diff --git a/crane.yaml b/crane.yaml
index 3f5c32dc2..9d458809f 100644
--- a/crane.yaml
+++ b/crane.yaml
@@ -1,13 +1,15 @@
 package:
   name: crane
   version: 0.18.0
-  epoch: 0
+  epoch: 1
   description: Tool for interacting with remote images and registries.
   copyright:
     - license: Apache-2.0
   dependencies:
     runtime:
       - ca-certificates-bundle
+    provides:
+      - foo=${{package.fullversion}}
 
 environment:
   contents:
```

```
ℹ️            | error during command execution: failed to apply replacement to provides "foo=${{package.fullversion}}": variable package.fullversion not defined
```