### PR TITLE
Take advantage of Octo STS to publish homebrew updates.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,11 +30,18 @@ jobs:
           version: latest
           install-only: true
 
+      # Federate to create a token to authenticate with the homebrew-tap repository.
+      - uses: chainguard-dev/actions/octo-sts@main
+        id: octo-sts
+        with:
+          scope: chainguard-dev/homebrew-tap
+          identity: melange
+
       - name: Release
         run: make release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ steps.octo-sts.outputs.token }}
 
   ko-build:
     name: Release melange image


### PR DESCRIPTION
Once the trust policy lands here: https://github.com/chainguard-dev/homebrew-tap/pull/53

This change will enable the release workflow to federate with the Octo STS app to create tokens in accordance with the trust policy and avoid the use of PATs.
