### PR TITLE
Add package.major-minor substitution

### DIFF
--- a/pkg/build/pipeline.go
+++ b/pkg/build/pipeline.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -38,6 +39,8 @@ import (
 	"chainguard.dev/melange/pkg/container"
 	"chainguard.dev/melange/pkg/util"
 )
+
+var majorMinorMicroRegex = regexp.MustCompile(`^(?P<major>[0-9]+)[.](?P<minor>[0-9]+)[.]{0,1}(?P<micro>[0-9]+){0,1}.*`)
 
 type PipelineContext struct {
 	Pipeline        *config.Pipeline
@@ -136,6 +139,10 @@ func substitutionMap(pb *PipelineBuild) (map[string]string, error) {
 		config.SubstitutionPackageFullVersion: fmt.Sprintf("%s-r%s", config.SubstitutionPackageVersion, config.SubstitutionPackageEpoch),
 		config.SubstitutionTargetsDestdir:     fmt.Sprintf("/home/build/melange-out/%s", pb.Package.Name),
 		config.SubstitutionTargetsContextdir:  fmt.Sprintf("/home/build/melange-out/%s", pb.Package.Name),
+	}
+
+	if majorMinorMicroRegex.MatchString(pb.Package.Version) {
+		nw[config.SubstitutionPackageMajorMinor] = majorMinorMicroRegex.ReplaceAllString(pb.Package.Version, "${major}.${minor}")
 	}
 
 	// These are not really meaningful for Test, so only use them for build.

--- a/pkg/config/vars.go
+++ b/pkg/config/vars.go
@@ -25,6 +25,7 @@ const (
 	SubstitutionPackageName           = "${{package.name}}"
 	SubstitutionPackageVersion        = "${{package.version}}"
 	SubstitutionPackageFullVersion    = "${{package.full-version}}"
+	SubstitutionPackageMajorMinor     = "${{package.major-minor}}"
 	SubstitutionPackageEpoch          = "${{package.epoch}}"
 	SubstitutionPackageDescription    = "${{package.description}}"
 	SubstitutionTargetsDestdir        = "${{targets.destdir}}"


### PR DESCRIPTION
I'm interested in feedback on this. 

I came to wanting a variable for major.minor when looking at [python-3.12](https://github.com/wolfi-dev/os/blob/main/python-3.12.yaml) which repeats the string 3.12 eleven times.

I can accept responses like "3.12 is more easily readable than ${{package.major-minor}}".

interested in thoughts.  