### PR TITLE
melange bump: don't skip main git checkout when mangled package versio…

### DIFF
--- a/pkg/renovate/bump/bump.go
+++ b/pkg/renovate/bump/bump.go
@@ -217,7 +217,7 @@ func updateGitCheckout(ctx context.Context, node *yaml.Node, expectedGitSha stri
 	if err != nil {
 		log.Infof("git-checkout node does not contain a tag, assume we need to update the expected-commit sha")
 	} else {
-		if !strings.Contains(tag.Value, "${{package.version}}") {
+		if !strings.Contains(tag.Value, "${{package.version}}") && !strings.Contains(tag.Value, "${{vars.mangled-package-version}}") {
 			log.Infof("Skipping git-checkout node as it does not contain a version substitution so assuming it is not the main checkout")
 			return nil
 		}

--- a/pkg/renovate/bump/testdata/multiple_checkouts_transforms.yaml
+++ b/pkg/renovate/bump/testdata/multiple_checkouts_transforms.yaml
@@ -1,0 +1,17 @@
+package:
+  name: cheese
+  version: 6.8
+  epoch: 2
+  description: "a cheesy library"
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: cheese/crisps
+      expected-commit: foo
+      tag: v${{vars.mangled-package-version}}
+  - uses: git-checkout
+    with:
+      repository: cheese/cheese
+      expected-commit: bar
+      tag: crackers


### PR DESCRIPTION
…n is used

There are cases where we use a mangled package version var when doing a git checkout of the main source repo.  Let's update the git commit in these cases.  The check was originally added in https://github.com/chainguard-dev/melange/pull/975 but only identified the main repo using `${{package.version}}`, we should include `${{vars.mangled-package-version}}`