### PR TITLE
test: skip when executing on an unsupported arch

### DIFF
--- a/examples/one-arch.yaml
+++ b/examples/one-arch.yaml
@@ -1,0 +1,39 @@
+package:
+  name: one-arch
+  version: 0.0.1
+  epoch: 0
+  description: "an example of how target-architecture works"
+  copyright:
+    - license: Not-Applicable
+  target-architecture:
+    - x86_64
+
+environment:
+  contents:
+    repositories:
+      - https://packages.wolfi.dev/os
+    keyring:
+      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    packages:
+      - busybox
+
+pipeline:
+  - runs: echo hello package
+
+test:
+  environment:
+    contents:
+      repositories:
+        - https://packages.wolfi.dev/os
+      keyring:
+        - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+      packages:
+        - busybox
+  pipeline:
+    - if: ${{targets.architecture == "x86_64"}}
+      runs: |
+        echo hello test
+    - if: ${{targets.architecture == "arm64"}}
+      runs: |
+        echo "BAD ARCHITECTURE"
+        exit 1

--- a/pkg/build/test.go
+++ b/pkg/build/test.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 
 	apko_build "chainguard.dev/apko/pkg/build"
+	"chainguard.dev/apko/pkg/build/types"
 	apko_types "chainguard.dev/apko/pkg/build/types"
 	"github.com/chainguard-dev/clog"
 	apkofs "github.com/chainguard-dev/go-apk/pkg/fs"
@@ -492,6 +493,18 @@ func (t *Test) TestPackage(ctx context.Context) error {
 		Package: pkg,
 	}
 
+	inarchs := false
+	for _, ta := range pkg.TargetArchitecture {
+		if types.ParseArchitecture(ta) == t.Arch {
+			inarchs = true
+			break
+		}
+	}
+	if !inarchs {
+		log.Warnf("skipping test for %s on %s", pkg.Name, t.Arch)
+		return nil
+	}
+
 	if t.GuestDir == "" {
 		guestDir, err := os.MkdirTemp(t.Runner.TempDir(), "melange-guest-*")
 		if err != nil {
@@ -566,6 +579,7 @@ func (t *Test) TestPackage(ctx context.Context) error {
 
 	if !t.IsTestless() {
 		cfg.Arch = t.Arch
+
 		if err := t.Runner.StartPod(ctx, cfg); err != nil {
 			return fmt.Errorf("unable to start pod: %w", err)
 		}


### PR DESCRIPTION
If you `melange build` a package for one arch, it should not cause an error to `melange test` that package on a different arch -- it shouldn't even care that the package to test doesn't exist.

Tested with:

```
$ go run ./ build examples/one-arch.yaml
# succeeds
$ go run ./ test examples/one-arch.yaml  ./packages/x86_64/one-arch-0.0.1-r0.apk --arch=x86_64
# passes              
$ go run ./ test examples/one-arch.yaml  ./packages/x86_64/one-arch-0.0.1-r0.apk --arch=aarch64              
⚠️            | skipping test for one-arch on arm64
$ go run ./ test examples/one-arch.yaml  ./packages/armv7/one-arch-0.0.1-r0.apk --arch=aarch64
⚠️            | skipping test for one-arch on arm64
```