### PR TITLE
go/build: remove subpackage input

### DIFF
--- a/pkg/build/pipelines/go/build.yaml
+++ b/pkg/build/pipelines/go/build.yaml
@@ -39,11 +39,6 @@ inputs:
       If true, the go mod command will also update the vendor directory
     default: "false"
 
-  subpackage:
-    description: |
-      Indicates that the build will write to a subpackage target folder
-    default: "false"
-
   modroot:
     default: "."
     required: false


### PR DESCRIPTION
Unused since ea789df (pipelines: use ${{targets.contextdir}} where it
makes sense, 2023-08-21)

Signed-off-by: Dimitri John Ledkov <dimitri.ledkov@surgut.co.uk>
