### PR TITLE
Add pombump pipeline.

### DIFF
--- a/pkg/build/pipelines/maven/pombump.yaml
+++ b/pkg/build/pipelines/maven/pombump.yaml
@@ -1,0 +1,57 @@
+name: Run pombump tool to update versions and properties in a Maven POM file
+needs:
+  packages:
+    - busybox
+    - pombump
+
+inputs:
+  patch-file:
+    description: |
+      Patches file to use for updating the POM file
+    default: ./patches.yaml
+  properties-file:
+    description: |
+      Properties file to be used for updating the POM file
+    default: ./properties.yaml
+  dependencies:
+    description: |
+      Dependencies to be used for updating the POM file via command line flag
+  properties:
+    description: |
+      Properties to update / add the POM file via command line flag
+  debug:
+    description: |
+      Enable debug mode, which will print out the diffs of the pom.xml file after running pombump
+    default: false
+
+
+pipeline:
+  - runs: |
+      PATCH_FILE_FLAG=""
+      PROPERTIES_FILE_FLAG=""
+      DEPENDENCIES_FLAG=""
+      PROPERTIES_FLAG=""
+
+      if [ -f"${{inputs.patch-file}}" ]; then
+        PATCH_FILE_FLAG="--patch-file ${{inputs.patch-file}}"
+      fi
+
+      if [ -f "${{inputs.properties-file}}" ]; then
+        PROPERTIES_FILE_FLAG="--properties-file ${{inputs.properties-file}}"
+      fi
+
+      if [ -n "${{inputs.dependencies}}" ]; then
+        DEPENDENCIES_FLAG="--dependencies ${{inputs.dependencies}}"
+      fi
+
+      if [ -n "${{inputs.properties}}" ]; then
+        PROPERTIES_FLAG="--properties ${{inputs.properties}}"
+      fi
+
+      pombump pom.xml $PATCH_FILE_FLAG $PROPERTIES_FILE_FLAG $DEPENDENCIES_FLAG $PROPERTIES_FLAG > pom.xml.new
+
+      if [ "${{inputs.debug}}" = "true" ]; then
+        # If there are any differences, it will return a non-zero exit code, so we use `|| true` to ignore that
+        diff -w pom.xml pom.xml.new || true
+      fi
+      mv pom.xml.new pom.xml


### PR DESCRIPTION
## Melange Pull Request Template
Tested on spark image with:

```
  - uses: maven/pombump
    with:
      debug: true
```

and just:
```
  - uses: maven/pombump
```



<!--
*** PULL REQUEST CHECKLIST: PLEASE START HERE ***

The single most important feature of melange is that we can build Wolfi.

Many changes to melange introduce a risk of breaking the build, and sometimes
these are not flushed out until a package is changed (much) later.  This
pertains to basic execution, SCA changes, linter changes, and more.
-->

### Functional Changes

- [ ] This change can build all of Wolfi without errors (describe results in notes)

Notes:

### SCA Changes

- [ ] Examining several representative APKs show no regression / the desired effect (details in notes)

Notes:

### Linter

- [ ] The new check is clean across Wolfi
- [ ] The new check is opt-in or a warning

Notes:
