### PR TITLE
Go fips deps

### DIFF
--- a/.github/workflows/go-tests.yaml
+++ b/.github/workflows/go-tests.yaml
@@ -23,6 +23,11 @@ jobs:
           go-version: '1.21'
           check-latest: true
 
+      - name: Install bubblewrap
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y bubblewrap
+
       - name: Checkout code
         uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
 

--- a/Makefile
+++ b/Makefile
@@ -146,7 +146,9 @@ lint: checkfmt setup-golangci-lint ## Run linters and checks like golangci-lint
 	$(GOLANGCI_LINT_BIN) run --verbose --concurrency 4 --deadline 3m0s  --skip-dirs .modcache ./...
 
 .PHONY: test
-test: ## Run go test
+test: melange ## Run go test
+	# build test package
+	 ./melange build --generate-index=false pkg/sca/testdata/go-fips-bin/go-fips-bin.yaml --arch=`uname -m` --source-dir=pkg/sca/testdata/go-fips-bin/ --out-dir pkg/sca/testdata/go-fips-bin/packages/ --log-level error
 	go test ./... -race
 
 .PHONY: clean

--- a/pkg/sca/sca_test.go
+++ b/pkg/sca/sca_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
@@ -136,6 +137,51 @@ func TestExecableSharedObjects(t *testing.T) {
 		Provides: []string{
 			"so:libcap.so.2=2",
 			"so:libpsx.so.2=2",
+		},
+	}
+
+	got.Runtime = util.Dedup(got.Runtime)
+	got.Provides = util.Dedup(got.Provides)
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("Analyze(): (-want, +got):\n%s", diff)
+	}
+}
+
+// test a fips like go binary package for SCA depends
+// Chainguard go-fips toolchain generates binaries like these
+// which at runtime require openssl and fips provider
+func TestGoFipsBinDeps(t *testing.T) {
+	ctx := slogtest.TestContextWithLogger(t)
+
+	var ldso, archdir string
+	switch runtime.GOARCH {
+	case "arm64":
+		ldso = "so:ld-linux-aarch64.so.1"
+		archdir = "aarch64"
+	case "amd64":
+		ldso = "so:ld-linux-x86-64.so.2"
+		archdir = "x86_64"
+	}
+
+	th := handleFromApk(ctx, t, fmt.Sprintf("go-fips-bin/packages/%s/go-fips-bin-v0.0.1-r0.apk", archdir), "go-fips-bin/go-fips-bin.yaml")
+	defer th.exp.Close()
+
+	got := config.Dependencies{}
+	if err := Analyze(ctx, th, &got); err != nil {
+		t.Fatal(err)
+	}
+
+	want := config.Dependencies{
+		Runtime: []string{
+			"openssl-config-fipshardened",
+			ldso,
+			"so:libc.so.6",
+			"so:libcrypto.so.3",
+			"so:libssl.so.3",
+		},
+		Provides: []string{
+			"cmd:go-fips-bin=v0.0.1-r0",
 		},
 	}
 

--- a/pkg/sca/testdata/go-fips-bin/go-fips-bin.yaml
+++ b/pkg/sca/testdata/go-fips-bin/go-fips-bin.yaml
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: 2022 Chainguard, Inc
+# SPDX-License-Identifier: Apache-2.0
+#
+# This is a sample configuration file to demonstrate how to build a software
+# project using melange's built-in go/install pipeline.
+#
+# For more information about melange's built-in golang support check out:
+#
+#
+# For an equivalent pipeline that uses go/install to build the same project
+# please see go-install.yaml in this directory.
+package:
+  name: go-fips-bin
+  version: v0.0.1
+  epoch: 0
+  description: "A tiny fips-like go binary"
+
+environment:
+  contents:
+    keyring:
+      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    repositories:
+      - https://packages.wolfi.dev/os
+
+pipeline:
+  - uses: go/install
+    with:
+      package: .
+      # This is an approximation to the real go-fips toolchain
+      experiments: boringcrypto

--- a/pkg/sca/testdata/go-fips-bin/go.mod
+++ b/pkg/sca/testdata/go-fips-bin/go.mod
@@ -1,0 +1,3 @@
+module go-fips-bin
+
+go 1.22.1

--- a/pkg/sca/testdata/go-fips-bin/main.go
+++ b/pkg/sca/testdata/go-fips-bin/main.go
@@ -1,0 +1,5 @@
+package main
+
+import _ "crypto/sha256"
+
+func main() {}


### PR DESCRIPTION
## Melange Pull Request Template

Automatically generate runtime deps for go binaries that smell like go-fips ones. Specifically check if CGO is on, and boringcrypto experiment is on, and in that case generate runtime dependencies on openssl libraries, fips config, and fips provider.

This will reduce number of by-hand declared runtime dependencies on the go-fips compiled binaries.

### Functional Changes

- [x] This change can build all of Wolfi without errors (describe results in notes)

It reduces manually specified runtime dependencies in many golang based -fips packages.

Notes:

### SCA Changes

- [x] Examining several representative APKs show no regression / the desired effect (details in notes)

The `openssl-config-fipshardened` is Chainguard-specific, however in practice it means "anything that will get one correctly configured OpenSSL fips provider" with no restriction as to which OpenSSL it is, or which fips provider build it is. Non-chainguard APK distributions can call that thing whatever they want, and add a virtual providers for it.
If this is deemed too specific, maybe we should add a more generic provides name; and use that in SCA; and have that match in Chainguard i.e. something fake like `so:openssl-fips-provider` and then use that everywhere.

W.r.t. detecting correct toolchain this should work for many go-fips builds from Chainguard, Microsoft, RHEL, Canonical. Thus it is universall-ish enough.

Notes:

### Linter

- [x] The new check is clean across Wolfi
- [x] The new check is opt-in or a warning

Notes:

Test case added for new behavior using a binary that mimics a fips go binary close enough.

Developed on x86_64, should work on arm64 too.