### PR TITLE
Only consider files in expected path (not under) for cmd provides.

### DIFF
--- a/pkg/sca/sca.go
+++ b/pkg/sca/sca.go
@@ -76,6 +76,16 @@ type SCAHandle interface {
 // findings based on analysis.
 type DependencyGenerator func(context.Context, SCAHandle, *config.Dependencies) error
 
+func isInDir(path string, paths []string) bool {
+	dir := filepath.Dir(path)
+	for _, p := range paths {
+		if dir+"/" == p {
+			return true
+		}
+	}
+	return false
+}
+
 func allowedPrefix(path string, prefixes []string) bool {
 	for _, pfx := range prefixes {
 		if strings.HasPrefix(path, pfx) {
@@ -116,7 +126,7 @@ func generateCmdProviders(ctx context.Context, hdl SCAHandle, generated *config.
 		}
 
 		if mode.Perm()&0555 == 0555 {
-			if allowedPrefix(path, cmdPrefixes) {
+			if isInDir(path, cmdPrefixes) {
 				basename := filepath.Base(path)
 				log.Infof("  found command %s", path)
 				generated.Provides = append(generated.Provides, fmt.Sprintf("cmd:%s=%s", basename, hdl.Version()))


### PR DESCRIPTION
Anything with +x in usr/bin/.../node_modules/... was getting marked as a command provided by the apk.

Instead, of considering any path under usr/bin, only consider usr/bin/.

## Melange Pull Request Template

<!--
*** PULL REQUEST CHECKLIST: PLEASE START HERE ***

The single most important feature of melange is that we can build Wolfi.

Many changes to melange introduce a risk of breaking the build, and sometimes
these are not flushed out until a package is changed (much) later.  This
pertains to basic execution, SCA changes, linter changes, and more.
-->

### Functional Changes

- [ ] This change can build all of Wolfi without errors (describe results in notes)

Notes:

### SCA Changes

- [ ] Examining several representative APKs show no regression / the desired effect (details in notes)

Notes:

### Linter

- [ ] The new check is clean across Wolfi
- [ ] The new check is opt-in or a warning

Notes:
