### PR TITLE
Move "executing:" logging to debug

### DIFF
--- a/pkg/container/bubblewrap_runner.go
+++ b/pkg/container/bubblewrap_runner.go
@@ -102,7 +102,7 @@ func (bw *bubblewrap) cmd(ctx context.Context, cfg *Config, debug bool, args ...
 	args = append(baseargs, args...)
 	execCmd := exec.CommandContext(ctx, "bwrap", args...)
 
-	clog.FromContext(ctx).Infof("executing: %s", strings.Join(execCmd.Args, " "))
+	clog.FromContext(ctx).Debugf("executing: %s", strings.Join(execCmd.Args, " "))
 
 	return execCmd
 }


### PR DESCRIPTION
This currently spams a ton of logs which aren't terribly helpful unless you're debugging something:

```
2024/03/13 13:49:06 INFO executing: bwrap --bind /tmp/melange-guest-712322663 / --bind /tmp/melange-workspace-1734788743 /home/build --bind /etc/resolv.conf /etc/resolv.conf --bind /gihtub/.melangecache /var/cache/melange --unshare-pid --die-with-parent --dev /dev --proc /proc --chdir /home/build --clearenv --new-session --setenv GOMODCACHE /var/cache/melange/gomodcache --setenv CFLAGS -O2 -Wall -fomit-frame-pointer -march=armv8-a+crc+crypto -mtune=neoverse-n1 --setenv SOURCE_DATE_EPOCH 0 --setenv LDFLAGS -Wl,--as-needed,-O1,--sort-common -Wl,-z,relro,-z,now,-z,noexecstack --setenv GOPATH /home/build/.cache/go --setenv GOTOOLCHAIN local --setenv CPPFLAGS -O2 -Wp,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS --setenv CXXFLAGS -O2 -Wall -fomit-frame-pointer -march=armv8-a+crc+crypto -mtune=neoverse-n1 --setenv GOFLAGS  --setenv HOME /home/build /bin/sh -c set -e 
export PATH='/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'

[ -d '/home/build' ] || mkdir -p '/home/build'
cd '/home/build'
if [ "8d104c26a154b29fd67d6568b4f375212212ad41e0c2caa3d66480e78dbd3b59" == "" ] && [ "" == "" ]; then
  printf "One of expected-sha256 or expected-sha512 is required"
  exit 1
fi

bn=$(basename https://download.redis.io/releases/redis-7.2.4.tar.gz)

if [ ! "8d104c26a154b29fd67d6568b4f375212212ad41e0c2caa3d66480e78dbd3b59" == "" ]; then
  fn="/var/cache/melange/sha256:8d104c26a154b29fd67d6568b4f375212212ad41e0c2caa3d66480e78dbd3b59"
  if [ -f $fn ]; then

...
```