### PR TITLE
Add filter-prefix option to update config.

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -459,6 +459,8 @@ type Update struct {
 	GitHubMonitor *GitHubMonitor `json:"github,omitempty" yaml:"github,omitempty"`
 	// The configuration block for transforming the `package.version` into an APK version
 	VersionTransform []VersionTransform `json:"version-transform,omitempty" yaml:"version-transform,omitempty"`
+	// Prefix filter to apply when searching releases
+	FilterPrefix string `json:"filter-prefix,omitempty" yaml:"filter-prefix,omitempty"`
 }
 
 // ReleaseMonitor indicates using the API for https://release-monitoring.org/

--- a/pkg/config/schema.json
+++ b/pkg/config/schema.json
@@ -879,6 +879,10 @@
           },
           "type": "array",
           "description": "The configuration block for transforming the `package.version` into an APK version"
+        },
+        "filter-prefix": {
+          "type": "string",
+          "description": "Prefix filter to apply when searching releases"
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
There is not currently a way to include only matching versions from the release update service

This adds filter-prefix entry to Update section of melange.yaml. Specific use case for filter-prefix is a streamed package (ruby).

After the corresponding change to make use of this filter lands in wolfi, then we can update ruby-3.2 to enable the release monitor like with:

 > update:
 >  enabled: true
 >  manual: true
 >  filter-prefix: "3.2."
 >  release-monitor:
 >    identifier: 4223

## Melange Pull Request Template

<!--
*** PULL REQUEST CHECKLIST: PLEASE START HERE ***

The single most important feature of melange is that we can build Wolfi.

Many changes to melange introduce a risk of breaking the build, and sometimes
these are not flushed out until a package is changed (much) later.  This
pertains to basic execution, SCA changes, linter changes, and more.
-->

### Functional Changes

- [ ] This change can build all of Wolfi without errors (describe results in notes)

Notes:

### SCA Changes

- [ ] Examining several representative APKs show no regression / the desired effect (details in notes)

Notes:

### Linter

- [ ] The new check is clean across Wolfi
- [ ] The new check is opt-in or a warning

Notes:
