### PR TITLE
omit arch log key when building one arch

### DIFF
--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -246,13 +246,16 @@ func BuildCmd(ctx context.Context, archs []apko_types.Architecture, baseOpts ...
 		bc := bc
 
 		errg.Go(func() error {
-			log := clog.New(slog.Default().Handler()).With("arch", bc.Arch.ToAPK())
-			ctx := clog.WithLogger(ctx, log)
+			lctx := ctx
+			if len(bcs) != 1 {
+				log := clog.New(slog.Default().Handler()).With("arch", bc.Arch.ToAPK())
+				lctx = clog.WithLogger(ctx, log)
+			}
 
-			if err := bc.BuildPackage(ctx); err != nil {
+			if err := bc.BuildPackage(lctx); err != nil {
 				if !bc.Remove {
 					log.Error("ERROR: failed to build package. the build environment has been preserved:")
-					bc.SummarizePaths(ctx)
+					bc.SummarizePaths(lctx)
 				}
 
 				return fmt.Errorf("failed to build package: %w", err)


### PR DESCRIPTION
When building a single arch, we don't have to log the arch.

Before:

```
go run ./ build examples/minimal.yaml --arch=aarch64      
2024/02/13 19:27:12 INFO melange is building: arch=aarch64
2024/02/13 19:27:12 INFO   configuration file: examples/minimal.yaml arch=aarch64
2024/02/13 19:27:12 INFO   workspace dir: /var/folders/gw/86t1jg2109s5j8vzszj281kc0000gn/T/melange-workspace-1982439457 arch=aarch64
2024/02/13 19:27:12 INFO evaluating pipelines for package requirements arch=aarch64
2024/02/13 19:27:12 INFO populating workspace /var/folders/gw/86t1jg2109s5j8vzszj281kc0000gn/T/melange-workspace-1982439457 from examples arch=aarch64
2024/02/13 19:27:12 INFO --cache-dir ./melange-cache/ not a dir; skipping arch=aarch64
```

After:

```
go run ./ build examples/minimal.yaml --arch=aarch64
2024/02/13 19:27:53 INFO melange is building:
2024/02/13 19:27:53 INFO   configuration file: examples/minimal.yaml
2024/02/13 19:27:53 INFO   workspace dir: /var/folders/gw/86t1jg2109s5j8vzszj281kc0000gn/T/melange-workspace-2097301316
2024/02/13 19:27:53 INFO evaluating pipelines for package requirements
2024/02/13 19:27:53 INFO populating workspace /var/folders/gw/86t1jg2109s5j8vzszj281kc0000gn/T/melange-workspace-2097301316 from examples
2024/02/13 19:27:53 INFO --cache-dir ./melange-cache/ not a dir; skipping
```

After (multiple arches):

```
go run ./ build examples/minimal.yaml --arch=aarch64,x86_64
2024/02/13 19:28:30 INFO melange is building: arch=aarch64
2024/02/13 19:28:30 INFO melange is building: arch=x86_64
2024/02/13 19:28:30 INFO   configuration file: examples/minimal.yaml arch=x86_64
2024/02/13 19:28:30 INFO   configuration file: examples/minimal.yaml arch=aarch64
2024/02/13 19:28:30 INFO   workspace dir: /var/folders/gw/86t1jg2109s5j8vzszj281kc0000gn/T/melange-workspace-1479578084 arch=aarch64
2024/02/13 19:28:30 INFO   workspace dir: /var/folders/gw/86t1jg2109s5j8vzszj281kc0000gn/T/melange-workspace-3079788183 arch=x86_64
2024/02/13 19:28:30 INFO evaluating pipelines for package requirements arch=aarch64
2024/02/13 19:28:30 INFO evaluating pipelines for package requirements arch=x86_64
2024/02/13 19:28:30 INFO populating workspace /var/folders/gw/86t1jg2109s5j8vzszj281kc0000gn/T/melange-workspace-1479578084
```