### PR TITLE
config: allow scriplets in subpackages with range replacements

### DIFF
--- a/pkg/config/schema.json
+++ b/pkg/config/schema.json
@@ -717,19 +717,7 @@
     "Scriptlets": {
       "properties": {
         "trigger": {
-          "properties": {
-            "script": {
-              "type": "string"
-            },
-            "paths": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            }
-          },
-          "additionalProperties": false,
-          "type": "object",
+          "$ref": "#/$defs/Trigger",
           "description": "Optional: A script to run on a custom trigger"
         },
         "pre-install": {
@@ -839,6 +827,23 @@
         "environment",
         "pipeline"
       ]
+    },
+    "Trigger": {
+      "properties": {
+        "script": {
+          "type": "string",
+          "description": "Optional: The script to run"
+        },
+        "paths": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Optional: The list of paths to monitor to trigger the script"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
     },
     "Update": {
       "properties": {


### PR DESCRIPTION
This allows to create subpackages with dynamic scriplets, which take range key/value subsitutions just like other subapckage values.

Example fun usage shown in https://github.com/xnox/os/commit/3a964132ebe26225b8510ec2875b506a8e617633

```yaml
    scriptlets:
      post-install: |
        #!/usr/bin/python${{range.key}}
        import glob, shutil
        for b in glob.glob("/usr/pybin/${{range.key}}/*"): shutil.copy2(b, "/usr/bin/")
```

```console
bb6225aab2ee:/# head -n1 /usr/bin/pip
#!/usr/bin/python3.10

bb6225aab2ee:/# apk add py3.11-pip
(1/4) Installing python-3.11-base (3.11.9-r0)
(2/4) Installing py3.11-flit-core (3.9.0-r2)
(3/4) Installing py3.11-setuptools (69.5.1-r1)
(4/4) Installing py3.11-pip (24.0-r2)
Executing py3.11-pip-24.0-r2.post-install
OK: 140 MiB in 35 packages

bb6225aab2ee:/# head -n1 /usr/bin/pip
#!/usr/bin/python3.11

bb6225aab2ee:/# apk add py3.12-pip
(1/4) Installing python-3.12-base (3.12.3-r0)
(2/4) Installing py3.12-flit-core (3.9.0-r2)
(3/4) Installing py3.12-setuptools (69.5.1-r1)
(4/4) Installing py3.12-pip (24.0-r2)
Executing py3.12-pip-24.0-r2.post-install
OK: 199 MiB in 39 packages

bb6225aab2ee:/# head -n1 /usr/bin/pip
#!/usr/bin/python3.12
```

This is mostly for completness sake to be able to support full package schema, in the subpackages-range cases.

## Melange Pull Request Template

<!--
*** PULL REQUEST CHECKLIST: PLEASE START HERE ***

The single most important feature of melange is that we can build Wolfi.

Many changes to melange introduce a risk of breaking the build, and sometimes
these are not flushed out until a package is changed (much) later.  This
pertains to basic execution, SCA changes, linter changes, and more.
-->

### Functional Changes

- [ ] This change can build all of Wolfi without errors (describe results in notes)

Notes:

### SCA Changes

- [ ] Examining several representative APKs show no regression / the desired effect (details in notes)

Notes:

### Linter

- [ ] The new check is clean across Wolfi
- [ ] The new check is opt-in or a warning

Notes:
