### PR TITLE
sbom: include external refs for fetched sourcecode in SPDX

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -78,7 +78,7 @@ jobs:
           grep '"pkg:generic/hello@v0.0.1?vcs_url=git%2Bhttps%3A%2F%2Fgitlab.com%2Fxnox%2Fhello.git%40a73c4feb284dc6ed1e5758740f717f99dcd4c9d7"' git-checkout.sbom.json
 
           # Verify ConfigFile ref
-          grep '"pkg:github/chainguard-dev/melange@8fc050fc9d85752332c2b09c64b06c69b95501ed#examples/git-checkout.yaml"' git-checkout.sbom.json
+          grep '"pkg:github/chainguard-dev/melange@${{github.sha}}#examples/git-checkout.yaml"' git-checkout.sbom.json
 
       - name: Verify SBOM External Refs (gnu-hello)
         if: matrix.example == 'gnu-hello.yaml'

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -59,6 +59,33 @@ jobs:
             docker run --rm -v $(pwd)/sbom.json:/sbom.json --entrypoint "sh" cgr.dev/chainguard/wolfi-base -c "apk add spdx-tools-java && tools-java Verify /sbom.json"
           done
 
+      - name: Verify SBOM External Refs (git-checkout)
+        if: matrix.example == 'git-checkout.yaml'
+        run: |
+          set -euxo pipefail
+          tar -Oxf packages/x86_64/git-checkout*.apk var/lib/db/sbom > git-checkout.sbom.json
+
+          # Verify APK ref
+          grep '"pkg:apk/unknown/git-checkout@v0.0.1-r0?arch=x86_64"' git-checkout.sbom.json
+
+          # Verify github tag ref
+          grep '"pkg:github/puerco/hello.git@v0.0.1"' sbom.json git-checkout.sbom.json
+
+          # Verify github sha ref
+          grep '"pkg:github/puerco/hello.git@a73c4feb284dc6ed1e5758740f717f99dcd4c9d7"' git-checkout.sbom.json
+
+          # Verify ConfigFile ref
+          grep '"pkg:github/chainguard-dev/melange@8fc050fc9d85752332c2b09c64b06c69b95501ed#examples/git-checkout.yaml"' git-checkout.sbom.json
+
+      - name: Verify SBOM External Refs (gnu-hello)
+        if: matrix.example == 'gnu-hello.yaml'
+        run: |
+          set -euxo pipefail
+          tar -Oxf packages/x86_64/hello-2*.apk var/lib/db/sbom > hello.sbom.json
+
+          # Verify generic fetch ref
+          grep '"pkg:generic/hello@2.12?checksum=sha256%3Acf04af86dc085268c5f4470fbae49b18afbc221b78096aab842d934a76bad0ab\\u0026download_url=https%3A%2F%2Fftp.gnu.org%2Fgnu%2Fhello%2Fhello-2.12.tar.gz"' hello.sbom.json
+
       - name: Check packages can be installed with apk
         run: |
           set -euxo pipefail

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -74,6 +74,9 @@ jobs:
           # Verify github sha ref
           grep '"pkg:github/puerco/hello.git@a73c4feb284dc6ed1e5758740f717f99dcd4c9d7"' git-checkout.sbom.json
 
+          # Verify generic git ref
+          grep '"pkg:generic/hello@v0.0.1?vcs_url=git%2Bhttps%3A%2F%2Fgitlab.com%2Fxnox%2Fhello.git%40a73c4feb284dc6ed1e5758740f717f99dcd4c9d7"' git-checkout.sbom.json
+
           # Verify ConfigFile ref
           grep '"pkg:github/chainguard-dev/melange@8fc050fc9d85752332c2b09c64b06c69b95501ed#examples/git-checkout.yaml"' git-checkout.sbom.json
 

--- a/.github/workflows/wolfi-presubmit.yaml
+++ b/.github/workflows/wolfi-presubmit.yaml
@@ -95,7 +95,23 @@ jobs:
       - run: |
           make SHELL="/bin/bash" MELANGE="sudo melange" package/${{ matrix.package }}
 
-      - run: |
+      - name: "Retrieve Wolfi advisory data"
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+        with:
+          repository: "wolfi-dev/advisories"
+          path: "data/wolfi-advisories"
+
+      # this need to point to main to always get the latest action
+      - uses: wolfi-dev/actions/install-wolfictl@main # main
+
+      - name: Test installable and Scan for CVEs
+        run: |
           for f in packages/x86_64/${{ matrix.package }}-*.apk; do
             docker run --rm -v $(pwd):/work cgr.dev/chainguard/wolfi-base apk add --allow-untrusted /work/$f
+            wolfictl scan \
+            --advisories-repo-dir 'data/wolfi-advisories' \
+            --advisory-filter 'resolved' \
+            --require-zero \
+            $f \
+            2> /dev/null # The error message renders strangely on GitHub Actions, and the important information is already being sent to stdout.
           done

--- a/examples/git-checkout.yaml
+++ b/examples/git-checkout.yaml
@@ -43,3 +43,10 @@ pipeline:
       destination: tag-unpeeled
       tag: v0.0.1
       expected-commit: fed9b28e2973bee65bcc503c6ab6522e8bfdd3d1
+
+  - uses: git-checkout
+    with:
+      repository: https://gitlab.com/xnox/hello.git
+      destination: gitlab
+      tag: v0.0.1
+      expected-commit: a73c4feb284dc6ed1e5758740f717f99dcd4c9d7

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -35,6 +35,8 @@ import (
 	"cloud.google.com/go/storage"
 	"github.com/chainguard-dev/clog"
 	apkofs "github.com/chainguard-dev/go-apk/pkg/fs"
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/storage/filesystem"
 	purl "github.com/package-url/packageurl-go"
 	"github.com/yookoala/realpath"
 	"github.com/zealic/xignore"
@@ -474,6 +476,62 @@ func (b *Build) IsBuildLess() bool {
 	return len(b.Configuration.Pipeline) == 0
 }
 
+// ConfigFileExternalRef calculates ExternalRef for the melange config
+// file itself.
+func (b *Build) ConfigFileExternalRef() (*purl.PackageURL, error) {
+	// configFile must exist
+	configpath, err := filepath.Abs(b.ConfigFile)
+	if err != nil {
+		return nil, err
+	}
+	// If not a git repository, skip
+	opt := &git.PlainOpenOptions{DetectDotGit: true}
+	r, err := git.PlainOpenWithOptions(configpath, opt)
+	if err != nil {
+		return nil, nil
+	}
+	// If no remote origin, skip (local git repo)
+	remote, err := r.Remote("origin")
+	if err != nil {
+		return nil, nil
+	}
+	repository := remote.Config().URLs[0]
+	// Only supports github-actions style https github checkouts
+	if !strings.HasPrefix(repository, "https://github.com/") {
+		return nil, nil
+	}
+	namespace, name, _ := strings.Cut(strings.TrimPrefix(repository, "https://github.com/"), "/")
+
+	// Head must exist
+	ref, err := r.Head()
+	if err != nil {
+		return nil, err
+	}
+	version := ref.Hash()
+
+	// Try to get configfile as subpath in the repository
+	s, ok := r.Storer.(*filesystem.Storage)
+	if !ok {
+		return nil, errors.New("Repository storage is not filesystem.Storage")
+	}
+	base := filepath.Dir(s.Filesystem().Root())
+	subpath, err := filepath.Rel(base, configpath)
+	if err != nil {
+		return nil, err
+	}
+	newpurl := &purl.PackageURL{
+		Type:      "github",
+		Namespace: namespace,
+		Name:      name,
+		Version:   version.String(),
+		Subpath:   subpath,
+	}
+	if err := newpurl.Normalize(); err != nil {
+		return nil, err
+	}
+	return newpurl, nil
+}
+
 func (b *Build) PopulateCache(ctx context.Context) error {
 	log := clog.FromContext(ctx)
 	ctx, span := otel.Tracer("melange").Start(ctx, "PopulateCache")
@@ -673,6 +731,16 @@ func (b *Build) BuildPackage(ctx context.Context) error {
 		}
 	}
 	pb.Subpackage = nil
+
+	configFileRef, err := b.ConfigFileExternalRef()
+	if err != nil {
+		return fmt.Errorf("failed to create ExternalRef for configfile: %w", err)
+	}
+
+	// In SPDX v3 there is dedicate field for this
+	// https://spdx.github.io/spdx-spec/v3.0/model/Build/Properties/configSourceUri/
+	log.Infof("adding external ref %s for ConfigFile", configFileRef)
+	externalRefs = append(externalRefs, *configFileRef)
 
 	if b.EmptyWorkspace {
 		log.Infof("empty workspace requested")

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -822,11 +822,6 @@ func (b *Build) BuildPackage(ctx context.Context) error {
 	// Run the SBOM generator.
 	generator := sbom.NewGenerator()
 
-	externalRefs, err := normalizeExternalRefs(externalRefs, b.Configuration.Package.Name, b.Configuration.Package.Version)
-	if err != nil {
-		return err
-	}
-
 	licensinginfos, err := b.Configuration.Package.LicensingInfos(b.WorkspaceDir)
 	if err != nil {
 		return err
@@ -1186,22 +1181,4 @@ func sourceDateEpoch(defaultTime time.Time) (time.Time, error) {
 	}
 
 	return time.Unix(sec, 0).UTC(), nil
-}
-
-// When pipelines are processed they don't have access to package
-// metadata. For "generic" external PURLs one has to declare
-// "upstream" name and version.
-func normalizeExternalRefs(externalRefs []purl.PackageURL, name string, version string) ([]purl.PackageURL, error) {
-	for idx, ref := range externalRefs {
-		if ref.Name == "" {
-			externalRefs[idx].Name = name
-		}
-		if ref.Version == "" {
-			externalRefs[idx].Version = version
-		}
-		if err := externalRefs[idx].Normalize(); err != nil {
-			return nil, err
-		}
-	}
-	return externalRefs, nil
 }

--- a/pkg/build/pipeline.go
+++ b/pkg/build/pipeline.go
@@ -553,11 +553,16 @@ func (pctx *PipelineContext) computeExternalRefs(spctx *PipelineContext) []purl.
 		if len(spctx.Pipeline.With["${{inputs.expected-sha512}}"]) > 0 {
 			args["checksum"] = "sha512:" + spctx.Pipeline.With["${{inputs.expected-sha512}}"]
 		}
-		purls = append(purls, purl.PackageURL{Type: "generic", Qualifiers: purl.QualifiersFromMap(args)})
+		newpurl := purl.PackageURL{
+			Type:       "generic",
+			Name:       spctx.Pipeline.With["${{inputs.purl-name}}"],
+			Version:    spctx.Pipeline.With["${{inputs.purl-version}}"],
+			Qualifiers: purl.QualifiersFromMap(args),
+		}
+		newpurl.Normalize()
+		purls = append(purls, newpurl)
 	}
-
 	return purls
-
 }
 
 // pipelineStepWorkDir returns the workdir for the current pipeline step.

--- a/pkg/build/pipeline.go
+++ b/pkg/build/pipeline.go
@@ -584,7 +584,6 @@ func (pctx *PipelineContext) computeExternalRefs(spctx *PipelineContext) ([]purl
 						Name:      name,
 						Version:   version,
 					}
-					newpurl.Normalize()
 					if err := newpurl.Normalize(); err != nil {
 						return nil, err
 					}

--- a/pkg/build/pipeline.go
+++ b/pkg/build/pipeline.go
@@ -515,10 +515,10 @@ func (pctx *PipelineContext) ApplyNeeds(ctx context.Context, pb *PipelineBuild) 
 			return err
 		}
 
-		externalrefs := pctx.computeExternalRefs(spctx)
-		if externalrefs != nil {
-			log.Infof("  adding external refs %s for pipeline %q", externalrefs, pctx.Identity())
-			pctx.ExternalRefs = append(pctx.ExternalRefs, externalrefs...)
+		externalRefs := pctx.computeExternalRefs(spctx)
+		if externalRefs != nil {
+			log.Infof("  adding external refs %s for pipeline %q", externalRefs, pctx.Identity())
+			pctx.ExternalRefs = append(pctx.ExternalRefs, externalRefs...)
 		}
 
 		if err := spctx.ApplyNeeds(ctx, pb); err != nil {

--- a/pkg/build/pipelines/fetch.yaml
+++ b/pkg/build/pipelines/fetch.yaml
@@ -23,6 +23,16 @@ inputs:
     description: |
       The expected SHA512 of the downloaded artifact.
 
+  purl-name:
+    description: |
+      package-URL (PURL) name for use in SPDX SBOM External References
+    default: ${{package.name}}
+
+  purl-version:
+    description: |
+      package-URL (PURL) version for use in SPDX SBOM External References
+    default: ${{package.version}}
+
   uri:
     description: |
       The URI to fetch as an artifact.

--- a/pkg/sbom/bom.go
+++ b/pkg/sbom/bom.go
@@ -17,9 +17,11 @@
 // data) designed to be transcoded to specific formats.
 package sbom
 
-import purl "github.com/package-url/packageurl-go"
+import (
+	"fmt"
 
-import "fmt"
+	purl "github.com/package-url/packageurl-go"
+)
 
 type bom struct {
 	Packages []pkg

--- a/pkg/sbom/bom.go
+++ b/pkg/sbom/bom.go
@@ -17,6 +17,8 @@
 // data) designed to be transcoded to specific formats.
 package sbom
 
+import purl "github.com/package-url/packageurl-go"
+
 import "fmt"
 
 type bom struct {
@@ -42,6 +44,7 @@ type pkg struct {
 	Arch             string
 	Checksums        map[string]string
 	Relationships    []relationship
+	ExternalRefs     []purl.PackageURL
 }
 
 func (p *pkg) ID() string {

--- a/pkg/sbom/generator.go
+++ b/pkg/sbom/generator.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/chainguard-dev/clog"
 	"go.opentelemetry.io/otel"
+	purl "github.com/package-url/packageurl-go"
 )
 
 func NewGenerator() *Generator {
@@ -33,6 +34,7 @@ type Spec struct {
 	PackageVersion  string
 	License         string // Full SPDX license expression
 	LicensingInfos  map[string]string
+	ExternalRefs    []purl.PackageURL
 	Copyright       string
 	Namespace       string
 	Arch            string

--- a/pkg/sbom/generator.go
+++ b/pkg/sbom/generator.go
@@ -20,8 +20,8 @@ import (
 	"time"
 
 	"github.com/chainguard-dev/clog"
-	"go.opentelemetry.io/otel"
 	purl "github.com/package-url/packageurl-go"
+	"go.opentelemetry.io/otel"
 )
 
 func NewGenerator() *Generator {

--- a/pkg/sbom/implementation.go
+++ b/pkg/sbom/implementation.go
@@ -90,6 +90,7 @@ func generateAPKPackage(spec *Spec) (pkg, error) {
 		Relationships:    []relationship{},
 		LicenseDeclared:  spdx.NOASSERTION,
 		LicenseConcluded: spdx.NOASSERTION, // remove when omitted upstream
+		ExternalRefs:     spec.ExternalRefs,
 		Copyright:        spec.Copyright,
 		Namespace:        spec.Namespace,
 		Arch:             spec.Arch,
@@ -147,6 +148,13 @@ func addPackage(doc *spdx.Document, p *pkg) {
 				"apk", p.Namespace, p.Name, p.Version, q, "",
 			).ToString(),
 			Type: "purl",
+		})
+	}
+	for _, purl := range p.ExternalRefs {
+		spdxPkg.ExternalRefs = append(spdxPkg.ExternalRefs, spdx.ExternalRef{
+			Category: "PACKAGE_MANAGER",
+			Locator:  purl.ToString(),
+			Type:     "purl",
 		})
 	}
 


### PR DESCRIPTION
External References to sources
=======
This aids with many aspects of compliance, and ability to self-locate all relevant source code.

This will be present in every package sbom, and by extension every image sbom accessible from console and container registry.

This is extensible to accommodate any other future inputs.

Current state:
=======
Currently we generate external self-reference to the binary APK package

```json
      "externalRefs": [
        {
          "referenceCategory": "PACKAGE_MANAGER",
          "referenceLocator": "pkg:apk/wolfi/acl@2.3.2-r2?arch=x86_64",
          "referenceType": "purl"
        }
      ]
```

This proposal extends this array with additional references to the source code.

For fetch:
=======

Add Package-URL to the download URI with checksum argument.

> 2024/05/17 16:18:51 INFO    adding external refs [pkg:generic/acl@2.3.2?checksum=sha256%3A5f2bdbad629707aa7d85c623f994aa8a1d2dec55a73de5205bac0bf6058a2f7c&download_url=https%3A%2F%2Fdownload.savannah.nongnu.org%2Freleases%2Facl%2Facl-2.3.2.tar.gz] for pipeline "fetch"

Resulting SBOM then has for the package this information:

```json
        {
          "referenceCategory": "PACKAGE_MANAGER",
          "referenceLocator": "pkg:generic/acl@2.3.2?checksum=sha256%3A5f2bdbad629707aa7d85c623f994aa8a1d2dec55a73de5205bac0bf6058a2f7c&download_url=https%3A%2F%2Fdownload.savannah.nongnu.org%2Freleases%2Facl%2Facl-2.3.2.tar.gz",
          "referenceType": "purl"
        }
```

For github based git-checkouts
=======

Add Package-URL to the github location with tag & commit-id versions.

> 2024/05/17 23:14:36 INFO   adding external refs [pkg:github/sigstore/cosign@v2.2.4 pkg:github/sigstore/cosign@fb651b4ddd8176bd81756fca2d988dd8611f514d] for pipeline "git-checkout"

```json
        {
          "referenceCategory": "PACKAGE_MANAGER",
          "referenceLocator": "pkg:github/sigstore/cosign@v2.2.4",
          "referenceType": "purl"
        },
        {
          "referenceCategory": "PACKAGE_MANAGER",
          "referenceLocator": "pkg:github/sigstore/cosign@fb651b4ddd8176bd81756fca2d988dd8611f514d",
          "referenceType": "purl"
        }
```

For non-github based git-checkouts
=======

Add Package-URL to vcs location with tag as version and commit encoded as `@commit` (approximately similar to how many tools pin to a commit, i.e. pip)

> 2024/05/20 14:34:53 INFO   adding external refs [pkg:generic/hello@v0.0.1?vcs_url=git%2Bhttps%3A%2F%2Fgitlab.com%2Fxnox%2Fhello.git%40a73c4feb284dc6ed1e5758740f717f99dcd4c9d7] for pipeline "git-checkout"

```json
        {
          "referenceCategory": "PACKAGE_MANAGER",
          "referenceLocator": "pkg:generic/hello@v0.0.1?vcs_url=git%2Bhttps%3A%2F%2Fgitlab.com%2Fxnox%2Fhello.git%40a73c4feb284dc6ed1e5758740f717f99dcd4c9d7",
          "referenceType": "purl"
        },
```

For melange config itself
=======

Add Package-URL to github location with commit as version and subpath set to the melange configfile.

> `2024/05/20 14:34:53 INFO adding external ref pkg:github/chainguard-dev/melange@7b29d0fe879878add7a26d515e679bab25047bfd#examples/git-checkout.yaml for ConfigFile`**

```json
        {
          "referenceCategory": "PACKAGE_MANAGER",
          "referenceLocator": "pkg:github/chainguard-dev/melange@7b29d0fe879878add7a26d515e679bab25047bfd#examples/git-checkout.yaml",
          "referenceType": "purl"
        }

```