### PR TITLE
Remove images even with cancelled ctx

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -214,13 +214,15 @@ func New(ctx context.Context, opts ...Option) (*Build, error) {
 }
 
 func (b *Build) Close(ctx context.Context) error {
+	log := clog.FromContext(ctx)
 	errs := []error{}
 	if b.Remove {
-		clog.FromContext(ctx).Infof("deleting guest dir %s", b.GuestDir)
+		log.Infof("deleting guest dir %s", b.GuestDir)
 		errs = append(errs, os.RemoveAll(b.GuestDir))
+		log.Infof("deleting workspace dir %s", b.WorkspaceDir)
 		errs = append(errs, os.RemoveAll(b.WorkspaceDir))
 		if b.containerConfig != nil && b.containerConfig.ImgRef != "" {
-			errs = append(errs, b.Runner.OCIImageLoader().RemoveImage(ctx, b.containerConfig.ImgRef))
+			errs = append(errs, b.Runner.OCIImageLoader().RemoveImage(context.WithoutCancel(ctx), b.containerConfig.ImgRef))
 		}
 	}
 	errs = append(errs, b.Runner.Close())

--- a/pkg/build/pipeline.go
+++ b/pkg/build/pipeline.go
@@ -357,8 +357,11 @@ func (pctx *PipelineContext) evalRun(ctx context.Context, pb *PipelineBuild) err
 
 	// We might have called signal.Ignore(os.Interrupt) as part of a previous debug step,
 	// so create a new context to make it possible to cancel the Run.
-	ctx, stop := signal.NotifyContext(ctx, os.Interrupt)
-	defer stop()
+	if pb.Interactive() {
+		var stop context.CancelFunc
+		ctx, stop = signal.NotifyContext(ctx, os.Interrupt)
+		defer stop()
+	}
 
 	command := pctx.buildEvalRunCommand(debugOption, sysPath, workdir, fragment)
 	if err := pb.GetRunner().Run(ctx, pctx.WorkspaceConfig, command...); err != nil {


### PR DESCRIPTION
The cleanup step would fail if we called RemoveImage with a cancelled context. This fixes that.