### PR TITLE
Cancel context on interrupt signal

### DIFF
--- a/main.go
+++ b/main.go
@@ -15,13 +15,19 @@
 package main
 
 import (
+	"context"
 	"log"
+	"os"
+	"os/signal"
 
 	"chainguard.dev/melange/pkg/cli"
 )
 
 func main() {
-	if err := cli.New().Execute(); err != nil {
+	ctx, done := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer done()
+
+	if err := cli.New().ExecuteContext(ctx); err != nil {
 		log.Fatalf("error during command execution: %v", err)
 	}
 }


### PR DESCRIPTION
This gives melange a chance to clean up processes and images.