### PR TITLE
Ensure configuration file is closed

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -689,6 +689,7 @@ func ParseConfiguration(ctx context.Context, configurationFilePath string, opts 
 	if err != nil {
 		return nil, err
 	}
+	defer f.Close()
 
 	root := yaml.Node{}
 


### PR DESCRIPTION
Currently the configuration file is opened but never closed. While it will be closed implicitly when the file is garbage collected, best practice would be to close the file when the function returns.