### PR TITLE
Don't use goroutines for monitoring logs

### DIFF
--- a/pkg/container/bubblewrap_runner.go
+++ b/pkg/container/bubblewrap_runner.go
@@ -82,7 +82,14 @@ func (bw *bubblewrap) Run(ctx context.Context, cfg *Config, args ...string) erro
 	execCmd := exec.CommandContext(ctx, "bwrap", args...)
 	slog.InfoContext(ctx, fmt.Sprintf("executing: %s", strings.Join(execCmd.Args, " ")))
 
-	return monitorCmd(ctx, cfg, execCmd)
+	stdout, stderr := logWriters(ctx)
+	defer stdout.Close()
+	defer stderr.Close()
+
+	execCmd.Stdout = stdout
+	execCmd.Stderr = stderr
+
+	return execCmd.Run()
 }
 
 // TestUsability determines if the Bubblewrap runner can be used


### PR DESCRIPTION
This is racey and silly because a log function is closer to a writer than it is to a reader, so using a pipe doesn't make sense. We can just turn a writer into a log function.
