### PR TITLE
Add buildmode to go/build

### DIFF
--- a/pkg/build/pipelines/go/build.yaml
+++ b/pkg/build/pipelines/go/build.yaml
@@ -91,6 +91,11 @@ inputs:
       GOARM64 microarchitecture level to use
     default: "v8.0"
 
+  buildmode:
+    description: |
+      The -buildmode flag value. See "go help buildmode" for more information.
+    default: "default"
+
 pipeline:
   - runs: |
       LDFLAGS="${{inputs.strip}} ${{inputs.ldflags}}"
@@ -116,4 +121,4 @@ pipeline:
       [ -e /home/build/go.mod.local ] && cp /home/build/go.mod.local go.mod
       [ -e /home/build/go.sum.local ] && cp /home/build/go.sum.local go.sum
 
-      GOAMD64="${{inputs.amd64}}" GOARM64="${{inputs.arm64}}" GOEXPERIMENT="${{inputs.experiments}}" go build -o "${{targets.contextdir}}"/${BASE_PATH} -tags "${{inputs.toolchaintags}},${{inputs.tags}}" -ldflags "${LDFLAGS}" -trimpath ${{inputs.packages}}
+      GOAMD64="${{inputs.amd64}}" GOARM64="${{inputs.arm64}}" GOEXPERIMENT="${{inputs.experiments}}" go build -o "${{targets.contextdir}}"/${BASE_PATH} -tags "${{inputs.toolchaintags}},${{inputs.tags}}" -ldflags "${LDFLAGS}" -trimpath -buildmode ${{inputs.buildmode}} ${{inputs.packages}}


### PR DESCRIPTION
This passes through -buildmode for e.g. c-shared targets.