### PR TITLE
Python/sca updates

### DIFF
--- a/pkg/sca/sca.go
+++ b/pkg/sca/sca.go
@@ -520,10 +520,8 @@ func generatePythonDeps(ctx context.Context, hdl SCAHandle, generated *config.De
 		}
 	}
 
-	// We use the python3 name here instead of the python-3 name so that we can be
-	// compatible with Alpine and Adelie.  Only Wolfi provides the python-3 name.
-	log.Infof("  found python module, generating python3~%s dependency", pythonModuleVer)
-	generated.Runtime = append(generated.Runtime, fmt.Sprintf("python3~%s", pythonModuleVer))
+	log.Infof("  found python module, generating python-%s-base dependency", pythonModuleVer)
+	generated.Runtime = append(generated.Runtime, fmt.Sprintf("python-%s-base", pythonModuleVer))
 
 	return nil
 }


### PR DESCRIPTION
There are 2 changes here, I'm happy to split them into separate PRs if requested.

1. instead of generating python3~$VERSION generate python-3.$VERSION-base . this way the python library does not depend on /usr/bin/python, but rather /usr/bin/python3.$VERSION
2. look at shebang programs and generate a cmd:<prog> for each of those.

