### PR TITLE
sca: allow co-installable pythons

### DIFF
--- a/pkg/sca/sca.go
+++ b/pkg/sca/sca.go
@@ -462,7 +462,7 @@ func generatePkgConfigDeps(ctx context.Context, hdl SCAHandle, generated *config
 	return nil
 }
 
-var pythonNamesRegexp = regexp.MustCompile(`^python-3.[0-9]*$`)
+var pythonNamesRegexp = regexp.MustCompile(`^python-3\.\d+$`)
 
 // generatePythonDeps generates a python3~$VERSION dependency for packages which ship
 // Python modules.

--- a/pkg/sca/sca.go
+++ b/pkg/sca/sca.go
@@ -462,6 +462,8 @@ func generatePkgConfigDeps(ctx context.Context, hdl SCAHandle, generated *config
 	return nil
 }
 
+var pythonNamesRegexp = regexp.MustCompile(`^python-3.[0-9]*$`)
+
 // generatePythonDeps generates a python3~$VERSION dependency for packages which ship
 // Python modules.
 func generatePythonDeps(ctx context.Context, hdl SCAHandle, generated *config.Dependencies) error {
@@ -471,6 +473,12 @@ func generatePythonDeps(ctx context.Context, hdl SCAHandle, generated *config.De
 	fsys, err := hdl.Filesystem()
 	if err != nil {
 		return err
+	}
+
+	// Skip streamed python-3.11 generating dependency on
+	// python-3.11-default, thus allowing co-install
+	if pythonNamesRegexp.MatchString(hdl.PackageName()) {
+		return nil
 	}
 
 	var pythonModuleVer string


### PR DESCRIPTION
## Melange Pull Request Template

Skip generating python3~N.M dependency on python-3.11 package itself (and similar). Thus allowing to co-install python-3.11 and python-3.12, as they got finally correctly streamed by @smoser 

### Functional Changes

- [ ] This change can build all of Wolfi without errors (describe results in notes)

Notes:

### SCA Changes

- [ ] Examining several representative APKs show no regression / the desired effect (details in notes)

Notes:

### Linter

- [ ] The new check is clean across Wolfi
- [ ] The new check is opt-in or a warning

Notes:

  * built python-3.11 & python-3.12 and they both co-install now
  * dropped manual python3 depends from py3-requests, rebuild it with this melange, and python3~3.12 is correctly added
  * note, the generated dependency is likely to change soon from python3~3.N to python-3.N