### PR TITLE
fix: incorrect parsing of shebangs

### DIFF
--- a/pkg/sca/sca.go
+++ b/pkg/sca/sca.go
@@ -598,11 +598,16 @@ func getShbang(fp fs.File) (string, error) {
 		return "", err
 	}
 
-	if !bytes.HasPrefix(buf, []byte("#!")) {
+	buf, found := bytes.CutPrefix(buf[:blen], []byte("#!"))
+	if !found {
 		return "", nil
 	}
 
-	toks := strings.Fields(string(buf[2 : blen-2]))
+	if eol := bytes.IndexByte(buf[:blen], '\n'); eol != -1 {
+		buf = buf[:eol]
+	}
+
+	toks := strings.Fields(string(buf))
 	bin := toks[0]
 
 	// if #! is '/usr/bin/env foo', then use next arg as the dep


### PR DESCRIPTION
While working on https://github.com/wolfi-dev/os/pull/19702 I noticed that the parsing of shebangs seems to struggle with some files:
```
2024/05/17 12:42:10 WARN Error reading shbang from usr/bin/fiologparser_hist.py: a shbang of only '/usr/bin/env' with multiple arguments (9 /usr/bin/env python3 """ Utility for converting *_clat_hist* files gene)
```
Source: https://github.com/axboe/fio/blob/3ed8eea0ee9b5d7de603e9b128e6c05941b99938/tools/hist/fiologparser_hist.py#L7

The parsing should terminate at the end of the line.

### Functional Changes

- Use `bytes.CutPrefix` for better clarity
- Stop parsing at `\n` if present

### SCA Changes

- [ ] Examining several representative APKs show no regression / the desired effect (details in notes)

Notes:

### Linter

- [ ] The new check is clean across Wolfi
- [ ] The new check is opt-in or a warning

Notes:
