### PR TITLE
Add Close() method to container runners

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -219,6 +219,10 @@ func New(ctx context.Context, opts ...Option) (*Build, error) {
 	return &b, nil
 }
 
+func (b *Build) Close() error {
+	return b.Runner.Close()
+}
+
 type Option func(*Build) error
 
 // WithConfig sets the configuration file used for the package build context.

--- a/pkg/build/test.go
+++ b/pkg/build/test.go
@@ -124,6 +124,10 @@ func NewTest(ctx context.Context, opts ...TestOption) (*Test, error) {
 	return &t, nil
 }
 
+func (t *Test) Close() error {
+	return t.Runner.Close()
+}
+
 type TestOption func(*Test) error
 
 // WithTestConfig sets the configuration file used for the package test context.

--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -194,6 +194,7 @@ func BuildCmd(ctx context.Context, archs []apko_types.Architecture, baseOpts ...
 		} else if err != nil {
 			return err
 		}
+		defer bc.Close()
 
 		bcs = append(bcs, bc)
 	}

--- a/pkg/cli/test.go
+++ b/pkg/cli/test.go
@@ -141,6 +141,7 @@ func TestCmd(ctx context.Context, archs []apko_types.Architecture, baseOpts ...b
 		} else if err != nil {
 			return err
 		}
+		defer bc.Close()
 
 		bcs = append(bcs, bc)
 	}

--- a/pkg/container/bubblewrap_runner.go
+++ b/pkg/container/bubblewrap_runner.go
@@ -42,6 +42,10 @@ func BubblewrapRunner() Runner {
 	return &bubblewrap{}
 }
 
+func (bw *bubblewrap) Close() error {
+	return nil
+}
+
 // Name name of the runner
 func (bw *bubblewrap) Name() string {
 	return BubblewrapName

--- a/pkg/container/kubernetes_runner.go
+++ b/pkg/container/kubernetes_runner.go
@@ -100,6 +100,10 @@ func KubernetesRunner(ctx context.Context) (Runner, error) {
 	return runner, nil
 }
 
+func (*k8s) Close() error {
+	return nil
+}
+
 // Name implements Runner
 func (*k8s) Name() string {
 	return KubernetesName

--- a/pkg/container/runner.go
+++ b/pkg/container/runner.go
@@ -29,6 +29,7 @@ import (
 )
 
 type Runner interface {
+	Close() error
 	Name() string
 	TestUsability(ctx context.Context) bool
 	// OCIImageLoader returns a Loader that will load an OCI image from a stream.
@@ -56,7 +57,7 @@ func GetRunner(ctx context.Context, s string) (Runner, error) {
 	case BubblewrapName:
 		return BubblewrapRunner(), nil
 	case DockerName:
-		return DockerRunner(), nil
+		return DockerRunner(ctx)
 	case KubernetesName:
 		return KubernetesRunner(ctx)
 	}


### PR DESCRIPTION
We were doing some needless RPCs to the docker daemon because we reconstruct a new client every time.

Instead, construct a client once and close it in a Close() method. Plumb Close() methods up through to melange build/test as well.