### PR TITLE
feat: GOEXPERIMENT support to go/build and go/install pipelines

### DIFF
--- a/pkg/build/pipelines/go/build.yaml
+++ b/pkg/build/pipelines/go/build.yaml
@@ -29,6 +29,12 @@ inputs:
       the apk will be in prefix / install-dir / output
     required: true
 
+  experiments:
+    description: |
+      A comma-separated list of Golang experiment names (ex: loopvar) to use
+      when building the binary.
+    default: ""
+
   vendor:
     description: |
       If true, the go mod command will also update the vendor directory
@@ -81,6 +87,8 @@ pipeline:
 
       # Take advantage of melange's buid cache for downloaded modules
       export GOMODCACHE=/var/cache/melange/gomodcache
+
+      export GOEXPERIMENT="${{inputs.experiments}}"
 
       cd "${{inputs.modroot}}"
 

--- a/pkg/build/pipelines/go/build.yaml
+++ b/pkg/build/pipelines/go/build.yaml
@@ -29,12 +29,6 @@ inputs:
       the apk will be in prefix / install-dir / output
     required: true
 
-  experiments:
-    description: |
-      A comma-separated list of Golang experiment names (ex: loopvar) to use
-      when building the binary.
-    default: ""
-
   vendor:
     description: |
       If true, the go mod command will also update the vendor directory
@@ -70,6 +64,12 @@ inputs:
     description: |
       space separated list of go modules to update before building. example: github.com/foo/bar@v1.2.3
 
+  experiments:
+    description: |
+      A comma-separated list of Golang experiment names (ex: loopvar) to use
+      when building the binary.
+    default: ""
+
 pipeline:
   - runs: |
       TAGS=""
@@ -88,8 +88,6 @@ pipeline:
       # Take advantage of melange's buid cache for downloaded modules
       export GOMODCACHE=/var/cache/melange/gomodcache
 
-      export GOEXPERIMENT="${{inputs.experiments}}"
-
       cd "${{inputs.modroot}}"
 
       # Install any specified dependencies
@@ -106,4 +104,4 @@ pipeline:
       [ -e /home/build/go.mod.local ] && cp /home/build/go.mod.local go.mod
       [ -e /home/build/go.sum.local ] && cp /home/build/go.sum.local go.sum
 
-      go build -o "${{targets.contextdir}}"/${BASE_PATH} -tags "${TAGS}" -ldflags "${LDFLAGS}" -trimpath ${{inputs.packages}}
+      GOEXPERIMENT="${{inputs.experiments}}" go build -o "${{targets.contextdir}}"/${BASE_PATH} -tags "${TAGS}" -ldflags "${LDFLAGS}" -trimpath ${{inputs.packages}}

--- a/pkg/build/pipelines/go/install.yaml
+++ b/pkg/build/pipelines/go/install.yaml
@@ -41,6 +41,12 @@ inputs:
     description: |
       A comma-separated list of build tags to pass to the go compiler
 
+  experiments:
+    description: |
+      A comma-separated list of Golang experiment names (ex: loopvar) to use
+      when building the binary.
+    default: ""
+
 pipeline:
   - runs: |
       TAGS=""
@@ -62,8 +68,9 @@ pipeline:
         VERSION="@${{inputs.version}}"
       fi
 
+
       # Run go install
-      go install ${DEST_PATH} -tags "${TAGS}" -ldflags "${LDFLAGS}" ${{inputs.package}}${VERSION}
+      GOEXPERIMENT="${{inputs.experiments}}" go install ${DEST_PATH} -tags "${TAGS}" -ldflags "${LDFLAGS}" ${{inputs.package}}${VERSION}
       mkdir -p ${{targets.contextdir}}/${{inputs.prefix}}/${{inputs.install-dir}}
 
       # Move all resulting files to the target dir


### PR DESCRIPTION
This PR adds support for the optional [GOEXPERIMENT](https://pkg.go.dev/internal/goexperiment) environment variable in the `go/build` and `go/install` pipelines which can tweak the behavior of various Golang features, ex: [Fixing For Loops in Go 1.22](https://go.dev/blog/loopvar-preview).