### PR TITLE
fix go-build example

### DIFF
--- a/examples/go-build.yaml
+++ b/examples/go-build.yaml
@@ -11,7 +11,7 @@
 # please see go-install.yaml in this directory.
 package:
   name: hello
-  version: v0.0.1
+  version: 0.0.1
   epoch: 0
   description: "A project that will greet the world infinitely"
 
@@ -26,14 +26,11 @@ pipeline:
   - uses: git-checkout
     with:
       repository: https://github.com/puerco/hello.git
-      destination: build-dir
-
-  - runs: |
-      git checkout ${{package.version}}
+      expected-commit: a73c4feb284dc6ed1e5758740f717f99dcd4c9d7
+      tag: v${{package.version}}
 
   - uses: go/build
     with:
-      modroot: build-dir
       tags: enterprise
-      packages: ./main.go
+      packages: .
       output: hello


### PR DESCRIPTION
This example had been broken because the `git checkout` didn't happen inside the directory that we cloned into.