### PR TITLE
skip mounting resolv.conf for the docker runner

### DIFF
--- a/pkg/container/dagger/dagger.go
+++ b/pkg/container/dagger/dagger.go
@@ -35,8 +35,10 @@ import (
 	"golang.org/x/exp/slices"
 )
 
-const DaggerName = "dagger"
-const imageTarName = "image.tar"
+const (
+	DaggerName   = "dagger"
+	imageTarName = "image.tar"
+)
 
 type daggerRunner struct {
 	client    *dagger.Client
@@ -126,7 +128,7 @@ func (d *daggerRunner) StartPod(ctx context.Context, cfg *container.Config) erro
 	for _, mnt := range cfg.Mounts {
 
 		// We skip mounting in some files that we don't need in this mode
-		if mnt.Source == "/etc/resolv.conf" {
+		if mnt.Source == container.DefaultResolvConfPath {
 			continue
 		}
 

--- a/pkg/container/docker/docker_runner.go
+++ b/pkg/container/docker/docker_runner.go
@@ -84,6 +84,11 @@ func (dk *docker) StartPod(ctx context.Context, cfg *mcontainer.Config) error {
 
 	mounts := []mount.Mount{}
 	for _, bind := range cfg.Mounts {
+		// We skip mounting in some files that we don't need in this mode
+		if bind.Source == mcontainer.DefaultResolvConfPath {
+			continue
+		}
+
 		mounts = append(mounts, mount.Mount{
 			Type:   mount.TypeBind,
 			Source: bind.Source,


### PR DESCRIPTION
we've been improperly mounting in the hosts `/etc/resolv.conf` forever, and have gotten away with it because some systems (docker desktop) works okay because the `nameserver` still resolves, but does not on others.

this ignores `/etc/resolv.conf` for the docker runner so we just fallback to letting docker manage its own `/etc/resolv.conf`

this should fix the `could not resolve host: ...` errors we've been seeing in GHA everytime we try to migrate to `--runner docker`