### PR TITLE
feat(pipelines): Add cargo build for rust packages

### DIFF
--- a/docs/PIPELINES-CARGO.md
+++ b/docs/PIPELINES-CARGO.md
@@ -1,0 +1,90 @@
+# Built-in cargo pipeline
+
+Melange includes a built-in pipeline to compile rust packages.
+
+To get started quickly, checkout the `cargo/build` pipeline:
+[cargo-build.yaml](https://github.com/chainguard-dev/melange/blob/main/examples/cargo-build.yaml)
+
+## Building rust packages with `cargo/build`
+
+The `cargo/build` pipeline is a declarative interface to the `cargo auditable build`
+command. This pipeline builds a rust package, embedding a JSON dependency tree in its
+own linker section of the produced binary.
+
+Here's a sample melange configuration file cloning and running the same
+sample project as above:
+
+```yaml
+package:
+  name: eza
+  version: 0.18.6
+  epoch: 1
+  description: "A modern, maintained replacement for ls"
+  copyright:
+    - license: MIT
+
+environment:
+  contents:
+    keyring:
+      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    repositories:
+      - https://packages.wolfi.dev/os
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - libgit2-dev
+      - zlib-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/eza-community/eza
+      tag: v${{package.version}}
+      expected-commit: 1918eb866840486f3ad00a2d89d45f051072b2a9
+
+  - uses: cargo/build
+    with:
+      output: ${{package.name}}
+```
+
+(:bulb: Experiment with this code, 
+[download it from the examples directory](https://github.com/chainguard-dev/melange/blob/main/examples/cargo-build.yaml))
+
+## Build Parameters
+
+The `cargo/build` pipeline supports passing a few parameters to cargo by setting
+them in the melange configuration file. As of this writing, you can define the
+following values:
+
+```yaml
+  output:
+    description: |
+      Filename to use when writing the binary. The final install location inside
+      the apk will be in prefix / install-dir / output
+
+  opts:
+    description: |
+      Options to pass to cargo build. Defaults to release
+
+  modroot:
+    description: |
+      Top directory of the rust package, this is where the target package lives.
+      Before building, the cargo pipeline wil cd into this directory. Defaults
+      to current working directory
+
+  prefix:
+    description: |
+      Installation prefix. Defaults to usr
+```
+
+For the most up to date supported features check the
+[build](https://github.com/chainguard-dev/melange/blob/main/pkg/build/pipelines/go/build.yaml)
+pipeline.
+
+Feel free to request more features in the built-in pipelines by
+[filing a new issue](https://github.com/chainguard-dev/melange/issues/new) in 
+the melange repository!

--- a/examples/cargo-build.yaml
+++ b/examples/cargo-build.yaml
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: 2024 Chainguard, Inc
+# SPDX-License-Identifier: Apache-2.0
+#
+# This is a sample configuration file to demonstrate how to build a software
+# project using melange's built-in cargo/build pipeline.
+#
+# For more information about melange's built-in rust support check out:
+# https://github.com/chainguard-dev/melange/blob/main/docs/PIPELINES-CARGO.md
+package:
+  name: eza
+  version: 0.18.6
+  epoch: 1
+  description: "A modern, maintained replacement for ls"
+  copyright:
+    - license: MIT
+
+environment:
+  contents:
+    keyring:
+      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    repositories:
+      - https://packages.wolfi.dev/os
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - libgit2-dev
+      - zlib-dev
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/eza-community/eza
+      tag: v${{package.version}}
+      expected-commit: 1918eb866840486f3ad00a2d89d45f051072b2a9
+
+  - uses: cargo/build
+    with:
+      output: ${{package.name}}
+
+  - uses: strip
+
+update:
+  enabled: true
+  github:
+    identifier: eza-community/eza
+    strip-prefix: v
+    tag-filter-prefix: v
+
+test:
+  pipeline:
+    - runs: |
+        eza
+        eza --version

--- a/pkg/build/pipelines/cargo/build.yaml
+++ b/pkg/build/pipelines/cargo/build.yaml
@@ -1,0 +1,44 @@
+name: Compile an auditable rust binary with Cargo
+
+needs:
+  packages:
+    - cargo-auditable
+    - rust
+
+inputs:
+  output:
+    description: |
+      Filename to use when writing the binary. The final install location inside
+      the apk will be in prefix / install-dir / output
+    required: true
+
+  opts:
+    default: "--release"
+    description: |
+      Options to pass to cargo build. Defaults to release
+
+  modroot:
+    default: "."
+    required: false
+    description: |
+      Top directory of the rust package, this is where the target package lives.
+      Before building, the cargo pipeline wil cd into this directory. Defaults
+      to current working directory
+
+  prefix:
+    default: usr
+    description: |
+      Installation prefix. Defaults to usr
+
+pipeline:
+  - runs: |
+      # Installation directory should always be bin as we are producing a binary
+      INSTALL_PATH="${{targets.contextdir}}/${{inputs.prefix}}/bin/${{inputs.output}}"
+      OUTPUT_PATH="target/release/${{inputs.output}}"
+
+      # Enter target package directory
+      cd "${{inputs.modroot}}"
+
+      # Build and install package
+      cargo auditable build "${{inputs.opts}}"
+      install -Dm755 "${OUTPUT_PATH}" "${INSTALL_PATH}"


### PR DESCRIPTION
Produces and installs an auditable rust binary with an embedded dependency tree in its own dedicated linker section in JSON format. This simplifies the packaging processes for rust packages and ensures that all rust binaries we build are able to be audited for bugs/vulnerabilities in crates fetched during the build process

## Melange Pull Request Template

<!--
*** PULL REQUEST CHECKLIST: PLEASE START HERE ***

The single most important feature of melange is that we can build Wolfi.

Many changes to melange introduce a risk of breaking the build, and sometimes
these are not flushed out until a package is changed (much) later.  This
pertains to basic execution, SCA changes, linter changes, and more.
-->

### Functional Changes

- [x] This change can build all of Wolfi without errors (describe results in notes)

Notes:

### SCA Changes

- [x] Examining several representative APKs show no regression / the desired effect (details in notes)

Notes:

### Linter

- [ ] The new check is clean across Wolfi
- [ ] The new check is opt-in or a warning

Notes:
