### PR TITLE
Disallow duplicate subpackage names

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1042,7 +1042,13 @@ func (cfg Configuration) validate() error {
 		return ErrInvalidConfiguration{Problem: err}
 	}
 
+	saw := map[string]int{}
 	for i, sp := range cfg.Subpackages {
+		if extant, ok := saw[sp.Name]; ok {
+			return fmt.Errorf("saw duplicate subpackage name %q (subpackages index: %d and %d)", sp.Name, extant, i)
+		}
+		saw[sp.Name] = i
+
 		if !packageNameRegex.MatchString(sp.Name) {
 			return ErrInvalidConfiguration{Problem: fmt.Errorf("subpackage name %q (subpackages index: %d) must match regex %q", sp.Name, i, packageNameRegex)}
 		}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -299,3 +299,33 @@ pipeline:
 	require.Equal(t, "/home/build/baz", cfg.Pipeline[1].Pipeline[0].Pipeline[1].WorkDir)
 	require.Equal(t, "/home/build/baz", cfg.Pipeline[1].Pipeline[0].Pipeline[2].WorkDir)
 }
+
+func TestDuplicateSubpackage(t *testing.T) {
+	ctx := slogtest.TestContextWithLogger(t)
+
+	fp := filepath.Join(os.TempDir(), "melange-test-applySubstitutionsInProvides")
+	if err := os.WriteFile(fp, []byte(`
+package:
+  name: dupe-subpackage
+  version: 0.0.1
+  epoch: 8
+  description: example using a two subpackages with same name
+
+data:
+  - name: I-am-a-range
+    items:
+      a: ""
+      b: ""
+
+subpackages:
+  - name: subpackage
+    range: I-am-a-range
+    pipeline:
+      - runs: echo "I am a subpackage for ${{range.key}"
+`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ParseConfiguration(ctx, fp); err == nil {
+		t.Errorf("configuration should have failed to validate, got: %v", err)
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/chainguard-dev/melange/issues/1236

We don't actually need range in pipelines AFAICT since we fixed the existing usages that would be broken by this change in other ways.