### PR TITLE
sbom: drop sha1 file checksums

### DIFF
--- a/pkg/sbom/implementation.go
+++ b/pkg/sbom/implementation.go
@@ -136,7 +136,6 @@ func scanFiles(spec *Spec, dirPackage *pkg) error {
 
 			// Hash the file contents
 			for algo, fn := range map[string]func(string) (string, error){
-				"SHA1":   hash.SHA1ForFile,
 				"SHA256": hash.SHA256ForFile,
 				"SHA512": hash.SHA512ForFile,
 			} {
@@ -228,7 +227,7 @@ func addPackage(doc *spdx.Document, p *pkg) {
 	for _, rel := range p.Relationships {
 		if f, ok := rel.Target.(*file); ok {
 			spdxPkg.HasFiles = append(spdxPkg.HasFiles, f.ID())
-			if h, ok := f.Checksums["SHA1"]; ok {
+			if h, ok := f.Checksums["SHA256"]; ok {
 				hashList = append(hashList, h)
 			} else {
 				excluded = append(excluded, f.ID())


### PR DESCRIPTION
## Melange Pull Request Template

This drops sha1 from generated sbom checksums.
I don't know if this works, and if this still passes the ntia scanner audit.
This still keeps sha1 usage in the verifcation code which is specified as sha1.

### Functional Changes

- [ ] This change can build all of Wolfi without errors (describe results in notes)

Notes:

### SCA Changes

- [ ] Examining several representative APKs show no regression / the desired effect (details in notes)

Notes:

### Linter

- [ ] The new check is clean across Wolfi
- [ ] The new check is opt-in or a warning

Notes:
