### PR TITLE
Make debugging melange builds less terrible

### DIFF
--- a/docs/md/melange_build.md
+++ b/docs/md/melange_build.md
@@ -47,6 +47,7 @@ melange build [flags]
       --generate-index              whether to generate APKINDEX.tar.gz (default true)
       --guest-dir string            directory used for the build environment guest
   -h, --help                        help for build
+  -i, --interactive                 when enabled, attaches stdin with a tty to the pod on failure
   -k, --keyring-append strings      path to extra keys to include in the build environment keyring
       --log-policy strings          logging policy to use (default [builtin:stderr])
       --memory string               default memory resources to use for builds

--- a/docs/md/melange_test.md
+++ b/docs/md/melange_test.md
@@ -36,6 +36,7 @@ melange test [flags]
       --debug-runner                  when enabled, the builder pod will persist after the build succeeds or fails
       --guest-dir string              directory used for the build environment guest
   -h, --help                          help for test
+  -i, --interactive                   when enabled, attaches stdin with a tty to the pod on failure
   -k, --keyring-append strings        path to extra keys to include in the build environment keyring
       --log-policy strings            logging policy to use (default [builtin:stderr])
       --overlay-binsh string          use specified file as /bin/sh overlay in build environment

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/chainguard-dev/kontext v0.1.0
 	github.com/chainguard-dev/yam v0.0.1
 	github.com/charmbracelet/log v0.3.2-0.20240205220859-7a3834f9b367
+	github.com/docker/cli v25.0.3+incompatible
 	github.com/docker/docker v25.0.3+incompatible
 	github.com/dprotaso/go-yit v0.0.0-20220510233725-9ba8df137936
 	github.com/dustin/go-humanize v1.0.1
@@ -62,6 +63,7 @@ require (
 	cloud.google.com/go/compute/metadata v0.2.3 // indirect
 	cloud.google.com/go/iam v1.1.5 // indirect
 	dario.cat/mergo v1.0.0 // indirect
+	github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 // indirect
 	github.com/MakeNowJust/heredoc/v2 v2.0.1 // indirect
 	github.com/Microsoft/go-winio v0.6.1 // indirect
 	github.com/ProtonMail/go-crypto v1.0.0 // indirect
@@ -79,7 +81,6 @@ require (
 	github.com/cyphar/filepath-securejoin v0.2.4 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/distribution/reference v0.5.0 // indirect
-	github.com/docker/cli v25.0.3+incompatible // indirect
 	github.com/docker/distribution v2.8.3+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.8.1 // indirect
 	github.com/docker/go-connections v0.5.0 // indirect
@@ -135,6 +136,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/moby/spdystream v0.2.0 // indirect
+	github.com/moby/term v0.5.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/muesli/reflow v0.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -537,6 +537,7 @@ golang.org/x/sys v0.0.0-20210112080510-489259a85091/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/pkg/build/options.go
+++ b/pkg/build/options.go
@@ -298,6 +298,14 @@ func WithDebugRunner(debug bool) Option {
 	}
 }
 
+// WithInteractive indicates whether to attach stdin and a tty to the runner on failures
+func WithInteractive(interactive bool) Option {
+	return func(b *Build) error {
+		b.Interactive = interactive
+		return nil
+	}
+}
+
 // WithRemove indicates whether the the build will clean up after itself.
 // This includes deleting any intermediate artifacts like container images.
 func WithRemove(remove bool) Option {

--- a/pkg/build/test.go
+++ b/pkg/build/test.go
@@ -61,6 +61,7 @@ type Test struct {
 	RunnerName        string
 	Debug             bool
 	DebugRunner       bool
+	Interactive       bool
 	LogPolicy         []string
 }
 

--- a/pkg/build/test_options.go
+++ b/pkg/build/test_options.go
@@ -114,6 +114,14 @@ func WithTestDebugRunner(debugRunner bool) TestOption {
 	}
 }
 
+// WithTestInteractive indicates whether to attach stdin and a tty to the runner on failures
+func WithTestInteractive(interactive bool) TestOption {
+	return func(t *Test) error {
+		t.Interactive = interactive
+		return nil
+	}
+}
+
 // WithTestExtraRepos adds a set of extra repos to the test context.
 func WithTestExtraRepos(extraRepos []string) TestOption {
 	return func(t *Test) error {

--- a/pkg/container/kubernetes_runner.go
+++ b/pkg/container/kubernetes_runner.go
@@ -685,6 +685,7 @@ func (k *k8sLoader) RemoveImage(ctx context.Context, str string) error {
 	if err != nil {
 		return err
 	}
+	clog.FromContext(ctx).Infof("deleting image %s", str)
 	return remote.Delete(ref, remote.WithAuthFromKeychain(authn.DefaultKeychain), remote.WithContext(ctx))
 }
 

--- a/pkg/container/runner.go
+++ b/pkg/container/runner.go
@@ -24,6 +24,10 @@ import (
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 )
 
+type Debugger interface {
+	Debug(context.Context, *Config, ...string) error
+}
+
 type Runner interface {
 	Close() error
 	Name() string


### PR DESCRIPTION
This introduces a new --interactive/-i flag that, if set, will drop you into an interactive tty with the melange build. This allows you to inspect the state of the filesystem and poke around.