### PR TITLE
Add ${{cross.triplet.rust.[glibc,musl]}}

### DIFF
--- a/pkg/build/pipeline.go
+++ b/pkg/build/pipeline.go
@@ -144,6 +144,8 @@ func substitutionMap(pb *PipelineBuild) (map[string]string, error) {
 		nw[config.SubstitutionHostTripletRust] = pb.Build.BuildTripletRust()
 		nw[config.SubstitutionCrossTripletGnuGlibc] = pb.Build.Arch.ToTriplet("gnu")
 		nw[config.SubstitutionCrossTripletGnuMusl] = pb.Build.Arch.ToTriplet("musl")
+		nw[config.SubstitutionCrossTripletRustGlibc] = pb.Build.Arch.ToRustTriplet("gnu")
+		nw[config.SubstitutionCrossTripletRustMusl] = pb.Build.Arch.ToRustTriplet("musl")
 		nw[config.SubstitutionBuildArch] = pb.Build.Arch.ToAPK()
 	}
 

--- a/pkg/config/vars.go
+++ b/pkg/config/vars.go
@@ -22,19 +22,21 @@ import (
 )
 
 const (
-	SubstitutionPackageName          = "${{package.name}}"
-	SubstitutionPackageVersion       = "${{package.version}}"
-	SubstitutionPackageFullVersion   = "${{package.full-version}}"
-	SubstitutionPackageEpoch         = "${{package.epoch}}"
-	SubstitutionPackageDescription   = "${{package.description}}"
-	SubstitutionTargetsDestdir       = "${{targets.destdir}}"
-	SubstitutionTargetsContextdir    = "${{targets.contextdir}}"
-	SubstitutionSubPkgDir            = "${{targets.subpkgdir}}"
-	SubstitutionHostTripletGnu       = "${{host.triplet.gnu}}"
-	SubstitutionHostTripletRust      = "${{host.triplet.rust}}"
-	SubstitutionCrossTripletGnuGlibc = "${{cross.triplet.gnu.glibc}}"
-	SubstitutionCrossTripletGnuMusl  = "${{cross.triplet.gnu.musl}}"
-	SubstitutionBuildArch            = "${{build.arch}}"
+	SubstitutionPackageName           = "${{package.name}}"
+	SubstitutionPackageVersion        = "${{package.version}}"
+	SubstitutionPackageFullVersion    = "${{package.full-version}}"
+	SubstitutionPackageEpoch          = "${{package.epoch}}"
+	SubstitutionPackageDescription    = "${{package.description}}"
+	SubstitutionTargetsDestdir        = "${{targets.destdir}}"
+	SubstitutionTargetsContextdir     = "${{targets.contextdir}}"
+	SubstitutionSubPkgDir             = "${{targets.subpkgdir}}"
+	SubstitutionHostTripletGnu        = "${{host.triplet.gnu}}"
+	SubstitutionHostTripletRust       = "${{host.triplet.rust}}"
+	SubstitutionCrossTripletGnuGlibc  = "${{cross.triplet.gnu.glibc}}"
+	SubstitutionCrossTripletGnuMusl   = "${{cross.triplet.gnu.musl}}"
+	SubstitutionCrossTripletRustGlibc = "${{cross.triplet.rust.glibc}}"
+	SubstitutionCrossTripletRustMusl  = "${{cross.triplet.rust.musl}}"
+	SubstitutionBuildArch             = "${{build.arch}}"
 )
 
 // Get variables from configuration and return them in a map


### PR DESCRIPTION
Unlike host.triplet.rust, these use hardcoded values for the libc flavor, which removes the need for trying to detect this at runtime.

See https://github.com/chainguard-dev/melange/issues/1056

We can migrate to these at our leisure, but we will want to figure out what to do with host.triplet.* substitutions to avoid breaking anyone using them.