### PR TITLE
Revert "presubmit: remove gdk-pixbuf"

### DIFF
--- a/.github/workflows/wolfi-presubmit.yaml
+++ b/.github/workflows/wolfi-presubmit.yaml
@@ -60,6 +60,7 @@ jobs:
           - tini
           - lzo
           - bubblewrap
+          - gdk-pixbuf
           - gitsign
           - guac
           - mdbook


### PR DESCRIPTION
Reverts chainguard-dev/melange#1143

This package should build now, and it's a required check.