### PR TITLE
fix(cargo): Install all built binaries if output isn't defined

### DIFF
--- a/pkg/build/pipelines/cargo/build.yaml
+++ b/pkg/build/pipelines/cargo/build.yaml
@@ -10,7 +10,6 @@ inputs:
     description: |
       Filename to use when writing the binary. The final install location inside
       the apk will be in prefix / install-dir / output
-    required: true
 
   opts:
     default: "--release"
@@ -33,12 +32,16 @@ inputs:
 pipeline:
   - runs: |
       # Installation directory should always be bin as we are producing a binary
-      INSTALL_PATH="${{targets.contextdir}}/${{inputs.prefix}}/bin/${{inputs.output}}"
-      OUTPUT_PATH="target/release/${{inputs.output}}"
+      INSTALL_PATH="${{targets.contextdir}}/${{inputs.prefix}}/bin"
+      OUTPUT_PATH="target/release"
 
       # Enter target package directory
       cd "${{inputs.modroot}}"
 
-      # Build and install package
+      # Build and install package(s)
       cargo auditable build "${{inputs.opts}}"
-      install -Dm755 "${OUTPUT_PATH}" "${INSTALL_PATH}"
+      if [[ -z "${{inputs.output}}" ]]; then
+        install -Dm755 "${OUTPUT_PATH}/${{inputs.output}}" "${INSTALL_PATH}/${{inputs.output}}"
+      else
+        install -Dm755 "${OUTPUT_PATH}"/* -t "${INSTALL_PATH}"
+      fi


### PR DESCRIPTION
Support installing multiple rust binaries after building them with cargo

## Melange Pull Request Template

<!--
*** PULL REQUEST CHECKLIST: PLEASE START HERE ***

The single most important feature of melange is that we can build Wolfi.

Many changes to melange introduce a risk of breaking the build, and sometimes
these are not flushed out until a package is changed (much) later.  This
pertains to basic execution, SCA changes, linter changes, and more.
-->

### Functional Changes

- [x] This change can build all of Wolfi without errors (describe results in notes)

Notes:

### SCA Changes

- [x] Examining several representative APKs show no regression / the desired effect (details in notes)

Notes:

### Linter

- [x] The new check is clean across Wolfi
- [ ] The new check is opt-in or a warning

Notes:
