### PR TITLE
Fix race condition in log monitoring

### DIFF
--- a/pkg/container/docker_runner.go
+++ b/pkg/container/docker_runner.go
@@ -16,12 +16,13 @@ package container
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
-	"os"
 
 	"go.opentelemetry.io/otel"
+	"golang.org/x/sync/errgroup"
 
 	apko_build "chainguard.dev/apko/pkg/build"
 	apko_oci "chainguard.dev/apko/pkg/build/oci"
@@ -181,30 +182,25 @@ func (dk *docker) TempDir() string {
 
 // waitForCommand waits for a command to complete in the pod.
 func (dk *docker) waitForCommand(cfg *Config, ctx context.Context, attachResp types.HijackedResponse, taskIDResp types.IDResponse) error {
-	stdoutPipeR, stdoutPipeW, err := os.Pipe()
-	if err != nil {
-		return err
-	}
+	// log := clog.FromContext(ctx)
+	ctx, span := otel.Tracer("melange").Start(ctx, "waitForCommand")
+	defer span.End()
 
-	stderrPipeR, stderrPipeW, err := os.Pipe()
-	if err != nil {
-		return err
-	}
+	stdoutPipeR, stdoutPipeW := io.Pipe()
+	stderrPipeR, stderrPipeW := io.Pipe()
 
-	finishStdout := make(chan struct{})
-	finishStderr := make(chan struct{})
+	var g errgroup.Group
+	g.Go(func() error {
+		return monitorPipe(ctx, slog.LevelInfo, stdoutPipeR)
+	})
+	g.Go(func() error {
+		return monitorPipe(ctx, slog.LevelWarn, stderrPipeR)
+	})
+	_, err := stdcopy.StdCopy(stdoutPipeW, stderrPipeW, attachResp.Reader)
+	stdoutPipeW.CloseWithError(err)
+	stderrPipeW.CloseWithError(err)
 
-	go monitorPipe(ctx, slog.LevelInfo, stdoutPipeR, finishStdout)
-	go monitorPipe(ctx, slog.LevelWarn, stderrPipeR, finishStderr)
-	_, err = stdcopy.StdCopy(stdoutPipeW, stderrPipeW, attachResp.Reader)
-
-	stdoutPipeW.Close()
-	stderrPipeW.Close()
-
-	<-finishStdout
-	<-finishStderr
-
-	return err
+	return errors.Join(err, g.Wait())
 }
 
 // Run runs a Docker task given a Config and command string.

--- a/pkg/container/monitor_pipe.go
+++ b/pkg/container/monitor_pipe.go
@@ -23,9 +23,8 @@ import (
 	"github.com/chainguard-dev/clog"
 )
 
-func monitorPipe(ctx context.Context, level slog.Level, pipe io.ReadCloser, finish chan struct{}) {
+func monitorPipe(ctx context.Context, level slog.Level, pipe io.Reader) error {
 	log := clog.FromContext(ctx)
-	defer pipe.Close()
 
 	scanner := bufio.NewScanner(pipe)
 	for scanner.Scan() {
@@ -38,5 +37,5 @@ func monitorPipe(ctx context.Context, level slog.Level, pipe io.ReadCloser, fini
 		}
 	}
 
-	finish <- struct{}{}
+	return scanner.Err()
 }


### PR DESCRIPTION
For some reason we were using os.Pipe instead of io.Pipe for an in-process pipe. I've switched those over to using io.Pipe so we can CloseWithError.

Also, switched to using errgroup.Group instead of manual channel signaling.

Now, when we hit an error, we actually log that error instead of the line just before that error.