### PR TITLE
Remove depth option from git clone if inputs.depth is set to -1

### DIFF
--- a/pkg/build/pipelines/git-checkout.yaml
+++ b/pkg/build/pipelines/git-checkout.yaml
@@ -17,7 +17,7 @@ inputs:
 
   depth:
     description: |
-      The depth to use when cloning.
+      The depth to use when cloning. Set to -1 to not specify depth when cloning.
     default: 1
 
   branch:
@@ -57,7 +57,11 @@ pipeline:
 
       git config --global --add safe.directory $workdir
       git config --global --add safe.directory $clone_fullpath
-      git clone $git_clone_flags $clone_target --depth '${{inputs.depth}}' '${{inputs.repository}}' $workdir
+      if [ '${{inputs.depth}}' == -1 ]; then
+        git clone $git_clone_flags $clone_target '${{inputs.repository}}' $workdir
+      else
+        git clone $git_clone_flags $clone_target --depth '${{inputs.depth}}' '${{inputs.repository}}' $workdir
+      fi
 
       cd $workdir
       tar -c . | (cd $clone_fullpath && tar -x)


### PR DESCRIPTION
## Melange Pull Request Template

<!--
*** PULL REQUEST CHECKLIST: PLEASE START HERE ***

The single most important feature of melange is that we can build Wolfi.

Many changes to melange introduce a risk of breaking the build, and sometimes
these are not flushed out until a package is changed (much) later.  This
pertains to basic execution, SCA changes, linter changes, and more.
-->

### Functional Changes

- [ ] This change can build all of Wolfi without errors (describe results in notes)

Notes:

### SCA Changes

- [ ] Examining several representative APKs show no regression / the desired effect (details in notes)

Notes:

### Linter

- [ ] The new check is clean across Wolfi
- [ ] The new check is opt-in or a warning

Notes:
