### PR TITLE
Allow substitutions in dependencies.replaces

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -170,11 +170,32 @@ func (cfg *Configuration) applySubstitutionsForRuntime() error {
 		}
 	}
 	for _, srt := range cfg.Subpackages {
-		for i, prov := range srt.Dependencies.Runtime {
+		for i, runtime := range srt.Dependencies.Runtime {
 			var err error
-			srt.Dependencies.Runtime[i], err = util.MutateStringFromMap(nw, prov)
+			srt.Dependencies.Runtime[i], err = util.MutateStringFromMap(nw, runtime)
 			if err != nil {
-				return fmt.Errorf("failed to apply replacement to runtime %q: %w", prov, err)
+				return fmt.Errorf("failed to apply replacement to runtime %q: %w", runtime, err)
+			}
+		}
+	}
+	return nil
+}
+
+func (cfg *Configuration) applySubstitutionsForReplaces() error {
+	nw := buildConfigMap(cfg)
+	for i, replaces := range cfg.Package.Dependencies.Replaces {
+		var err error
+		cfg.Package.Dependencies.Replaces[i], err = util.MutateStringFromMap(nw, replaces)
+		if err != nil {
+			return fmt.Errorf("failed to apply replacement to replaces %q: %w", replaces, err)
+		}
+	}
+	for _, srt := range cfg.Subpackages {
+		for i, replaces := range srt.Dependencies.Replaces {
+			var err error
+			srt.Dependencies.Replaces[i], err = util.MutateStringFromMap(nw, replaces)
+			if err != nil {
+				return fmt.Errorf("failed to apply replacement to replaces %q: %w", replaces, err)
 			}
 		}
 	}
@@ -885,6 +906,9 @@ func ParseConfiguration(ctx context.Context, configurationFilePath string, opts 
 		return nil, err
 	}
 	if err := cfg.applySubstitutionsForRuntime(); err != nil {
+		return nil, err
+	}
+	if err := cfg.applySubstitutionsForReplaces(); err != nil {
 		return nil, err
 	}
 	if err := cfg.applySubstitutionsForPackages(); err != nil {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -50,6 +50,8 @@ subpackages:
         - subpackage-version=${{package.version}}
         - subpackage-foo=${{vars.foo}}
         - subpackage-bar=${{vars.bar}}
+      replaces:
+        - james=${{package.name}}
 `), 0644); err != nil {
 		t.Fatal(err)
 	}
@@ -81,6 +83,10 @@ subpackages:
 		"FOO",
 		"other-package=0.0.1",
 	}, cfg.Subpackages[0].Dependencies.Runtime)
+
+	require.Equal(t, []string{
+		"james=replacement-provides",
+	}, cfg.Subpackages[0].Dependencies.Replaces)
 
 	require.Equal(t, []string{
 		"dep~0.0.1",


### PR DESCRIPTION
This looks like an oversight. I don't love how this code works but I'm favoring consistency over introducing a larger diff.