### PR TITLE
Respond to cancelled context while streaming logs

### DIFF
--- a/pkg/container/docker_runner.go
+++ b/pkg/container/docker_runner.go
@@ -179,7 +179,10 @@ func (dk *docker) waitForCommand(ctx context.Context, r io.Reader) error {
 	defer stdout.Close()
 	defer stderr.Close()
 
-	_, err := stdcopy.StdCopy(stdout, stderr, r)
+	// Wrap this in a contextReader so we respond to cancel.
+	ctxr := &contextReader{r: r, ctx: ctx}
+
+	_, err := stdcopy.StdCopy(stdout, stderr, ctxr)
 	return err
 }
 

--- a/pkg/container/monitor_pipe.go
+++ b/pkg/container/monitor_pipe.go
@@ -64,3 +64,16 @@ func (l *levelWriter) Close() error {
 	}
 	return nil
 }
+
+type contextReader struct {
+	r   io.Reader
+	ctx context.Context
+}
+
+func (c *contextReader) Read(p []byte) (int, error) {
+	if err := c.ctx.Err(); err != nil {
+		return 0, err
+	}
+	n, err := c.r.Read(p)
+	return n, err
+}


### PR DESCRIPTION
Since StdCopy is a blocking call, even if ctx is cancelled, we won't actually clean up any containers. This ~fixes that.

This isn't a complete solution, but it's really straightfoward to implement, so I'm starting here. This only works when logs are being actively streamed (so we are actually calling Read). If the container isn't very chatty, this isn't as effective.

This is harmless to keep in, but we can also remove it when we have a better solution.