### PR TITLE
Fix: example of ignore-regex-patterns

### DIFF
--- a/docs/UPDATE.md
+++ b/docs/UPDATE.md
@@ -65,8 +65,8 @@ To achieve this you can specify a list of regex patterns to identify versions th
 update:
   enabled: true
   ignore-regex-patterns:
-    - "ignore_me*"
-    - "*ignore_me"
+    - "ignore_me.*"
+    - ".*ignore_me"
 ```
 
 ## Version Transform


### PR DESCRIPTION
for error parsing regexp: missing argument to repetition operator: `*`

## Melange Pull Request Template

<!--
*** PULL REQUEST CHECKLIST: PLEASE START HERE ***

The single most important feature of melange is that we can build Wolfi.

Many changes to melange introduce a risk of breaking the build, and sometimes
these are not flushed out until a package is changed (much) later.  This
pertains to basic execution, SCA changes, linter changes, and more.
-->

### Functional Changes

- [x] This change can build all of Wolfi without errors (describe results in notes)

Notes:

### SCA Changes

- [x] Examining several representative APKs show no regression / the desired effect (details in notes)

Notes:

### Linter

- [x] The new check is clean across Wolfi
- [ ] The new check is opt-in or a warning

Notes:
