### PR TITLE
move runner determination to pkg/cli

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -84,7 +84,6 @@ type Build struct {
 	EnvFile           string
 	VarsFile          string
 	Runner            container.Runner
-	RunnerName        string
 	containerConfig   *container.Config
 	Debug             bool
 	DebugRunner       bool
@@ -116,13 +115,6 @@ func New(ctx context.Context, opts ...Option) (*Build, error) {
 
 	log := clog.New(slog.Default().Handler()).With("arch", b.Arch.ToAPK())
 	ctx = clog.WithLogger(ctx, log)
-
-	// try to get the runner
-	runner, err := container.GetRunner(ctx, b.RunnerName)
-	if err != nil {
-		return nil, fmt.Errorf("unable to get runner %s: %w", b.RunnerName, err)
-	}
-	b.Runner = runner
 
 	// If no workspace directory is explicitly requested, create a
 	// temporary directory for it.  Otherwise, ensure we are in a
@@ -202,8 +194,8 @@ func New(ctx context.Context, opts ...Option) (*Build, error) {
 	}
 
 	// Check that we actually can run things in containers.
-	if !runner.TestUsability(ctx) {
-		return nil, fmt.Errorf("unable to run containers using %s, specify --runner and one of %s", runner.Name(), GetAllRunners())
+	if !b.Runner.TestUsability(ctx) {
+		return nil, fmt.Errorf("unable to run containers using %s, specify --runner and one of %s", b.Runner.Name(), GetAllRunners())
 	}
 
 	// Apply build options to the context.

--- a/pkg/build/options.go
+++ b/pkg/build/options.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	apko_types "chainguard.dev/apko/pkg/build/types"
+	"chainguard.dev/melange/pkg/container"
 )
 
 type Option func(*Build) error
@@ -317,9 +318,9 @@ func WithLogPolicy(policy []string) Option {
 
 // WithRunner specifies what runner to use to wrap
 // the build environment.
-func WithRunner(runner string) Option {
+func WithRunner(runner container.Runner) Option {
 	return func(b *Build) error {
-		b.RunnerName = runner
+		b.Runner = runner
 		return nil
 	}
 }

--- a/pkg/build/runner.go
+++ b/pkg/build/runner.go
@@ -1,7 +1,5 @@
 package build
 
-import "runtime"
-
 type Runner string
 
 const (
@@ -11,22 +9,6 @@ const (
 	runnerKubernetes Runner = "kubernetes"
 	// more to come
 )
-
-// GetDefaultRunner returns the default runner to use.
-// Currently, this is bubblewrap, but will be replaced with determining by platform.
-func GetDefaultRunner() Runner {
-	var r Runner
-	switch runtime.GOOS {
-	case "linux":
-		r = runnerBubblewrap
-	case "darwin":
-		// darwin is the same as default, but we want to keep it explicit
-		r = runnerDocker
-	default:
-		r = runnerDocker
-	}
-	return r
-}
 
 // GetAllRunners returns a list of all valid runners.
 func GetAllRunners() []Runner {

--- a/pkg/build/test.go
+++ b/pkg/build/test.go
@@ -58,7 +58,6 @@ type Test struct {
 	ApkCacheDir       string
 	CacheSource       string
 	Runner            container.Runner
-	RunnerName        string
 	Debug             bool
 	DebugRunner       bool
 	LogPolicy         []string
@@ -79,13 +78,6 @@ func NewTest(ctx context.Context, opts ...TestOption) (*Test, error) {
 
 	log := clog.New(slog.Default().Handler()).With("arch", t.Arch)
 	ctx = clog.WithLogger(ctx, log)
-
-	// try to get the runner
-	runner, err := container.GetRunner(ctx, t.RunnerName)
-	if err != nil {
-		return nil, fmt.Errorf("unable to get runner %s: %w", t.RunnerName, err)
-	}
-	t.Runner = runner
 
 	// If no workspace directory is explicitly requested, create a
 	// temporary directory for it.  Otherwise, ensure we are in a
@@ -117,8 +109,8 @@ func NewTest(ctx context.Context, opts ...TestOption) (*Test, error) {
 	t.Configuration = *parsedCfg
 
 	// Check that we actually can run things in containers.
-	if !runner.TestUsability(ctx) {
-		return nil, fmt.Errorf("unable to run containers using %s, specify --runner and one of %s", runner.Name(), GetAllRunners())
+	if !t.Runner.TestUsability(ctx) {
+		return nil, fmt.Errorf("unable to run containers using %s, specify --runner and one of %s", t.Runner.Name(), GetAllRunners())
 	}
 
 	return &t, nil

--- a/pkg/build/test_options.go
+++ b/pkg/build/test_options.go
@@ -14,7 +14,10 @@
 
 package build
 
-import apko_types "chainguard.dev/apko/pkg/build/types"
+import (
+	apko_types "chainguard.dev/apko/pkg/build/types"
+	"chainguard.dev/melange/pkg/container"
+)
 
 type TestOption func(*Test) error
 
@@ -141,9 +144,9 @@ func WithTestLogPolicy(policy []string) TestOption {
 
 // WithTestRunner specifies what runner to use to wrap
 // the test environment.
-func WithTestRunner(runner string) TestOption {
+func WithTestRunner(runner container.Runner) TestOption {
 	return func(t *Test) error {
-		t.RunnerName = runner
+		t.Runner = runner
 		return nil
 	}
 }

--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -20,10 +20,12 @@ import (
 	"fmt"
 	"log/slog"
 	"path/filepath"
+	"runtime"
 	"time"
 
 	apko_types "chainguard.dev/apko/pkg/build/types"
 	"chainguard.dev/melange/pkg/build"
+	"chainguard.dev/melange/pkg/container"
 	"github.com/chainguard-dev/clog"
 	"github.com/spf13/cobra"
 	"go.opentelemetry.io/otel"
@@ -74,8 +76,10 @@ func Build() *cobra.Command {
 		Example: `  melange build [config.yaml]`,
 		Args:    cobra.MinimumNArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if runner == "" {
-				runner = string(build.GetDefaultRunner())
+			ctx := cmd.Context()
+			r, err := getRunner(ctx, runner)
+			if err != nil {
+				return err
 			}
 
 			archs := apko_types.ParseArchitectures(archstrs)
@@ -110,7 +114,7 @@ func Build() *cobra.Command {
 				build.WithDebugRunner(debugRunner),
 				build.WithRemove(remove),
 				build.WithLogPolicy(logPolicy),
-				build.WithRunner(runner),
+				build.WithRunner(r),
 				build.WithFailOnLintWarning(failOnLintWarning),
 				build.WithCPU(cpu),
 				build.WithMemory(memory),
@@ -169,6 +173,31 @@ func Build() *cobra.Command {
 	cmd.Flags().DurationVar(&timeout, "timeout", 0, "default timeout for builds")
 
 	return cmd
+}
+
+func getRunner(ctx context.Context, runner string) (container.Runner, error) {
+	if runner != "" {
+		switch runner {
+		case "bubblewrap":
+			return container.BubblewrapRunner(), nil
+		case "docker":
+			return container.DockerRunner(ctx)
+		case "kubernetes":
+			return container.KubernetesRunner(ctx)
+		default:
+			return nil, fmt.Errorf("unknown runner: %s", runner)
+		}
+	}
+
+	switch runtime.GOOS {
+	case "linux":
+		return container.BubblewrapRunner(), nil
+	case "darwin":
+		// darwin is the same as default, but we want to keep it explicit
+		fallthrough
+	default:
+		return container.DockerRunner(ctx)
+	}
 }
 
 func BuildCmd(ctx context.Context, archs []apko_types.Architecture, baseOpts ...build.Option) error {

--- a/pkg/cli/test.go
+++ b/pkg/cli/test.go
@@ -53,8 +53,10 @@ func Test() *cobra.Command {
 		Example: `  melange test <test.yaml> [package-name]`,
 		Args:    cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if runner == "" {
-				runner = string(build.GetDefaultRunner())
+			ctx := cmd.Context()
+			r, err := getRunner(ctx, runner)
+			if err != nil {
+				return err
 			}
 
 			archs := apko_types.ParseArchitectures(archstrs)
@@ -68,7 +70,7 @@ func Test() *cobra.Command {
 				build.WithTestExtraRepos(extraRepos),
 				build.WithExtraTestPackages(extraTestPackages),
 				build.WithTestBinShOverlay(overlayBinSh),
-				build.WithTestRunner(runner),
+				build.WithTestRunner(r),
 				build.WithTestDebug(debug),
 				build.WithTestDebugRunner(debugRunner),
 			}


### PR DESCRIPTION
This should mean that callers that depend on `pkg/build` (like wolfictl) won't necessarily have to depend on k8s libraries, making their builds slower.

We may also need to move the runner implementations into separate subpackages in `pkg/container`, we can investigate that separately.