### PR TITLE
Only consider that are in a PATH dir from generateCmdProviders

### DIFF
--- a/pkg/sca/sca.go
+++ b/pkg/sca/sca.go
@@ -86,7 +86,17 @@ func allowedPrefix(path string, prefixes []string) bool {
 	return false
 }
 
-var cmdPrefixes = []string{"bin/", "sbin/", "usr/bin/", "usr/sbin/"}
+func isInDir(path string, dirs []string) bool {
+	mydir := filepath.Dir(path)
+	for _, d := range dirs {
+		if mydir == d || mydir+"/" == d {
+			return true
+		}
+	}
+	return false
+}
+
+var pathBinDirs = []string{"bin/", "sbin/", "usr/bin/", "usr/sbin/"}
 
 func generateCmdProviders(ctx context.Context, hdl SCAHandle, generated *config.Dependencies) error {
 	log := clog.FromContext(ctx)
@@ -116,7 +126,7 @@ func generateCmdProviders(ctx context.Context, hdl SCAHandle, generated *config.
 		}
 
 		if mode.Perm()&0555 == 0555 {
-			if allowedPrefix(path, cmdPrefixes) {
+			if isInDir(path, pathBinDirs) {
 				basename := filepath.Base(path)
 				log.Infof("  found command %s", path)
 				generated.Provides = append(generated.Provides, fmt.Sprintf("cmd:%s=%s", basename, hdl.Version()))


### PR DESCRIPTION
generateCmdProviders would pick up all files under /usr/bin, /bin, /usr/sbin, /sbin.  The result was that files installed in /usr/bin/subdir/here/some/thing would get marked as Provides.

Thsi was found in sqlpad-7.4.1-r3.apk, which installs things under usr/bin/sqlpad-server/ like
usr/bin/sqlpad-server/test/fixtures/config.json

## Melange Pull Request Template

<!--
*** PULL REQUEST CHECKLIST: PLEASE START HERE ***

The single most important feature of melange is that we can build Wolfi.

Many changes to melange introduce a risk of breaking the build, and sometimes
these are not flushed out until a package is changed (much) later.  This
pertains to basic execution, SCA changes, linter changes, and more.
-->

### Functional Changes

- [ ] This change can build all of Wolfi without errors (describe results in notes)

Notes:

### SCA Changes

- [ ] Examining several representative APKs show no regression / the desired effect (details in notes)

Notes:

### Linter

- [ ] The new check is clean across Wolfi
- [ ] The new check is opt-in or a warning

Notes:
