### PR TITLE
label containers created by docker runner for easier external management

### DIFF
--- a/pkg/container/docker/docker_runner.go
+++ b/pkg/container/docker/docker_runner.go
@@ -121,6 +121,9 @@ func (dk *docker) StartPod(ctx context.Context, cfg *mcontainer.Config) error {
 		Image: cfg.ImgRef,
 		Cmd:   []string{"/bin/sh", "-c", "[ -x /sbin/ldconfig ] && /sbin/ldconfig /lib || true\nwhile true; do sleep 5; done"},
 		Tty:   false,
+		Labels: map[string]string{
+			"melange": "true",
+		},
 	}, hostConfig, nil, platform, "")
 	if err != nil {
 		return err


### PR DESCRIPTION
simple change to attach labels to containers created with melange's docker runner.

this makes it easier for external management for things like cleanup:

```
docker rm -f $(docker ps -q --filter "label=melange=true")
```

I'm not married to the label, feel free to suggest others!