### PR TITLE
Fix resource usage in melange

### DIFF
--- a/internal/contextreader/contextreader.go
+++ b/internal/contextreader/contextreader.go
@@ -49,7 +49,7 @@ func (c *contextReader) init() {
 				c.n, c.err = c.r.Read(p)
 				c.done <- struct{}{}
 			case <-c.ctx.Done():
-				break
+				return
 			}
 		}
 	}()

--- a/pkg/container/docker/docker_runner.go
+++ b/pkg/container/docker/docker_runner.go
@@ -199,6 +199,8 @@ func (dk *docker) waitForCommand(ctx context.Context, r io.Reader) error {
 	defer stderr.Close()
 
 	// Wrap this in a contextReader so we respond to cancel.
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 	ctxr := contextreader.New(ctx, r)
 
 	_, err := stdcopy.StdCopy(stdout, stderr, ctxr)


### PR DESCRIPTION
Apparently `for { select { break } }` doesn't do what I thought.

This cleans up orphaned goroutines after the reader is done.