### PR TITLE
Remove breakpoint labels

### DIFF
--- a/docs/md/melange_build.md
+++ b/docs/md/melange_build.md
@@ -30,12 +30,10 @@ melange build [flags]
 ```
       --apk-cache-dir string        directory used for cached apk packages (default is system-defined cache directory)
       --arch strings                architectures to build for (e.g., x86_64,ppc64le,arm64) -- default is all, unless specified in config
-      --breakpoint-label string     stop build execution at the specified label
       --build-date string           date used for the timestamps of the files inside the image
       --build-option strings        build options to enable
       --cache-dir string            directory used for cached inputs (default "./melange-cache/")
       --cache-source string         directory or bucket used for preloading the cache
-      --continue-label string       continue build execution at the specified label
       --cpu string                  default CPU resources to use for builds
       --create-build-log            creates a package.log file containing a list of packages that were built by the command
       --debug                       enables debug logging of build pipelines

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -77,9 +77,6 @@ type Build struct {
 	CacheDir          string
 	ApkCacheDir       string
 	CacheSource       string
-	BreakpointLabel   string
-	ContinueLabel     string
-	foundContinuation bool
 	StripOriginName   bool
 	EnvFile           string
 	VarsFile          string
@@ -121,13 +118,7 @@ func New(ctx context.Context, opts ...Option) (*Build, error) {
 	// temporary directory for it.  Otherwise, ensure we are in a
 	// subdir for this specific build context.
 	if b.WorkspaceDir != "" {
-		// If we are continuing the build, do not modify the workspace
-		// directory path.
-		// TODO(kaniini): Clean up the logic for this, perhaps by signalling
-		// multi-arch builds to the build context.
-		if b.ContinueLabel == "" {
-			b.WorkspaceDir = filepath.Join(b.WorkspaceDir, b.Arch.ToAPK())
-		}
+		b.WorkspaceDir = filepath.Join(b.WorkspaceDir, b.Arch.ToAPK())
 
 		// Get the absolute path to the workspace dir, which is needed for bind
 		// mounts.

--- a/pkg/build/options.go
+++ b/pkg/build/options.go
@@ -202,24 +202,6 @@ func WithBinShOverlay(binShOverlay string) Option {
 	}
 }
 
-// WithBreakpointLabel sets a label to stop build execution at.  The build
-// environment and workspace are preserved.
-func WithBreakpointLabel(breakpointLabel string) Option {
-	return func(b *Build) error {
-		b.BreakpointLabel = breakpointLabel
-		return nil
-	}
-}
-
-// WithContinueLabel sets a label to continue build execution from.  This
-// requires a preserved build environment and workspace.
-func WithContinueLabel(continueLabel string) Option {
-	return func(b *Build) error {
-		b.ContinueLabel = continueLabel
-		return nil
-	}
-}
-
 // WithStripOriginName determines whether the origin name should be stripped
 // from generated packages.  The APK solver uses origin names to flatten
 // possible dependency nodes when solving for a DAG, which means that they

--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -55,8 +55,6 @@ func Build() *cobra.Command {
 	var extraRepos []string
 	var dependencyLog string
 	var overlayBinSh string
-	var breakpointLabel string
-	var continueLabel string
 	var envFile string
 	var varsFile string
 	var purlNamespace string
@@ -105,8 +103,6 @@ func Build() *cobra.Command {
 				build.WithExtraRepos(extraRepos),
 				build.WithDependencyLog(dependencyLog),
 				build.WithBinShOverlay(overlayBinSh),
-				build.WithBreakpointLabel(breakpointLabel),
-				build.WithContinueLabel(continueLabel),
 				build.WithStripOriginName(stripOriginName),
 				build.WithEnvFile(envFile),
 				build.WithVarsFile(varsFile),
@@ -158,8 +154,6 @@ func Build() *cobra.Command {
 	cmd.Flags().StringVar(&outDir, "out-dir", "./packages/", "directory where packages will be output")
 	cmd.Flags().StringVar(&dependencyLog, "dependency-log", "", "log dependencies to a specified file")
 	cmd.Flags().StringVar(&overlayBinSh, "overlay-binsh", "", "use specified file as /bin/sh overlay in build environment")
-	cmd.Flags().StringVar(&breakpointLabel, "breakpoint-label", "", "stop build execution at the specified label")
-	cmd.Flags().StringVar(&continueLabel, "continue-label", "", "continue build execution at the specified label")
 	cmd.Flags().StringVar(&purlNamespace, "namespace", "unknown", "namespace to use in package URLs in SBOM (eg wolfi, alpine)")
 	cmd.Flags().StringSliceVar(&archstrs, "arch", nil, "architectures to build for (e.g., x86_64,ppc64le,arm64) -- default is all, unless specified in config")
 	cmd.Flags().StringSliceVar(&buildOption, "build-option", []string{}, "build options to enable")


### PR DESCRIPTION
The `--interactive` flag should be a suitable replacement for this.

Fixes https://github.com/chainguard-dev/melange/issues/1023