### PR TITLE
Allow symlinks to provide cmd:

### DIFF
--- a/pkg/sca/sca.go
+++ b/pkg/sca/sca.go
@@ -121,10 +121,6 @@ func generateCmdProviders(ctx context.Context, hdl SCAHandle, generated *config.
 		}
 
 		mode := fi.Mode()
-		if !mode.IsRegular() {
-			return nil
-		}
-
 		if mode.Perm()&0555 == 0555 {
 			if isInDir(path, pathBinDirs) {
 				basename := filepath.Base(path)
@@ -582,8 +578,10 @@ func sonameLibver(soname string) string {
 }
 
 func getShbang(fp fs.File) (string, error) {
-	// python3 and sh are symlinks and generateCmdProviders currently only considers
-	// regular files. Since nothing will fulfill such a depend, do not generate one.
+	// Lots of programs have shbangs with python3 or sh which are symlinks.
+	// generateCmdProviders did not previously add a provides for symlinks
+	// that means we cannot let packages *depend* on python3, python or sh
+	// until we have packages that *provide* them.
 	ignores := map[string]bool{"python3": true, "python": true, "sh": true}
 
 	buf := make([]byte, 80)


### PR DESCRIPTION
Previously code that added automatic 'cmd:' provides ignored symlinks.  That doesn't seem right.

Possible fall out of this is busybox and /bin/sh related things as well as python -> python3 -> python3.12

## Melange Pull Request Template

<!--
*** PULL REQUEST CHECKLIST: PLEASE START HERE ***

The single most important feature of melange is that we can build Wolfi.

Many changes to melange introduce a risk of breaking the build, and sometimes
these are not flushed out until a package is changed (much) later.  This
pertains to basic execution, SCA changes, linter changes, and more.
-->

### Functional Changes

- [ ] This change can build all of Wolfi without errors (describe results in notes)

Notes:

### SCA Changes

- [ ] Examining several representative APKs show no regression / the desired effect (details in notes)

Notes:

### Linter

- [ ] The new check is clean across Wolfi
- [ ] The new check is opt-in or a warning

Notes:
