### PR TITLE
Add --die-with-parent to bwrap flags

### DIFF
--- a/pkg/container/bubblewrap_runner.go
+++ b/pkg/container/bubblewrap_runner.go
@@ -64,7 +64,7 @@ func (bw *bubblewrap) Run(ctx context.Context, cfg *Config, args ...string) erro
 	}
 	// add the ref of the directory
 
-	baseargs = append(baseargs, "--unshare-pid",
+	baseargs = append(baseargs, "--unshare-pid", "--die-with-parent",
 		"--dev", "/dev",
 		"--proc", "/proc",
 		"--chdir", runnerWorkdir,


### PR DESCRIPTION
This prevents us from failing when background processes have not exited.