### PR TITLE
sort with key/values

### DIFF
--- a/pkg/build/pipeline.go
+++ b/pkg/build/pipeline.go
@@ -20,11 +20,13 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 
 	"github.com/chainguard-dev/clog"
 	"go.opentelemetry.io/otel"
+	"golang.org/x/exp/maps"
 
 	"gopkg.in/yaml.v3"
 
@@ -268,8 +270,10 @@ func (pctx *PipelineContext) loadUse(ctx context.Context, pb *PipelineBuild, use
 
 func (pctx *PipelineContext) dumpWith(ctx context.Context) {
 	log := clog.FromContext(ctx)
-	for k, v := range pctx.Pipeline.With {
-		log.Debug("    " + k + ": " + v)
+	ks := maps.Keys(pctx.Pipeline.With)
+	sort.Strings(ks)
+	for _, k := range ks {
+		log.Debugf("    %s: %s", k, pctx.Pipeline.With[k])
 	}
 }
 


### PR DESCRIPTION
Before (recent release)

```
ℹ️  aarch64   | running pipeline for subpackage containerd-stress
❕ aarch64   |     ${{targets.contextdir}}: /home/build/melange-out/containerd-stress
❕ aarch64   |     ${{targets.package.ctr}}: /home/build/melange-out/ctr
❕ aarch64   |     ${{cross.triplet.gnu.musl}}: aarch64-unknown-linux-musl
❕ aarch64   |     ${{targets.subpkgdir}}: /home/build/melange-out/containerd-stress
❕ aarch64   |     ${{targets.package.containerd-shim-runc-v1}}: /home/build/melange-out/containerd-shim-runc-v1
❕ aarch64   |     ${{package.epoch}}: 3
❕ aarch64   |     ${{targets.destdir}}: /home/build/melange-out/containerd
❕ aarch64   |     ${{targets.package.containerd}}: /home/build/melange-out/containerd
...
```

After (including clog improvements)

```
ℹ️  aarch64   | running step Run a build using the go compiler
ℹ️  aarch64   |     ${{build.arch}}: aarch64
ℹ️  aarch64   |     ${{cross.triplet.gnu.glibc}}: aarch64-unknown-linux-gnu
ℹ️  aarch64   |     ${{cross.triplet.gnu.musl}}: aarch64-unknown-linux-musl
ℹ️  aarch64   |     ${{host.triplet.gnu}}: aarch64-unknown-linux-gnu
ℹ️  aarch64   |     ${{host.triplet.rust}}: aarch64-unknown-linux-gnu
ℹ️  aarch64   |     ${{inputs.go-package}}: go
ℹ️  aarch64   |     ${{inputs.install-dir}}: bin
...
```