### PR TITLE
update dario/mergo

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ toolchain go1.21.5
 require (
 	chainguard.dev/apko v0.14.1-0.20240207151428-faf3e41d1a71
 	cloud.google.com/go/storage v1.37.0
+	dario.cat/mergo v1.0.0
 	github.com/chainguard-dev/clog v1.3.1
 	github.com/chainguard-dev/go-apk v0.0.0-20240207141231-4a3a18e598d6
 	github.com/chainguard-dev/go-pkgconfig v0.0.0-20230818193557-bee0072057ce
@@ -23,7 +24,6 @@ require (
 	github.com/google/go-containerregistry v0.19.0
 	github.com/google/go-github/v54 v54.0.0
 	github.com/ijt/goparsify v0.0.0-20221203142333-3a5276334b8d
-	github.com/imdario/mergo v0.3.16
 	github.com/invopop/jsonschema v0.12.0
 	github.com/joho/godotenv v1.5.1
 	github.com/kelseyhightower/envconfig v1.4.0
@@ -62,7 +62,6 @@ require (
 	cloud.google.com/go/compute v1.23.3 // indirect
 	cloud.google.com/go/compute/metadata v0.2.3 // indirect
 	cloud.google.com/go/iam v1.1.5 // indirect
-	dario.cat/mergo v1.0.0 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 // indirect
 	github.com/MakeNowJust/heredoc/v2 v2.0.1 // indirect
 	github.com/Microsoft/go-winio v0.6.1 // indirect
@@ -121,6 +120,7 @@ require (
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-hclog v1.6.2 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.5 // indirect
+	github.com/imdario/mergo v0.3.16 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/jinzhu/copier v0.4.0 // indirect

--- a/pkg/container/kubernetes_runner.go
+++ b/pkg/container/kubernetes_runner.go
@@ -24,6 +24,7 @@ import (
 
 	apko_build "chainguard.dev/apko/pkg/build"
 	apko_types "chainguard.dev/apko/pkg/build/types"
+	"dario.cat/mergo"
 	"github.com/chainguard-dev/clog"
 	"github.com/chainguard-dev/kontext"
 	"github.com/dustin/go-humanize"
@@ -32,7 +33,6 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/empty"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
-	"github.com/imdario/mergo"
 	"github.com/kelseyhightower/envconfig"
 	"go.opentelemetry.io/otel"
 	"k8s.io/client-go/kubernetes"

--- a/pkg/container/kubernetes_runner_test.go
+++ b/pkg/container/kubernetes_runner_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/chainguard-dev/clog/slogtest"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/imdario/mergo"
+	"dario.cat/mergo"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/container/kubernetes_runner_test.go
+++ b/pkg/container/kubernetes_runner_test.go
@@ -7,10 +7,10 @@ import (
 	"time"
 
 	"chainguard.dev/apko/pkg/build/types"
+	"dario.cat/mergo"
 	"github.com/chainguard-dev/clog/slogtest"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"dario.cat/mergo"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"


### PR DESCRIPTION
github.com/imdario/mergo updated to 1.0.0 last year and changed its importpath. This updates us to the new one.