### PR TITLE
Speed up presubmit

### DIFF
--- a/.github/workflows/wolfi-presubmit.yaml
+++ b/.github/workflows/wolfi-presubmit.yaml
@@ -106,12 +106,13 @@ jobs:
 
       - name: Test installable and Scan for CVEs
         run: |
-          for f in packages/x86_64/${{ matrix.package }}-*.apk; do
-            docker run --rm -v $(pwd):/work cgr.dev/chainguard/wolfi-base apk add --allow-untrusted /work/$f
+            docker run --rm -v $(pwd):/work --workdir /work cgr.dev/chainguard/wolfi-base apk add --allow-untrusted packages/x86_64/${{ matrix.package }}-*.apk
+
+            # There is a huge fixed cost for every wolfictl scan invocation for grype DB init.
+            # Do this outside of the loop in one invocation with every package.
             wolfictl scan \
             --advisories-repo-dir 'data/wolfi-advisories' \
             --advisory-filter 'resolved' \
             --require-zero \
-            $f \
+            packages/x86_64/${{ matrix.package }}-*.apk \
             2> /dev/null # The error message renders strangely on GitHub Actions, and the important information is already being sent to stdout.
-          done


### PR DESCRIPTION
wolfictl scan is very slow to start, and glibc has like a million subpackages, so the presubmit jumped from 15 to 30 minutes when we started wolfictl scanning every package.

![image](https://github.com/chainguard-dev/melange/assets/17863526/e6517560-1aef-4e34-827b-6e83f60dd008)
