### PR TITLE
add package name to docker labels

### DIFF
--- a/pkg/container/docker/docker_runner.go
+++ b/pkg/container/docker/docker_runner.go
@@ -122,7 +122,8 @@ func (dk *docker) StartPod(ctx context.Context, cfg *mcontainer.Config) error {
 		Cmd:   []string{"/bin/sh", "-c", "[ -x /sbin/ldconfig ] && /sbin/ldconfig /lib || true\nwhile true; do sleep 5; done"},
 		Tty:   false,
 		Labels: map[string]string{
-			"melange": "true",
+			"dev.chainguard.melange":         "true",
+			"dev.chainguard.melange.package": cfg.PackageName,
 		},
 	}, hostConfig, nil, platform, "")
 	if err != nil {


### PR DESCRIPTION
follow on to #1028.

keeps the `melange=true` for general use, but also adds a package name