### PR TITLE
Propagate user from image configuration

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -1030,6 +1030,7 @@ func (b *Build) buildWorkspaceConfig(ctx context.Context) *container.Config {
 		},
 		WorkspaceDir: b.WorkspaceDir,
 		Timeout:      b.Configuration.Package.Timeout,
+		RunAs:        b.Configuration.Environment.Accounts.RunAs,
 	}
 
 	if b.Configuration.Package.Resources != nil {

--- a/pkg/build/test.go
+++ b/pkg/build/test.go
@@ -419,7 +419,7 @@ func (t *Test) TestPackage(ctx context.Context) error {
 		}
 	}
 
-	cfg, err := t.buildWorkspaceConfig(ctx, imgRef, pkg.Name, t.Configuration.Test.Environment.Environment)
+	cfg, err := t.buildWorkspaceConfig(ctx, imgRef, pkg.Name, t.Configuration.Test.Environment)
 	if err != nil {
 		return fmt.Errorf("unable to build workspace config: %w", err)
 	}
@@ -485,7 +485,7 @@ func (t *Test) TestPackage(ctx context.Context) error {
 			if err := t.OverlayBinSh(sp.Name); err != nil {
 				return fmt.Errorf("unable to install overlay /bin/sh: %w", err)
 			}
-			subCfg, err := t.buildWorkspaceConfig(ctx, spImgRef, sp.Name, sp.Test.Environment.Environment)
+			subCfg, err := t.buildWorkspaceConfig(ctx, spImgRef, sp.Name, sp.Test.Environment)
 			if err != nil {
 				return fmt.Errorf("unable to build workspace config: %w", err)
 			}
@@ -547,7 +547,7 @@ func (t *Test) Summarize(ctx context.Context) {
 	t.SummarizePaths(ctx)
 }
 
-func (t *Test) buildWorkspaceConfig(ctx context.Context, imgRef, pkgName string, env map[string]string) (*container.Config, error) {
+func (t *Test) buildWorkspaceConfig(ctx context.Context, imgRef, pkgName string, imgcfg apko_types.ImageConfiguration) (*container.Config, error) {
 	log := clog.FromContext(ctx)
 	mounts := []container.BindMount{
 		{Source: t.WorkspaceDir, Destination: container.DefaultWorkspaceDir},
@@ -577,9 +577,10 @@ func (t *Test) buildWorkspaceConfig(ctx context.Context, imgRef, pkgName string,
 		Mounts:       mounts,
 		Capabilities: caps,
 		Environment:  map[string]string{},
+		RunAs:        imgcfg.Accounts.RunAs,
 	}
 
-	for k, v := range env {
+	for k, v := range imgcfg.Environment {
 		cfg.Environment[k] = v
 	}
 

--- a/pkg/build/test_test.go
+++ b/pkg/build/test_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"chainguard.dev/apko/pkg/build/types"
+	apko_types "chainguard.dev/apko/pkg/build/types"
 	"chainguard.dev/melange/pkg/config"
 	"chainguard.dev/melange/pkg/container"
 	"github.com/chainguard-dev/clog/slogtest"
@@ -118,7 +119,7 @@ func TestBuildWorkspaceConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := slogtest.TestContextWithLogger(t)
-			got, gotErr := tt.t.buildWorkspaceConfig(ctx, testImgRef, testPkgName, tt.env)
+			got, gotErr := tt.t.buildWorkspaceConfig(ctx, testImgRef, testPkgName, apko_types.ImageConfiguration{Environment: tt.env})
 			if gotErr != nil {
 				if tt.wantErr == "" {
 					t.Fatalf("unexpected error: %v", gotErr)

--- a/pkg/container/bubblewrap_runner.go
+++ b/pkg/container/bubblewrap_runner.go
@@ -85,6 +85,11 @@ func (bw *bubblewrap) cmd(ctx context.Context, cfg *Config, debug bool, args ...
 		"--chdir", runnerWorkdir,
 		"--clearenv")
 
+	if cfg.RunAs != "" {
+		baseargs = append(baseargs, "--unshare-user")
+		baseargs = append(baseargs, "--uid", cfg.RunAs)
+	}
+
 	if !debug {
 		// This flag breaks job control, which we only care about for --interactive debugging.
 		// So we usually include it, but if we're about to debug, don't set it.

--- a/pkg/container/config.go
+++ b/pkg/container/config.go
@@ -50,6 +50,7 @@ type Config struct {
 	ImgRef       string
 	PodID        string
 	Arch         apko_types.Architecture
+	RunAs        string
 	WorkspaceDir string
 	CPU, Memory  string
 	Timeout      time.Duration

--- a/pkg/container/docker/docker_runner.go
+++ b/pkg/container/docker/docker_runner.go
@@ -219,11 +219,8 @@ func (dk *docker) Run(ctx context.Context, cfg *mcontainer.Config, args ...strin
 		environ = append(environ, fmt.Sprintf("%s=%s", k, v))
 	}
 
-	// TODO(kaniini): We want to use the build user here, but for now lets keep it simple.
-	// TODO(epsilon-phase): building as the user "build" was removed from docker runner
-	// for consistency with other runners and to ensure that packages can be generated with files
-	// that have owners other than root. We should explore using fakeroot or similar tricks for these use-cases.
 	taskIDResp, err := dk.cli.ContainerExecCreate(ctx, cfg.PodID, types.ExecConfig{
+		User:         cfg.RunAs,
 		Cmd:          args,
 		WorkingDir:   runnerWorkdir,
 		Env:          environ,


### PR DESCRIPTION
This works for both build and test, but will probably be harder to make work with builds because of file ownership shenanigans. For tests, this makes it possible to test non-root users for packages that get mad if you run them as root.