### PR TITLE
Make unit tests faster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,7 +149,7 @@ lint: checkfmt setup-golangci-lint ## Run linters and checks like golangci-lint
 test: melange ## Run go test
 	# build test package
 	 ./melange build --generate-index=false pkg/sca/testdata/go-fips-bin/go-fips-bin.yaml --arch=`uname -m` --source-dir=pkg/sca/testdata/go-fips-bin/ --out-dir pkg/sca/testdata/go-fips-bin/packages/ --log-level error
-	go test ./... -race
+	go test -tags e2e ./... -race
 
 .PHONY: clean
 clean: ## Clean the workspace

--- a/pkg/convert/python/e2e_test.go
+++ b/pkg/convert/python/e2e_test.go
@@ -1,0 +1,96 @@
+// Copyright 2022 Chainguard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build e2e
+// +build e2e
+
+package python
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/chainguard-dev/clog/slogtest"
+	"github.com/stretchr/testify/assert"
+)
+
+// This test downloads 10MB from files.pythonhosted.org (twice).
+// I am not in a position to untangle it, so we're going to gate this behind an e2e build tag that only runs in CI.
+func TestGenerateManifest(t *testing.T) {
+	ctx := slogtest.TestContextWithLogger(t)
+
+	for i := range versions {
+		pythonctxs, err := SetupContext(versions[i])
+		assert.NoError(t, err)
+
+		// botocore ctx
+		pythonctx := pythonctxs[0]
+		// Add additionalReposities and additionalKeyrings
+		pythonctx.AdditionalRepositories = []string{"https://packages.wolfi.dev/os"}
+		pythonctx.AdditionalKeyrings = []string{"https://packages.wolfi.dev/os/wolfi-signing.rsa.pub"}
+
+		got, err := pythonctx.generateManifest(ctx, pythonctx.Package, pythonctx.PackageVersion, nil, nil)
+		assert.NoError(t, err)
+
+		// Check Package
+		assert.Equal(t, got.Package.Name, "py"+versions[i]+"-botocore")
+		assert.Equal(t, got.Package.Version, "1.29.78")
+		assert.EqualValues(t, got.Package.Epoch, 0)
+		assert.Equal(t, got.Package.Description, "Low-level, data-driven core of boto 3.")
+		assert.Equal(t, got.Package.Dependencies.Runtime, []string{"py" + versions[i] + "-jmespath", "py" + versions[i] + "-python-dateutil", "py" + versions[i] + "-urllib3", "python-" + versions[i]})
+
+		// Check Package.Copyright
+		assert.Equal(t, len(got.Package.Copyright), 1)
+		assert.Equal(t, got.Package.Copyright[0].License, "Apache License 2.0")
+
+		// Check Environment
+		assert.Equal(t, got.Environment.Contents.Packages, []string{
+			"build-base",
+			"busybox",
+			"ca-certificates-bundle",
+			"wolfi-base",
+		})
+
+		// Check Pipeline
+		assert.Equal(t, len(got.Pipeline), 3)
+
+		// Check Pipeline - fetch
+		assert.Equal(t, got.Pipeline[0].Uses, "fetch")
+
+		releases, ok := pythonctx.Package.Releases[pythonctx.PackageVersion]
+
+		// If the key exists
+		assert.True(t, ok)
+
+		var release Release
+		for _, r := range releases {
+			if r.PackageType == "sdist" {
+				release = r
+			}
+		}
+		assert.NotEmpty(t, release)
+		assert.Equal(t, "https://files.pythonhosted.org/packages/8f/34/d4bcefeabfb8e4b46157e84ea55c3ecc7399d5f9a3454728e1d0d5f9cb83/botocore-"+pythonctx.PackageVersion+".tar.gz", release.URL)
+
+		tempURI := fmt.Sprintf("https://files.pythonhosted.org/packages/source/%c/%s/%s-%s.tar.gz", pythonctx.PackageName[0], pythonctx.PackageName, pythonctx.PackageName, pythonctx.PackageVersion)
+		assert.Equal(t, got.Pipeline[0].With, map[string]string{
+			"expected-sha256": "2bee6ed037590ef1e4884d944486232871513915f12a8590c63e3bb6046479bf",
+			"uri":             strings.ReplaceAll(tempURI, pythonctx.PackageVersion, "${{package.version}}"),
+		})
+
+		// Check Pipeline - runs
+		assert.Equal(t, got.Pipeline[1].Uses, "python/build-wheel")
+		assert.Equal(t, got.Pipeline[2].Uses, "strip")
+	}
+}

--- a/pkg/convert/python/pypi.go
+++ b/pkg/convert/python/pypi.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -155,14 +154,10 @@ func (p *PackageIndex) packageReq(ctx context.Context, endpoint string) (*Packag
 		err := fmt.Errorf("%d when getting %s: %w", resp.StatusCode, url, cause)
 		return nil, err
 	}
-	data, err := io.ReadAll(resp.Body)
-	if err != nil {
+
+	if err := json.NewDecoder(resp.Body).Decode(&pkg); err != nil {
 		return nil, err
 	}
 
-	err = json.Unmarshal(data, &pkg)
-	if err != nil {
-		return nil, err
-	}
-	return pkg, err
+	return pkg, nil
 }

--- a/pkg/convert/python/python_test.go
+++ b/pkg/convert/python/python_test.go
@@ -68,6 +68,7 @@ func TestGetPythonMeta(t *testing.T) {
 
 	pythonctx, err := New("botocore")
 	pythonctx.PackageIndex = NewPackageIndex("https://pypi.org")
+	pythonctx.PackageIndex.Client.Ratelimiter = nil // don't rate limit our unit tests
 	assert.NoError(t, err)
 
 	var expected Package
@@ -106,6 +107,7 @@ func TestFindDependencies(t *testing.T) {
 
 		for _, pythonctx := range pythonctxs {
 			pythonctx.PackageIndex.url = server.URL
+			pythonctx.PackageIndex.Client.Ratelimiter = nil // don't rate limit our unit tests
 			p, err := pythonctx.PackageIndex.Get(slogtest.TestContextWithLogger(t), pythonctx.PackageName, pythonctx.PackageVersion)
 			assert.NoError(t, err)
 			pythonctx.ToCheck = append(pythonctx.ToCheck, p.Info.Name)
@@ -130,73 +132,6 @@ func TestFindDependencies(t *testing.T) {
 			// The dependency list should be empty
 			assert.Empty(t, pythonctx.ToGenerate)
 		}
-	}
-}
-
-func TestGenerateManifest(t *testing.T) {
-	ctx := slogtest.TestContextWithLogger(t)
-
-	for i := range versions {
-		pythonctxs, err := SetupContext(versions[i])
-		assert.NoError(t, err)
-
-		// botocore ctx
-		pythonctx := pythonctxs[0]
-		// Add additionalReposities and additionalKeyrings
-		pythonctx.AdditionalRepositories = []string{"https://packages.wolfi.dev/os"}
-		pythonctx.AdditionalKeyrings = []string{"https://packages.wolfi.dev/os/wolfi-signing.rsa.pub"}
-
-		got, err := pythonctx.generateManifest(ctx, pythonctx.Package, pythonctx.PackageVersion, nil, nil)
-		assert.NoError(t, err)
-
-		// Check Package
-		assert.Equal(t, got.Package.Name, "py"+versions[i]+"-botocore")
-		assert.Equal(t, got.Package.Version, "1.29.78")
-		assert.EqualValues(t, got.Package.Epoch, 0)
-		assert.Equal(t, got.Package.Description, "Low-level, data-driven core of boto 3.")
-		assert.Equal(t, got.Package.Dependencies.Runtime, []string{"py" + versions[i] + "-jmespath", "py" + versions[i] + "-python-dateutil", "py" + versions[i] + "-urllib3", "python-" + versions[i]})
-
-		// Check Package.Copyright
-		assert.Equal(t, len(got.Package.Copyright), 1)
-		assert.Equal(t, got.Package.Copyright[0].License, "Apache License 2.0")
-
-		// Check Environment
-		assert.Equal(t, got.Environment.Contents.Packages, []string{
-			"build-base",
-			"busybox",
-			"ca-certificates-bundle",
-			"wolfi-base",
-		})
-
-		// Check Pipeline
-		assert.Equal(t, len(got.Pipeline), 3)
-
-		// Check Pipeline - fetch
-		assert.Equal(t, got.Pipeline[0].Uses, "fetch")
-
-		releases, ok := pythonctx.Package.Releases[pythonctx.PackageVersion]
-
-		// If the key exists
-		assert.True(t, ok)
-
-		var release Release
-		for _, r := range releases {
-			if r.PackageType == "sdist" {
-				release = r
-			}
-		}
-		assert.NotEmpty(t, release)
-		assert.Equal(t, "https://files.pythonhosted.org/packages/8f/34/d4bcefeabfb8e4b46157e84ea55c3ecc7399d5f9a3454728e1d0d5f9cb83/botocore-"+pythonctx.PackageVersion+".tar.gz", release.URL)
-
-		tempURI := fmt.Sprintf("https://files.pythonhosted.org/packages/source/%c/%s/%s-%s.tar.gz", pythonctx.PackageName[0], pythonctx.PackageName, pythonctx.PackageName, pythonctx.PackageVersion)
-		assert.Equal(t, got.Pipeline[0].With, map[string]string{
-			"expected-sha256": "2bee6ed037590ef1e4884d944486232871513915f12a8590c63e3bb6046479bf",
-			"uri":             strings.ReplaceAll(tempURI, pythonctx.PackageVersion, "${{package.version}}"),
-		})
-
-		// Check Pipeline - runs
-		assert.Equal(t, got.Pipeline[1].Uses, "python/build-wheel")
-		assert.Equal(t, got.Pipeline[2].Uses, "strip")
 	}
 }
 
@@ -236,6 +171,7 @@ func SetupContext(version string) ([]*PythonContext, error) {
 	}
 
 	botocorepythonctx.PackageIndex = NewPackageIndex("https://pypi.org/")
+	botocorepythonctx.PackageIndex.Client.Ratelimiter = nil // don't rate limit our unit tests
 	botocorepythonctx.PackageName = "botocore"
 	botocorepythonctx.PackageVersion = "1.29.78"
 	botocorepythonctx.PythonVersion = version
@@ -261,6 +197,7 @@ func SetupContext(version string) ([]*PythonContext, error) {
 	}
 
 	jsonschemapythonctx.PackageIndex = NewPackageIndex("https://pypi.org/")
+	jsonschemapythonctx.PackageIndex.Client.Ratelimiter = nil // don't rate limit our unit tests
 	jsonschemapythonctx.PackageName = "jsonschema"
 	jsonschemapythonctx.PackageVersion = "4.17.3"
 	jsonschemapythonctx.PythonVersion = version

--- a/pkg/sca/e2e_test.go
+++ b/pkg/sca/e2e_test.go
@@ -1,0 +1,74 @@
+// Copyright 2024 Chainguard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build e2e
+// +build e2e
+
+package sca
+
+import (
+	"fmt"
+	"runtime"
+	"testing"
+
+	"chainguard.dev/melange/pkg/config"
+	"chainguard.dev/melange/pkg/util"
+	"github.com/chainguard-dev/clog/slogtest"
+	"github.com/google/go-cmp/cmp"
+)
+
+// test a fips like go binary package for SCA depends
+// Chainguard go-fips toolchain generates binaries like these
+// which at runtime require openssl and fips provider
+func TestGoFipsBinDeps(t *testing.T) {
+	ctx := slogtest.TestContextWithLogger(t)
+
+	var ldso, archdir string
+	switch runtime.GOARCH {
+	case "arm64":
+		ldso = "so:ld-linux-aarch64.so.1"
+		archdir = "aarch64"
+	case "amd64":
+		ldso = "so:ld-linux-x86-64.so.2"
+		archdir = "x86_64"
+	}
+
+	th := handleFromApk(ctx, t, fmt.Sprintf("go-fips-bin/packages/%s/go-fips-bin-v0.0.1-r0.apk", archdir), "go-fips-bin/go-fips-bin.yaml")
+	defer th.exp.Close()
+
+	got := config.Dependencies{}
+	if err := Analyze(ctx, th, &got); err != nil {
+		t.Fatal(err)
+	}
+
+	want := config.Dependencies{
+		Runtime: []string{
+			"openssl-config-fipshardened",
+			ldso,
+			"so:libc.so.6",
+			"so:libcrypto.so.3",
+			"so:libssl.so.3",
+		},
+		Provides: []string{
+			"cmd:go-fips-bin=v0.0.1-r0",
+		},
+	}
+
+	got.Runtime = util.Dedup(got.Runtime)
+	got.Provides = util.Dedup(got.Provides)
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("Analyze(): (-want, +got):\n%s", diff)
+	}
+}


### PR DESCRIPTION
I was flummoxed to find that `go test ./...` was both very slow and did not work. The very slowness comes from a couple sources. One is that we use a 1 QPS rate limiter in a lot of places, even when we are using an in-process http server to serve up testdata. I've removed those instances. In one particular python test, we are fetching a 10MB targz from the internet twice. I've gated that behind an `e2e` build tag, so to run that test you need to execute:

  go test -tags e2e ./...

That's cumbersome, so I've added it to the `make test` target.

I've also added the `e2e` build tag to the go fips generated APK test because it requires you to first generate a binary before the test will pass. This is unacceptable to me, so the `make test` target will still test that, but `go test ./...` will not.

Before:

```
go test -count=1 ./...
?   	chainguard.dev/melange	[no test files]
?   	chainguard.dev/melange/docs	[no test files]
?   	chainguard.dev/melange/internal/contextreader	[no test files]
?   	chainguard.dev/melange/internal/gen-jsonschema	[no test files]
?   	chainguard.dev/melange/internal/logwriter	[no test files]
?   	chainguard.dev/melange/pkg/cli	[no test files]
?   	chainguard.dev/melange/pkg/container	[no test files]
?   	chainguard.dev/melange/pkg/container/dagger	[no test files]
?   	chainguard.dev/melange/pkg/container/docker	[no test files]
ok  	chainguard.dev/melange/pkg/build	0.352s
ok  	chainguard.dev/melange/pkg/cond	0.424s
?   	chainguard.dev/melange/pkg/convert/github	[no test files]
?   	chainguard.dev/melange/pkg/convert/relmon	[no test files]
?   	chainguard.dev/melange/pkg/http	[no test files]
ok  	chainguard.dev/melange/pkg/config	0.553s
?   	chainguard.dev/melange/pkg/linter/defaults	[no test files]
?   	chainguard.dev/melange/pkg/manifest	[no test files]
?   	chainguard.dev/melange/pkg/renovate	[no test files]
?   	chainguard.dev/melange/pkg/renovate/cache	[no test files]
ok  	chainguard.dev/melange/pkg/container/k8s	0.738s
ok  	chainguard.dev/melange/pkg/convert/apkbuild	0.224s
ok  	chainguard.dev/melange/pkg/convert/gem	5.139s
ok  	chainguard.dev/melange/pkg/convert/python	37.305s
ok  	chainguard.dev/melange/pkg/convert/wolfios	1.257s
ok  	chainguard.dev/melange/pkg/index	0.891s
ok  	chainguard.dev/melange/pkg/linter	1.309s
ok  	chainguard.dev/melange/pkg/renovate/bump	1.267s
ok  	chainguard.dev/melange/pkg/sbom	1.267s
ok  	chainguard.dev/melange/pkg/sca	1.414s
ok  	chainguard.dev/melange/pkg/sign	1.328s
ok  	chainguard.dev/melange/pkg/util	1.397s
```

After:

```
go test -count=1 ./...
?   	chainguard.dev/melange	[no test files]
?   	chainguard.dev/melange/docs	[no test files]
?   	chainguard.dev/melange/internal/contextreader	[no test files]
?   	chainguard.dev/melange/internal/gen-jsonschema	[no test files]
?   	chainguard.dev/melange/internal/logwriter	[no test files]
?   	chainguard.dev/melange/pkg/cli	[no test files]
?   	chainguard.dev/melange/pkg/container	[no test files]
?   	chainguard.dev/melange/pkg/container/dagger	[no test files]
?   	chainguard.dev/melange/pkg/container/docker	[no test files]
ok  	chainguard.dev/melange/pkg/build	0.352s
ok  	chainguard.dev/melange/pkg/cond	0.473s
ok  	chainguard.dev/melange/pkg/config	0.602s
?   	chainguard.dev/melange/pkg/convert/github	[no test files]
?   	chainguard.dev/melange/pkg/convert/relmon	[no test files]
?   	chainguard.dev/melange/pkg/http	[no test files]
?   	chainguard.dev/melange/pkg/linter/defaults	[no test files]
?   	chainguard.dev/melange/pkg/manifest	[no test files]
?   	chainguard.dev/melange/pkg/renovate	[no test files]
?   	chainguard.dev/melange/pkg/renovate/cache	[no test files]
ok  	chainguard.dev/melange/pkg/container/k8s	0.834s
ok  	chainguard.dev/melange/pkg/convert/apkbuild	0.183s
ok  	chainguard.dev/melange/pkg/convert/gem	0.336s
ok  	chainguard.dev/melange/pkg/convert/python	1.593s
ok  	chainguard.dev/melange/pkg/convert/wolfios	1.083s
ok  	chainguard.dev/melange/pkg/index	0.989s
ok  	chainguard.dev/melange/pkg/linter	1.379s
ok  	chainguard.dev/melange/pkg/renovate/bump	1.197s
ok  	chainguard.dev/melange/pkg/sbom	1.292s
ok  	chainguard.dev/melange/pkg/sca	1.404s
ok  	chainguard.dev/melange/pkg/sign	1.369s
ok  	chainguard.dev/melange/pkg/util	1.440s
```