### PR TITLE
index: add json index writing

### DIFF
--- a/docs/md/melange_index.md
+++ b/docs/md/melange_index.md
@@ -30,6 +30,7 @@ melange index [flags]
 ```
   -a, --arch string          Index only packages which match the expected architecture
   -h, --help                 help for index
+  -j, --jsonoutput string    Output generated JSON index to FILE
   -m, --merge                Merge pre-existing index entries
   -o, --output string        Output generated index to FILE (default "APKINDEX.tar.gz")
       --signing-key string   Key to use for signing the index (optional)

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -929,6 +929,7 @@ func (b *Build) BuildPackage(ctx context.Context) error {
 			index.WithSigningKey(b.SigningKey),
 			index.WithMergeIndexFileFlag(true),
 			index.WithIndexFile(filepath.Join(packageDir, "APKINDEX.tar.gz")),
+			index.WithIndexJsonFile(filepath.Join(packageDir, "APKINDEX.json")),
 		}
 
 		idx, err := index.New(opts...)
@@ -938,10 +939,6 @@ func (b *Build) BuildPackage(ctx context.Context) error {
 
 		if err := idx.GenerateIndex(ctx); err != nil {
 			return fmt.Errorf("unable to generate index: %w", err)
-		}
-
-		if err := idx.WriteJSONIndex(filepath.Join(packageDir, "APKINDEX.json")); err != nil {
-			return fmt.Errorf("unable to generate JSON index: %w", err)
 		}
 	}
 

--- a/pkg/cli/index.go
+++ b/pkg/cli/index.go
@@ -24,6 +24,7 @@ import (
 // Index is a constructor for a cobra.Command which wraps the IndexCmd function.
 func Index() *cobra.Command {
 	var apkIndexFilename string
+	var apkIndexJsonFilename string
 	var sourceIndexFilename string
 	var expectedArch string
 	var signingKey string
@@ -38,6 +39,7 @@ func Index() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			options := []index.Option{
 				index.WithIndexFile(apkIndexFilename),
+				index.WithIndexJsonFile(apkIndexJsonFilename),
 				index.WithSourceIndexFile(sourceIndexFilename),
 				index.WithExpectedArch(expectedArch),
 				index.WithMergeIndexFileFlag(mergeIndexEntries),
@@ -50,6 +52,8 @@ func Index() *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&apkIndexFilename, "output", "o", "APKINDEX.tar.gz", "Output generated index to FILE")
+	// No default for now, as it's too new and is unexpected
+	cmd.Flags().StringVarP(&apkIndexJsonFilename, "jsonoutput", "j", "", "Output generated JSON index to FILE")
 	cmd.Flags().StringVarP(&sourceIndexFilename, "source", "s", "APKINDEX.tar.gz", "Source FILE to use for pre-existing index entries")
 	cmd.Flags().StringVarP(&expectedArch, "arch", "a", "", "Index only packages which match the expected architecture")
 	cmd.Flags().StringVar(&signingKey, "signing-key", "", "Key to use for signing the index (optional)")

--- a/pkg/index/index.go
+++ b/pkg/index/index.go
@@ -34,6 +34,7 @@ import (
 type Index struct {
 	PackageFiles       []string
 	IndexFile          string
+	IndexJsonFile      string
 	SourceIndexFile    string
 	MergeIndexFileFlag bool
 	SigningKey         string
@@ -54,6 +55,13 @@ func WithIndexFile(indexFile string) Option {
 	return func(idx *Index) error {
 		idx.IndexFile = indexFile
 		idx.SourceIndexFile = indexFile
+		return nil
+	}
+}
+
+func WithIndexJsonFile(indexJsonFile string) Option {
+	return func(idx *Index) error {
+		idx.IndexJsonFile = indexJsonFile
 		return nil
 	}
 }
@@ -224,6 +232,11 @@ func (idx *Index) GenerateIndex(ctx context.Context) error {
 
 	if err := idx.WriteArchiveIndex(ctx, idx.IndexFile); err != nil {
 		return fmt.Errorf("writing index: %w", err)
+	}
+	if idx.IndexJsonFile != "" {
+		if err := idx.WriteJSONIndex(idx.IndexJsonFile); err != nil {
+			return fmt.Errorf("unable to generate JSON index: %w", err)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
YOLO - no tests neither before nor after

Doing update on a single package, of an apk repository, seems to generate json which is much larger, so the json seems very stale.

```diff
$ git diff --stat
 APKINDEX.json | 179154 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++------------------------------------------------
 1 file changed, 114348 insertions(+), 64806 deletions(-)
```

Once this change lands, we can update `melange index` command in pipelines to generate `new.json` in addition to `new.tar.gz` and then copy that to the buckets.

## Melange Pull Request Template

<!--
*** PULL REQUEST CHECKLIST: PLEASE START HERE ***

The single most important feature of melange is that we can build Wolfi.

Many changes to melange introduce a risk of breaking the build, and sometimes
these are not flushed out until a package is changed (much) later.  This
pertains to basic execution, SCA changes, linter changes, and more.
-->

### Functional Changes

- [ ] This change can build all of Wolfi without errors (describe results in notes)

Notes:

### SCA Changes

- [ ] Examining several representative APKs show no regression / the desired effect (details in notes)

Notes:

### Linter

- [ ] The new check is clean across Wolfi
- [ ] The new check is opt-in or a warning

Notes:
