### PR TITLE
Add GitLabMonitor update configuration

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -523,12 +523,12 @@ type GitLabMonitor struct {
 	StripPrefix string `json:"strip-prefix,omitempty" yaml:"strip-prefix,omitempty"`
 	// If the version in GitLab contains a suffix which should be ignored
 	StripSuffix string `json:"strip-suffix,omitempty" yaml:"strip-suffix,omitempty"`
-	// Prefix filter to apply when searching tags on a GitHub repository
+	// Prefix filter to apply when searching tags on a GitLab repository
 	TagFilterPrefix string `json:"tag-filter-prefix,omitempty" yaml:"tag-filter-prefix,omitempty"`
-	// Filter to apply when searching tags on a GitHub repository
+	// Filter to apply when searching tags on a GitLab repository
 	TagFilterContains string `json:"tag-filter-contains,omitempty" yaml:"tag-filter-contains,omitempty"`
-	// Override the default of using a GitHub release to identify related tag to
-	// fetch.  Not all projects use GitHub releases but just use tags
+	// Override the default of using a GitLab release to identify related tag to
+	// fetch.  Not all projects use GitLab releases but just use tags
 	UseTags bool `json:"use-tag,omitempty" yaml:"use-tag,omitempty"`
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -479,6 +479,8 @@ type Update struct {
 	ReleaseMonitor *ReleaseMonitor `json:"release-monitor,omitempty" yaml:"release-monitor,omitempty"`
 	// The configuration block for updates tracked via the Github API
 	GitHubMonitor *GitHubMonitor `json:"github,omitempty" yaml:"github,omitempty"`
+	// The configuration block for updates tracked via the GitLab rest API
+	GitLabMonitor *GitLabMonitor `json:"gitlab,omitempty" yaml:"gitlab,omitempty"`
 	// The configuration block for transforming the `package.version` into an APK version
 	VersionTransform []VersionTransform `json:"version-transform,omitempty" yaml:"version-transform,omitempty"`
 }
@@ -504,6 +506,23 @@ type GitHubMonitor struct {
 	// Filter to apply when searching tags on a GitHub repository
 	// Deprecated: Use TagFilterPrefix instead
 	TagFilter string `json:"tag-filter,omitempty" yaml:"tag-filter,omitempty"`
+	// Prefix filter to apply when searching tags on a GitHub repository
+	TagFilterPrefix string `json:"tag-filter-prefix,omitempty" yaml:"tag-filter-prefix,omitempty"`
+	// Filter to apply when searching tags on a GitHub repository
+	TagFilterContains string `json:"tag-filter-contains,omitempty" yaml:"tag-filter-contains,omitempty"`
+	// Override the default of using a GitHub release to identify related tag to
+	// fetch.  Not all projects use GitHub releases but just use tags
+	UseTags bool `json:"use-tag,omitempty" yaml:"use-tag,omitempty"`
+}
+
+// GitLabMonitor indicates using the GitLab API
+type GitLabMonitor struct {
+	// Org/Subgroup/repo for GitLab
+	Identifier string `json:"identifier" yaml:"identifier"`
+	// If the version in GitLab contains a prefix which should be ignored
+	StripPrefix string `json:"strip-prefix,omitempty" yaml:"strip-prefix,omitempty"`
+	// If the version in GitLab contains a suffix which should be ignored
+	StripSuffix string `json:"strip-suffix,omitempty" yaml:"strip-suffix,omitempty"`
 	// Prefix filter to apply when searching tags on a GitHub repository
 	TagFilterPrefix string `json:"tag-filter-prefix,omitempty" yaml:"tag-filter-prefix,omitempty"`
 	// Filter to apply when searching tags on a GitHub repository

--- a/pkg/config/schema.json
+++ b/pkg/config/schema.json
@@ -266,15 +266,15 @@
         },
         "tag-filter-prefix": {
           "type": "string",
-          "description": "Prefix filter to apply when searching tags on a GitHub repository"
+          "description": "Prefix filter to apply when searching tags on a GitLab repository"
         },
         "tag-filter-contains": {
           "type": "string",
-          "description": "Filter to apply when searching tags on a GitHub repository"
+          "description": "Filter to apply when searching tags on a GitLab repository"
         },
         "use-tag": {
           "type": "boolean",
-          "description": "Override the default of using a GitHub release to identify related tag to\nfetch.  Not all projects use GitHub releases but just use tags"
+          "description": "Override the default of using a GitLab release to identify related tag to\nfetch.  Not all projects use GitLab releases but just use tags"
         }
       },
       "additionalProperties": false,

--- a/pkg/config/schema.json
+++ b/pkg/config/schema.json
@@ -250,6 +250,40 @@
       ],
       "description": "GitHubMonitor indicates using the GitHub API"
     },
+    "GitLabMonitor": {
+      "properties": {
+        "identifier": {
+          "type": "string",
+          "description": "Org/Subgroup/repo for GitLab"
+        },
+        "strip-prefix": {
+          "type": "string",
+          "description": "If the version in GitLab contains a prefix which should be ignored"
+        },
+        "strip-suffix": {
+          "type": "string",
+          "description": "If the version in GitLab contains a suffix which should be ignored"
+        },
+        "tag-filter-prefix": {
+          "type": "string",
+          "description": "Prefix filter to apply when searching tags on a GitHub repository"
+        },
+        "tag-filter-contains": {
+          "type": "string",
+          "description": "Filter to apply when searching tags on a GitHub repository"
+        },
+        "use-tag": {
+          "type": "boolean",
+          "description": "Override the default of using a GitHub release to identify related tag to\nfetch.  Not all projects use GitHub releases but just use tags"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "identifier"
+      ],
+      "description": "GitLabMonitor indicates using the GitLab API"
+    },
     "Group": {
       "properties": {
         "groupname": {
@@ -899,6 +933,10 @@
         "github": {
           "$ref": "#/$defs/GitHubMonitor",
           "description": "The configuration block for updates tracked via the Github API"
+        },
+        "gitlab": {
+          "$ref": "#/$defs/GitLabMonitor",
+          "description": "The configuration block for updates tracked via the GitLab rest API"
         },
         "version-transform": {
           "items": {


### PR DESCRIPTION
## Add GitLabMonitor update

/cc @rawlingsj 

I am trying to implement to get the release and tag info from the Gitlab Api in wolfictl.

Currently all the packages which are in GitLab uses Release Monitor to update the package.
But by this we do not get the commit sha of that update and we have to manually update the expected-commit sha for those package updates.


<!--
*** PULL REQUEST CHECKLIST: PLEASE START HERE ***

The single most important feature of melange is that we can build Wolfi.

Many changes to melange introduce a risk of breaking the build, and sometimes
these are not flushed out until a package is changed (much) later.  This
pertains to basic execution, SCA changes, linter changes, and more.
-->

### Functional Changes

- [x] This change can build all of Wolfi without errors (describe results in notes)

Notes:

This is a Update configuration change (addition of new update config) should not affect any wolfi package build

### SCA Changes

- [ ] Examining several representative APKs show no regression / the desired effect (details in notes)

Notes:

### Linter

- [ ] The new check is clean across Wolfi
- [ ] The new check is opt-in or a warning

Notes:
