### PR TITLE
unexport some methods in pkg/sbom

### DIFF
--- a/pkg/sbom/generator.go
+++ b/pkg/sbom/generator.go
@@ -47,7 +47,7 @@ func (g *Generator) GenerateSBOM(ctx context.Context, spec *Spec) error {
 	_, span := otel.Tracer("melange").Start(ctx, "GenerateSBOM")
 	defer span.End()
 
-	shouldRun, err := CheckEnvironment(spec)
+	shouldRun, err := checkEnvironment(spec)
 	if err != nil {
 		return fmt.Errorf("checking SBOM environment: %w", err)
 	}
@@ -62,20 +62,20 @@ func (g *Generator) GenerateSBOM(ctx context.Context, spec *Spec) error {
 		Files:    []file{},
 	}
 
-	pkg, err := GenerateAPKPackage(spec)
+	pkg, err := generateAPKPackage(spec)
 	if err != nil {
 		return fmt.Errorf("generating main package: %w", err)
 	}
 
 	// Add file inventory to packages
-	if err := ScanFiles(spec, &pkg); err != nil {
+	if err := scanFiles(spec, &pkg); err != nil {
 		return fmt.Errorf("reading SBOM file inventory: %w", err)
 	}
 
 	sbomDoc.Packages = append(sbomDoc.Packages, pkg)
 
 	// Finally, write the SBOM data to disk
-	if err := WriteSBOM(spec, sbomDoc); err != nil {
+	if err := writeSBOM(spec, sbomDoc); err != nil {
 		return fmt.Errorf("writing sbom to disk: %w", err)
 	}
 

--- a/pkg/sbom/implementation.go
+++ b/pkg/sbom/implementation.go
@@ -59,7 +59,7 @@ func stringToIdentifier(in string) (out string) {
 	})
 }
 
-func CheckEnvironment(spec *Spec) (bool, error) {
+func checkEnvironment(spec *Spec) (bool, error) {
 	dirPath, err := filepath.Abs(spec.Path)
 	if err != nil {
 		return false, fmt.Errorf("getting absolute directory path: %w", err)
@@ -76,8 +76,8 @@ func CheckEnvironment(spec *Spec) (bool, error) {
 	return true, nil
 }
 
-// GenerateAPKPackage generates the sbom package representing the apk
-func GenerateAPKPackage(spec *Spec) (pkg, error) {
+// generateAPKPackage generates the sbom package representing the apk
+func generateAPKPackage(spec *Spec) (pkg, error) {
 	if spec.PackageName == "" {
 		return pkg{}, errors.New("unable to generate package, name not specified")
 	}
@@ -103,9 +103,9 @@ func GenerateAPKPackage(spec *Spec) (pkg, error) {
 	return newPackage, nil
 }
 
-// ScanFiles reads the files to be packaged in the apk and
+// scanFiles reads the files to be packaged in the apk and
 // extracts the required data for the SBOM.
-func ScanFiles(spec *Spec, dirPackage *pkg) error {
+func scanFiles(spec *Spec, dirPackage *pkg) error {
 	dirPath, err := filepath.Abs(spec.Path)
 	if err != nil {
 		return fmt.Errorf("getting absolute directory path: %w", err)
@@ -376,8 +376,8 @@ func buildDocumentSPDX(spec *Spec, doc *bom) (*spdx.Document, error) {
 	return &spdxDoc, nil
 }
 
-// WriteSBOM writes the SBOM to the apk filesystem
-func WriteSBOM(spec *Spec, doc *bom) error {
+// writeSBOM writes the SBOM to the apk filesystem
+func writeSBOM(spec *Spec, doc *bom) error {
 	spdxDoc, err := buildDocumentSPDX(spec, doc)
 	if err != nil {
 		return fmt.Errorf("building SPDX document: %w", err)


### PR DESCRIPTION
These aren't called outside of this package, and exposing implementation details like this can make future refactorings harder.