### PR TITLE
presubmit: remove gdk-pixbuf

### DIFF
--- a/.github/workflows/wolfi-presubmit.yaml
+++ b/.github/workflows/wolfi-presubmit.yaml
@@ -60,7 +60,6 @@ jobs:
           - tini
           - lzo
           - bubblewrap
-          - gdk-pixbuf
           - gitsign
           - guac
           - mdbook


### PR DESCRIPTION
This build seems to be broken, and shouldn't block melange presubmit
