### PR TITLE
Add --package-append flag to build

### DIFF
--- a/docs/md/melange_build.md
+++ b/docs/md/melange_build.md
@@ -52,6 +52,7 @@ melange build [flags]
       --namespace string            namespace to use in package URLs in SBOM (eg wolfi, alpine) (default "unknown")
       --out-dir string              directory where packages will be output (default "./packages/")
       --overlay-binsh string        use specified file as /bin/sh overlay in build environment
+      --package-append strings      extra packages to install for each of the build environments
       --pipeline-dir string         directory used to extend defined built-in pipelines
   -r, --repository-append strings   path to extra repositories to include in the build environment
       --rm                          clean up intermediate artifacts (e.g. container images)

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -71,6 +71,7 @@ type Build struct {
 	Arch              apko_types.Architecture
 	ExtraKeys         []string
 	ExtraRepos        []string
+	ExtraPackages     []string
 	DependencyLog     string
 	BinShOverlay      string
 	CreateBuildLog    bool
@@ -239,6 +240,7 @@ func (b *Build) BuildGuest(ctx context.Context, imgConfig apko_types.ImageConfig
 		apko_build.WithArch(b.Arch),
 		apko_build.WithExtraKeys(b.ExtraKeys),
 		apko_build.WithExtraRepos(b.ExtraRepos),
+		apko_build.WithExtraPackages(b.ExtraPackages),
 		apko_build.WithCacheDir(b.ApkCacheDir, false), // TODO: Replace with real offline plumbing
 		apko_build.WithTempDir(tmp),
 	)

--- a/pkg/build/options.go
+++ b/pkg/build/options.go
@@ -342,3 +342,11 @@ func WithTimeout(dur time.Duration) Option {
 		return nil
 	}
 }
+
+// WithExtraPackages specifies packages that are added to each build by default.
+func WithExtraPackages(extraPackages []string) Option {
+	return func(b *Build) error {
+		b.ExtraPackages = extraPackages
+		return nil
+	}
+}

--- a/pkg/build/test.go
+++ b/pkg/build/test.go
@@ -136,14 +136,12 @@ func (t *Test) BuildGuest(ctx context.Context, imgConfig apko_types.ImageConfigu
 	}
 	defer os.RemoveAll(tmp)
 
-	// Then add any extra packages specified by the command line.
-	imgConfig.Contents.Packages = append(imgConfig.Contents.Packages, t.ExtraTestPackages...)
-
 	bc, err := apko_build.New(ctx, guestFS,
 		apko_build.WithImageConfiguration(imgConfig),
 		apko_build.WithArch(t.Arch),
 		apko_build.WithExtraKeys(t.ExtraKeys),
 		apko_build.WithExtraRepos(t.ExtraRepos),
+		apko_build.WithExtraPackages(t.ExtraTestPackages),
 		apko_build.WithCacheDir(t.ApkCacheDir, false), // TODO: Replace with real offline plumbing
 		apko_build.WithTempDir(tmp),
 	)

--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -73,6 +73,7 @@ func Build() *cobra.Command {
 	var failOnLintWarning bool
 	var cpu, memory string
 	var timeout time.Duration
+	var extraPackages []string
 
 	var traceFile string
 
@@ -132,6 +133,7 @@ func Build() *cobra.Command {
 				build.WithOutDir(outDir),
 				build.WithExtraKeys(extraKeys),
 				build.WithExtraRepos(extraRepos),
+				build.WithExtraPackages(extraPackages),
 				build.WithDependencyLog(dependencyLog),
 				build.WithBinShOverlay(overlayBinSh),
 				build.WithStripOriginName(stripOriginName),
@@ -192,6 +194,7 @@ func Build() *cobra.Command {
 	cmd.Flags().StringVar(&runner, "runner", "", fmt.Sprintf("which runner to use to enable running commands, default is based on your platform. Options are %q", build.GetAllRunners()))
 	cmd.Flags().StringSliceVarP(&extraKeys, "keyring-append", "k", []string{}, "path to extra keys to include in the build environment keyring")
 	cmd.Flags().StringSliceVarP(&extraRepos, "repository-append", "r", []string{}, "path to extra repositories to include in the build environment")
+	cmd.Flags().StringSliceVar(&extraPackages, "package-append", []string{}, "extra packages to install for each of the build environments")
 	cmd.Flags().BoolVar(&createBuildLog, "create-build-log", false, "creates a package.log file containing a list of packages that were built by the command")
 	cmd.Flags().BoolVar(&debug, "debug", false, "enables debug logging of build pipelines")
 	cmd.Flags().BoolVar(&debugRunner, "debug-runner", false, "when enabled, the builder pod will persist after the build succeeds or fails")


### PR DESCRIPTION
This passes through any additional packages to add to the guest environment for builds.

Mostly, this is useful when combined with --interactive so that you can add e.g. "apk-tools" to the build environment without having to modify the build file.