### PR TITLE
fix: error out when pipeline contains with but no uses

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1065,6 +1065,10 @@ func (cfg Configuration) validate() error {
 
 func validatePipelines(ps []Pipeline) error {
 	for _, p := range ps {
+		if p.With != nil && p.Uses == "" {
+			return fmt.Errorf("pipeline contains with but no uses")
+		}
+
 		if p.Uses != "" && p.Runs != "" {
 			return fmt.Errorf("pipeline cannot contain both uses %q and runs", p.Uses)
 		}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -329,3 +329,49 @@ subpackages:
 		t.Errorf("configuration should have failed to validate, got: %v", err)
 	}
 }
+
+func TestValidatePipelines(t *testing.T) {
+	tests := []struct {
+		name    string
+		p       []Pipeline
+		wantErr bool
+	}{
+		{
+			name: "valid pipeline with uses",
+			p: []Pipeline{
+				{Uses: "build", With: map[string]string{"param": "value"}},
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid pipeline with with but no uses",
+			p: []Pipeline{
+				{With: map[string]string{"param": "value"}},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid pipeline with both uses and runs",
+			p: []Pipeline{
+				{Uses: "deploy", Runs: "somescript.sh"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid pipeline with both with and runs",
+			p: []Pipeline{
+				{Runs: "somescript.sh", With: map[string]string{"param": "value"}},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validatePipelines(tt.p)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validatePipelines() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
We should fail if you use ``with`` without ``uses``.

Example of where it should error out:

```
  - uses:
    with:
      pom: management-api-agent-5.0.x/pom.xml
      properties-file: pombump-properties-management-api-agent-5.0.x.yaml

```