### PR TITLE
stop logging tons of "detected git commit for build configuration" wh…

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -572,7 +572,6 @@ func detectCommit(ctx context.Context, dirPath string) string {
 	}
 
 	commit := head.Hash().String()
-	log.Infof("detected git commit for build configuration: %s", commit)
 	return commit
 }
 


### PR DESCRIPTION
…en parsing melange config

Downstream projects used `ParseConfiguration` which in turn generates a log for each package that is being parsed.  On wolfi that is over a thousand packages so you get lots of logs in you terminal