### PR TITLE
sca: allow building packages with version-less command provides

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -79,6 +79,8 @@ type PackageOption struct {
 	NoDepends bool `json:"no-depends" yaml:"no-depends"`
 	// Optional: Mark this package as not providing any executables
 	NoCommands bool `json:"no-commands" yaml:"no-commands"`
+	// Optional: Mark this package as providing executables without full version
+	NoVersionedCommands bool `json:"no-versioned-commands" yaml:"no-versioned-commands"`
 }
 
 type Checks struct {

--- a/pkg/config/schema.json
+++ b/pkg/config/schema.json
@@ -570,6 +570,10 @@
         "no-commands": {
           "type": "boolean",
           "description": "Optional: Mark this package as not providing any executables"
+        },
+        "no-versioned-commands": {
+          "type": "boolean",
+          "description": "Optional: Mark this package as providing executables without full version"
         }
       },
       "additionalProperties": false,
@@ -577,7 +581,8 @@
       "required": [
         "no-provides",
         "no-depends",
-        "no-commands"
+        "no-commands",
+        "no-versioned-commands"
       ]
     },
     "PathMutation": {

--- a/pkg/sca/sca.go
+++ b/pkg/sca/sca.go
@@ -129,7 +129,12 @@ func generateCmdProviders(ctx context.Context, hdl SCAHandle, generated *config.
 			if isInDir(path, pathBinDirs) {
 				basename := filepath.Base(path)
 				log.Infof("  found command %s", path)
-				generated.Provides = append(generated.Provides, fmt.Sprintf("cmd:%s=%s", basename, hdl.Version()))
+				if hdl.Options().NoVersionedCommands {
+					generated.Provides = append(generated.Provides, fmt.Sprintf("cmd:%s", basename))
+				} else {
+					generated.Provides = append(generated.Provides, fmt.Sprintf("cmd:%s=%s", basename, hdl.Version()))
+				}
+
 			}
 		}
 


### PR DESCRIPTION
Both apk and go-apk allow co-installing packages which have
versionless provides. This is useful for commands which per-se have
identical or unrelated version strings, but provide the same or
similar enough behaviour.

Eg. /usr/bin/pip from py3.10-pip py3.11-pip py3.12-pip of same, or
even different versions, should be co-installable.

Signed-off-by: Dimitri John Ledkov <dimitri.ledkov@chainguard.dev>
