### PR TITLE
Update pombump.yaml

### DIFF
--- a/pkg/build/pipelines/maven/pombump.yaml
+++ b/pkg/build/pipelines/maven/pombump.yaml
@@ -8,11 +8,11 @@ inputs:
   patch-file:
     description: |
       Patches file to use for updating the POM file
-    default: ./pombump.yaml
+    default: ./pombump-deps.yaml
   properties-file:
     description: |
       Properties file to be used for updating the POM file
-    default: ./properties.yaml
+    default: ./pombump-properties.yaml
   dependencies:
     description: |
       Dependencies to be used for updating the POM file via command line flag


### PR DESCRIPTION
The default name file name of `pombump.yaml` is causing issues, since our CI build thinks it could be a package