### PR TITLE
Add --rm flag (and options) to Build

### DIFF
--- a/docs/md/melange_build.md
+++ b/docs/md/melange_build.md
@@ -55,6 +55,7 @@ melange build [flags]
       --overlay-binsh string        use specified file as /bin/sh overlay in build environment
       --pipeline-dir string         directory used to extend defined built-in pipelines
   -r, --repository-append strings   path to extra repositories to include in the build environment
+      --rm                          clean up intermediate artifacts (e.g. container images)
       --runner string               which runner to use to enable running commands, default is based on your platform. Options are ["bubblewrap" "docker" "lima" "kubernetes"]
       --signing-key string          key to use for signing
       --source-dir string           directory used for included sources

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -86,6 +86,7 @@ type Build struct {
 	containerConfig   *container.Config
 	Debug             bool
 	DebugRunner       bool
+	Remove            bool
 	LogPolicy         []string
 	FailOnLintWarning bool
 	DefaultCPU        string
@@ -220,6 +221,11 @@ func New(ctx context.Context, opts ...Option) (*Build, error) {
 }
 
 func (b *Build) Close() error {
+	if b.Remove {
+		if err := b.Runner.OCIImageLoader().RemoveImage(context.TODO(), b.containerConfig.ImgRef); err != nil {
+			return err
+		}
+	}
 	return b.Runner.Close()
 }
 
@@ -495,6 +501,15 @@ func WithDebug(debug bool) Option {
 func WithDebugRunner(debug bool) Option {
 	return func(b *Build) error {
 		b.DebugRunner = debug
+		return nil
+	}
+}
+
+// WithRemove indicates whether the the build will clean up after itself.
+// This includes deleting any intermediate artifacts like container images.
+func WithRemove(remove bool) Option {
+	return func(b *Build) error {
+		b.Remove = remove
 		return nil
 	}
 }

--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -61,6 +61,7 @@ func Build() *cobra.Command {
 	var createBuildLog bool
 	var debug bool
 	var debugRunner bool
+	var remove bool
 	var runner string
 	var failOnLintWarning bool
 	var cpu, memory string
@@ -107,6 +108,7 @@ func Build() *cobra.Command {
 				build.WithCreateBuildLog(createBuildLog),
 				build.WithDebug(debug),
 				build.WithDebugRunner(debugRunner),
+				build.WithRemove(remove),
 				build.WithLogPolicy(logPolicy),
 				build.WithRunner(runner),
 				build.WithFailOnLintWarning(failOnLintWarning),
@@ -160,6 +162,7 @@ func Build() *cobra.Command {
 	cmd.Flags().BoolVar(&createBuildLog, "create-build-log", false, "creates a package.log file containing a list of packages that were built by the command")
 	cmd.Flags().BoolVar(&debug, "debug", false, "enables debug logging of build pipelines")
 	cmd.Flags().BoolVar(&debugRunner, "debug-runner", false, "when enabled, the builder pod will persist after the build succeeds or fails")
+	cmd.Flags().BoolVar(&remove, "rm", false, "clean up intermediate artifacts (e.g. container images)")
 	cmd.Flags().BoolVar(&failOnLintWarning, "fail-on-lint-warning", false, "turns linter warnings into failures")
 	cmd.Flags().StringVar(&cpu, "cpu", "", "default CPU resources to use for builds")
 	cmd.Flags().StringVar(&memory, "memory", "", "default memory resources to use for builds")

--- a/pkg/container/bubblewrap_runner.go
+++ b/pkg/container/bubblewrap_runner.go
@@ -191,3 +191,7 @@ func (b bubblewrapOCILoader) LoadImage(ctx context.Context, layer v1.Layer, arch
 	}
 	return guestDir, nil
 }
+
+func (b bubblewrapOCILoader) RemoveImage(ctx context.Context, ref string) error {
+	return os.RemoveAll(ref)
+}

--- a/pkg/container/kubernetes_runner.go
+++ b/pkg/container/kubernetes_runner.go
@@ -680,6 +680,14 @@ func (k *k8sLoader) LoadImage(ctx context.Context, layer ggcrv1.Layer, arch apko
 	return ref.String(), nil
 }
 
+func (k *k8sLoader) RemoveImage(ctx context.Context, str string) error {
+	ref, err := name.ParseReference(str)
+	if err != nil {
+		return err
+	}
+	return remote.Delete(ref, remote.WithAuthFromKeychain(authn.DefaultKeychain), remote.WithContext(ctx))
+}
+
 type k8sTarFetcher struct {
 	client     kubernetes.Interface
 	restconfig *rest.Config

--- a/pkg/container/runner.go
+++ b/pkg/container/runner.go
@@ -45,6 +45,7 @@ type Runner interface {
 
 type Loader interface {
 	LoadImage(ctx context.Context, layer v1.Layer, arch apko_types.Architecture, bc *apko_build.Context) (ref string, err error)
+	RemoveImage(ctx context.Context, ref string) error
 }
 
 // GetRunner returns the requested runner implementation.


### PR DESCRIPTION
This instructs melange to clean up after itself. Currently, this only applies to the guest container image, but we can expand the scope over time.

Sample output:

```
ℹ️  aarch64   | wrote packages/aarch64/crane-0.19.0-r0.apk
ℹ️  aarch64   | generating apk index from packages in packages/aarch64
ℹ️  aarch64   | processing package packages/aarch64/crane-0.19.0-r0.apk
ℹ️  aarch64   | updating index at packages/aarch64/APKINDEX.tar.gz with new packages: [crane-0.19.0-r0]
ℹ️  aarch64   | signing apk index at packages/aarch64/APKINDEX.tar.gz
ℹ️            | signing index packages/aarch64/APKINDEX.tar.gz with key local-melange.rsa
ℹ️            | appending signature to index packages/aarch64/APKINDEX.tar.gz
ℹ️            | writing signed index to packages/aarch64/APKINDEX.tar.gz
ℹ️            | signed index packages/aarch64/APKINDEX.tar.gz with key local-melange.rsa
ℹ️  aarch64   | pod ac91254af4489e676d0e563915219776d36962b53f332d0b19db4c87c72fc6b4 terminated.
ℹ️            | deleting image "apko.local/cache:f5128d9cacfe2b73b586e319f38d7c752d0459343fe2ab683ed99c38646d5f96"
ℹ️            | untagged "apko.local/cache:f5128d9cacfe2b73b586e319f38d7c752d0459343fe2ab683ed99c38646d5f96"
ℹ️            | deleted "sha256:0a961ac8f1279bca232cb414d5e1dcd997e10d283d09f2ae28149e7d4a8b4543"
```