### PR TITLE
Continue interactive execution on exit 0

### DIFF
--- a/pkg/build/pipeline.go
+++ b/pkg/build/pipeline.go
@@ -376,13 +376,16 @@ func (pctx *PipelineContext) maybeDebug(ctx context.Context, pb *PipelineBuild, 
 	}
 
 	log.Errorf("Step failed: %v\n%s", runErr, strings.Join(cmd, " "))
-	log.Infof("Execing into %q to debug", pctx.WorkspaceConfig.PodID)
+	log.Infof("Execing into pod %q to debug interactively.", pctx.WorkspaceConfig.PodID)
+	log.Infof("Type 'exit 0' to continue the next pipeline step or 'exit 1' to abort.")
+	log.Warnf("NOTE: ctrl+C will cause melange to exit, see: https://github.com/chainguard-dev/melange/issues/1004")
 
 	if dbgErr := dbg.Debug(ctx, pctx.WorkspaceConfig, "/bin/sh"); dbgErr != nil {
 		return fmt.Errorf("failed to debug: %w; original error: %w", dbgErr, runErr)
 	}
 
-	return runErr
+	// If Debug() returns succesfully (via exit 0), it is a signal to continue execution.
+	return nil
 }
 
 func (pctx *PipelineContext) evaluateBranchConditional(ctx context.Context, pb *PipelineBuild) bool {

--- a/pkg/container/bubblewrap_runner.go
+++ b/pkg/container/bubblewrap_runner.go
@@ -101,7 +101,7 @@ func (bw *bubblewrap) cmd(ctx context.Context, cfg *Config, args ...string) *exe
 	// TODO: Remove bubblewrap runner or get someone at redhat to merge something.
 	execCmd.WaitDelay = 1 * time.Second
 
-	clog.FromContext(ctx).InfoContext(ctx, fmt.Sprintf("executing: %s", strings.Join(execCmd.Args, " ")))
+	clog.FromContext(ctx).Infof("executing: %s", strings.Join(execCmd.Args, " "))
 
 	return execCmd
 }


### PR DESCRIPTION
If you exit the session with an error (e.g. "exit 1"), we will abort the pipeline.

If instead you type "exit 0" from within the pod, we will exit that build step and continue with the rest of the build or test.

Note that hitting ctrl+C will cancel the root context and cause things to exit no matter what. This is a bug, and we now log that caveat.