### PR TITLE
Split pkg/container up into smaller packages

### DIFF
--- a/internal/logwriter/logwriter.go
+++ b/internal/logwriter/logwriter.go
@@ -1,0 +1,53 @@
+// Copyright 2024 Chainguard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logwriter
+
+import (
+	"bytes"
+	"io"
+)
+
+func New(log func(string, ...any)) io.WriteCloser {
+	buf := new(bytes.Buffer)
+	return &levelWriter{log, buf}
+}
+
+type levelWriter struct {
+	log func(string, ...any)
+	buf *bytes.Buffer
+}
+
+func (l *levelWriter) Write(p []byte) (int, error) {
+	n, err := l.buf.Write(p)
+
+	for {
+		line, lerr := l.buf.ReadString('\n')
+		if lerr != nil {
+			l.buf.WriteString(line)
+			break
+		}
+		line = line[:len(line)-1] // trim the newline at the end
+		l.log(line)
+	}
+
+	return n, err
+}
+
+func (l *levelWriter) Close() error {
+	if l.buf.Len() != 0 {
+		l.log(l.buf.String())
+	}
+	return nil
+}

--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -26,6 +26,8 @@ import (
 	apko_types "chainguard.dev/apko/pkg/build/types"
 	"chainguard.dev/melange/pkg/build"
 	"chainguard.dev/melange/pkg/container"
+	"chainguard.dev/melange/pkg/container/docker"
+	"chainguard.dev/melange/pkg/container/k8s"
 	"github.com/chainguard-dev/clog"
 	"github.com/spf13/cobra"
 	"go.opentelemetry.io/otel"
@@ -184,9 +186,9 @@ func getRunner(ctx context.Context, runner string) (container.Runner, error) {
 		case "bubblewrap":
 			return container.BubblewrapRunner(), nil
 		case "docker":
-			return container.DockerRunner(ctx)
+			return docker.NewRunner(ctx)
 		case "kubernetes":
-			return container.KubernetesRunner(ctx)
+			return k8s.NewRunner(ctx)
 		default:
 			return nil, fmt.Errorf("unknown runner: %s", runner)
 		}
@@ -199,7 +201,7 @@ func getRunner(ctx context.Context, runner string) (container.Runner, error) {
 		// darwin is the same as default, but we want to keep it explicit
 		fallthrough
 	default:
-		return container.DockerRunner(ctx)
+		return docker.NewRunner(ctx)
 	}
 }
 

--- a/pkg/container/bubblewrap_runner.go
+++ b/pkg/container/bubblewrap_runner.go
@@ -27,6 +27,7 @@ import (
 
 	apko_build "chainguard.dev/apko/pkg/build"
 	apko_types "chainguard.dev/apko/pkg/build/types"
+	"chainguard.dev/melange/internal/logwriter"
 	"github.com/chainguard-dev/clog"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"go.opentelemetry.io/otel"
@@ -57,7 +58,8 @@ func (bw *bubblewrap) Name() string {
 func (bw *bubblewrap) Run(ctx context.Context, cfg *Config, args ...string) error {
 	execCmd := bw.cmd(ctx, cfg, args...)
 
-	stdout, stderr := logWriters(ctx)
+	log := clog.FromContext(ctx)
+	stdout, stderr := logwriter.New(log.Info), logwriter.New(log.Warn)
 	defer stdout.Close()
 	defer stderr.Close()
 

--- a/pkg/container/runner.go
+++ b/pkg/container/runner.go
@@ -16,7 +16,6 @@ package container
 
 import (
 	"context"
-	"fmt"
 	"io"
 
 	apko_build "chainguard.dev/apko/pkg/build"
@@ -50,17 +49,4 @@ type Runner interface {
 type Loader interface {
 	LoadImage(ctx context.Context, layer v1.Layer, arch apko_types.Architecture, bc *apko_build.Context) (ref string, err error)
 	RemoveImage(ctx context.Context, ref string) error
-}
-
-// GetRunner returns the requested runner implementation.
-func GetRunner(ctx context.Context, s string) (Runner, error) {
-	switch s {
-	case BubblewrapName:
-		return BubblewrapRunner(), nil
-	case DockerName:
-		return DockerRunner(ctx)
-	case KubernetesName:
-		return KubernetesRunner(ctx)
-	}
-	return nil, fmt.Errorf("unknown virtualizer %q", s)
 }


### PR DESCRIPTION
Two new internal packages: contextreader and logwriter, both of which are independently useful and probably worth publishing as non-internal.

Two new public packages: k8s and docker.

Both docker and k8s are huge dependencies, so we owe it to our users (and ourselves) to make them optional.