### PR TITLE
Separate compilation from execution

### DIFF
--- a/docs/md/melange.md
+++ b/docs/md/melange.md
@@ -23,6 +23,7 @@ toc: true
 
 * [melange build](/docs/md/melange_build.md)	 - Build a package from a YAML configuration file
 * [melange bump](/docs/md/melange_bump.md)	 - Update a Melange YAML file to reflect a new package version
+* [melange compile](/docs/md/melange_compile.md)	 - Compile a YAML configuration file
 * [melange completion](/docs/md/melange_completion.md)	 - Generate completion script
 * [melange convert](/docs/md/melange_convert.md)	 - EXPERIMENTAL COMMAND - Attempts to convert packages/gems/apkbuild files into melange configuration files
 * [melange index](/docs/md/melange_index.md)	 - Creates a repository index from a list of package files

--- a/docs/md/melange_compile.md
+++ b/docs/md/melange_compile.md
@@ -1,0 +1,77 @@
+---
+title: "melange compile"
+slug: melange_compile
+url: /docs/md/melange_compile.md
+draft: false
+images: []
+type: "article"
+toc: true
+---
+## melange compile
+
+Compile a YAML configuration file
+
+### Synopsis
+
+Compile a YAML configuration file.
+
+```
+melange compile [flags]
+```
+
+### Examples
+
+```
+  melange compile [config.yaml]
+```
+
+### Options
+
+```
+      --apk-cache-dir string        directory used for cached apk packages (default is system-defined cache directory)
+      --arch string                 architectures to compile for
+      --build-date string           date used for the timestamps of the files inside the image
+      --build-option strings        build options to enable
+      --cache-dir string            directory used for cached inputs (default "./melange-cache/")
+      --cache-source string         directory or bucket used for preloading the cache
+      --cpu string                  default CPU resources to use for builds
+      --create-build-log            creates a package.log file containing a list of packages that were built by the command
+      --debug                       enables debug logging of build pipelines
+      --debug-runner                when enabled, the builder pod will persist after the build succeeds or fails
+      --dependency-log string       log dependencies to a specified file
+      --empty-workspace             whether the build workspace should be empty
+      --env-file string             file to use for preloaded environment variables
+      --fail-on-lint-warning        turns linter warnings into failures
+      --generate-index              whether to generate APKINDEX.tar.gz (default true)
+      --guest-dir string            directory used for the build environment guest
+  -h, --help                        help for compile
+  -i, --interactive                 when enabled, attaches stdin with a tty to the pod on failure
+  -k, --keyring-append strings      path to extra keys to include in the build environment keyring
+      --log-policy strings          logging policy to use (default [builtin:stderr])
+      --memory string               default memory resources to use for builds
+      --namespace string            namespace to use in package URLs in SBOM (eg wolfi, alpine) (default "unknown")
+      --out-dir string              directory where packages will be output (default "./packages/")
+      --overlay-binsh string        use specified file as /bin/sh overlay in build environment
+      --package-append strings      extra packages to install for each of the build environments
+      --pipeline-dir string         directory used to extend defined built-in pipelines
+  -r, --repository-append strings   path to extra repositories to include in the build environment
+      --rm                          clean up intermediate artifacts (e.g. container images)
+      --runner string               which runner to use to enable running commands, default is based on your platform. Options are ["bubblewrap" "docker" "lima" "kubernetes"]
+      --signing-key string          key to use for signing
+      --source-dir string           directory used for included sources
+      --strip-origin-name           whether origin names should be stripped (for bootstrap)
+      --timeout duration            default timeout for builds
+      --vars-file string            file to use for preloaded build configuration variables
+      --workspace-dir string        directory used for the workspace at /home/build
+```
+
+### Options inherited from parent commands
+
+```
+      --log-level string   log level (e.g. debug, info, warn, error) (default "info")
+```
+
+### SEE ALSO
+
+* [melange](/docs/md/melange.md)	 - 
+

--- a/pkg/build/compile.go
+++ b/pkg/build/compile.go
@@ -1,0 +1,351 @@
+// Copyright 2023 Chainguard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build
+
+import (
+	"context"
+	"fmt"
+	"maps"
+
+	"chainguard.dev/melange/pkg/cond"
+	"chainguard.dev/melange/pkg/config"
+	"chainguard.dev/melange/pkg/util"
+	"github.com/chainguard-dev/clog"
+	purl "github.com/package-url/packageurl-go"
+	"gopkg.in/yaml.v3"
+)
+
+func (t *Test) Compile(ctx context.Context) error {
+	cfg := t.Configuration
+	pb := &PipelineBuild{
+		Test:    t,
+		Package: &cfg.Package,
+	}
+
+	c := &Compiled{
+		PipelineDirs: t.PipelineDirs,
+	}
+
+	ignore := &Compiled{
+		PipelineDirs: t.PipelineDirs,
+	}
+
+	// We want to evaluate this but not accumulate its deps.
+	if err := ignore.CompilePipelines(ctx, pb, cfg.Pipeline); err != nil {
+		return fmt.Errorf("compiling main pipelines: %w", err)
+	}
+
+	if err := c.CompilePipelines(ctx, pb, cfg.Test.Pipeline); err != nil {
+		return fmt.Errorf("compiling main pipelines: %w", err)
+	}
+
+	for i, sp := range cfg.Subpackages {
+		pb.Subpackage = &sp
+
+		if sp.If != "" {
+			mutated, err := MutateWith(pb, map[string]string{})
+			if err != nil {
+				return fmt.Errorf("creating subpackage map: %w", err)
+			}
+			sp.If, err = util.MutateAndQuoteStringFromMap(mutated, sp.If)
+			if err != nil {
+				return fmt.Errorf("mutating subpackage if: %w", err)
+			}
+		}
+
+		// We want to evaluate this but not accumulate its deps.
+		if err := ignore.CompilePipelines(ctx, pb, sp.Pipeline); err != nil {
+			return fmt.Errorf("compiling subpackage %q: %w", sp.Name, err)
+		}
+
+		test := &Compiled{
+			PipelineDirs: t.PipelineDirs,
+		}
+		if err := c.CompilePipelines(ctx, pb, sp.Test.Pipeline); err != nil {
+			return fmt.Errorf("compiling subpackage %q tests: %w", sp.Name, err)
+		}
+
+		te := &cfg.Subpackages[i].Test.Environment.Contents
+
+		// Append the subpackage that we're testing to be installed.
+		te.Packages = append(te.Packages, sp.Name)
+
+		// Append anything this subpackage test needs.
+		te.Packages = append(te.Packages, test.Needs...)
+	}
+
+	te := &t.Configuration.Test.Environment.Contents
+
+	// Append the main test package to be installed unless explicitly specified by the command line.
+	if t.Package != "" {
+		te.Packages = append(te.Packages, t.Package)
+	} else {
+		te.Packages = append(te.Packages, t.Configuration.Package.Name)
+	}
+
+	// Append anything the main package test needs.
+	te.Packages = append(te.Packages, c.Needs...)
+
+	return nil
+}
+
+// Compile compiles all configuration, including tests, by loading any pipelines and substituting all variables.
+func (b *Build) Compile(ctx context.Context) error {
+	cfg := b.Configuration
+	pb := &PipelineBuild{
+		Build:   b,
+		Package: &cfg.Package,
+	}
+
+	c := &Compiled{
+		PipelineDirs: b.PipelineDirs,
+	}
+
+	if err := c.CompilePipelines(ctx, pb, cfg.Pipeline); err != nil {
+		return fmt.Errorf("compiling main pipelines: %w", err)
+	}
+
+	for i, sp := range cfg.Subpackages {
+		pb.Subpackage = &sp
+
+		if sp.If != "" {
+			mutated, err := MutateWith(pb, map[string]string{})
+			if err != nil {
+				return fmt.Errorf("creating subpackage map: %w", err)
+			}
+			sp.If, err = util.MutateAndQuoteStringFromMap(mutated, sp.If)
+			if err != nil {
+				return fmt.Errorf("mutating subpackage if: %w", err)
+			}
+		}
+
+		if err := c.CompilePipelines(ctx, pb, sp.Pipeline); err != nil {
+			return fmt.Errorf("compiling subpackage %q: %w", sp.Name, err)
+		}
+
+		if sp.Test == nil {
+			continue
+		}
+
+		tc := &Compiled{
+			PipelineDirs: b.PipelineDirs,
+		}
+		if err := tc.CompilePipelines(ctx, pb, sp.Test.Pipeline); err != nil {
+			return fmt.Errorf("compiling subpackage %q tests: %w", sp.Name, err)
+		}
+
+		te := &cfg.Subpackages[i].Test.Environment.Contents
+
+		// Append the subpackage that we're testing to be installed.
+		te.Packages = append(te.Packages, sp.Name)
+
+		// Append anything this subpackage test needs.
+		te.Packages = append(te.Packages, tc.Needs...)
+	}
+
+	ic := &b.Configuration.Environment.Contents
+	ic.Packages = append(ic.Packages, c.Needs...)
+
+	if cfg.Test != nil {
+		tc := &Compiled{
+			PipelineDirs: b.PipelineDirs,
+		}
+
+		if err := tc.CompilePipelines(ctx, pb, cfg.Test.Pipeline); err != nil {
+			return fmt.Errorf("compiling main pipelines: %w", err)
+		}
+
+		te := &b.Configuration.Test.Environment.Contents
+		te.Packages = append(te.Packages, tc.Needs...)
+
+		// This can be overridden by the command line but in the context of a build, just use the main package.
+		te.Packages = append(te.Packages, b.Configuration.Package.Name)
+	}
+
+	b.externalRefs = c.ExternalRefs
+
+	return nil
+}
+
+type Compiled struct {
+	PipelineDirs []string
+
+	Needs        []string
+	ExternalRefs []purl.PackageURL
+}
+
+func (c *Compiled) CompilePipelines(ctx context.Context, pb *PipelineBuild, pipelines []config.Pipeline) error {
+	for i := range pipelines {
+		if err := c.compilePipeline(ctx, pb, &pipelines[i]); err != nil {
+			return fmt.Errorf("compiling Pipeline[%d]: %w", i, err)
+		}
+
+		if err := c.gatherDeps(ctx, &pipelines[i]); err != nil {
+			return fmt.Errorf("gathering deps for Pipeline[%d]: %w", i, err)
+		}
+	}
+
+	return nil
+}
+
+func (c *Compiled) compilePipeline(ctx context.Context, pb *PipelineBuild, pipeline *config.Pipeline) error {
+	log := clog.FromContext(ctx)
+	uses, with := pipeline.Uses, maps.Clone(pipeline.With)
+
+	if uses != "" {
+		var data []byte
+		// Set this to fail up front in case there are no pipeline dirs specified
+		// and we can't find them.
+		err := fmt.Errorf("could not find 'uses' pipeline %q", uses)
+
+		for _, pd := range c.PipelineDirs {
+			log.Debugf("trying to load pipeline %q from %q", uses, pd)
+			data, err = loadPipelineData(pd, uses)
+			if err == nil {
+				log.Infof("Found pipeline %s", string(data))
+				break
+			}
+		}
+		if err != nil {
+			log.Debugf("trying to load pipeline %q from embedded fs pipelines/%q.yaml", uses, uses)
+			data, err = f.ReadFile("pipelines/" + uses + ".yaml")
+			if err != nil {
+				return fmt.Errorf("unable to load pipeline: %w", err)
+			}
+		}
+
+		if err := yaml.Unmarshal(data, pipeline); err != nil {
+			return fmt.Errorf("unable to parse pipeline %q: %w", uses, err)
+		}
+	}
+
+	validated, err := validateWith(with, pipeline.Inputs)
+	if err != nil {
+		return fmt.Errorf("unable to validate with: %w", err)
+	}
+
+	mutated, err := MutateWith(pb, validated)
+	if err != nil {
+		return fmt.Errorf("mutating with: %w", err)
+	}
+
+	// allow input mutations on needs.packages
+	if pipeline.Needs != nil {
+		for i := range pipeline.Needs.Packages {
+			pipeline.Needs.Packages[i], err = util.MutateStringFromMap(mutated, pipeline.Needs.Packages[i])
+			if err != nil {
+				return fmt.Errorf("mutating needs: %w", err)
+			}
+		}
+	}
+
+	if pipeline.WorkDir != "" {
+		pipeline.WorkDir, err = util.MutateStringFromMap(mutated, pipeline.WorkDir)
+		if err != nil {
+			return fmt.Errorf("mutating workdir: %w", err)
+		}
+	}
+
+	pipeline.Runs, err = util.MutateStringFromMap(mutated, pipeline.Runs)
+	if err != nil {
+		return fmt.Errorf("mutating runs: %w", err)
+	}
+
+	if pipeline.If != "" {
+		pipeline.If, err = util.MutateAndQuoteStringFromMap(mutated, pipeline.If)
+		if err != nil {
+			return fmt.Errorf("mutating if: %w", err)
+		}
+	}
+
+	// Compute external refs for this pipeline.
+	externalRefs, err := computeExternalRefs(uses, mutated)
+	if err != nil {
+		return fmt.Errorf("computing external refs: %w", err)
+	}
+
+	c.ExternalRefs = append(c.ExternalRefs, externalRefs...)
+
+	for i := range pipeline.Pipeline {
+		p := &pipeline.Pipeline[i]
+		p.With = util.RightJoinMap(mutated, p.With)
+
+		if err := c.compilePipeline(ctx, pb, p); err != nil {
+			return fmt.Errorf("compiling Pipeline[%d]: %w", i, err)
+		}
+	}
+
+	// We only want to include "with"s that have non-default values.
+	defaults := map[string]string{}
+	for k, v := range pipeline.Inputs {
+		defaults[k] = v.Default
+	}
+	cleaned := map[string]string{}
+	for k := range with {
+		nk := fmt.Sprintf("${{inputs.%s}}", k)
+
+		nv := mutated[nk]
+		if nv != defaults[k] {
+			cleaned[k] = nv
+		}
+	}
+	pipeline.With = cleaned
+
+	// We don't care about the documented inputs.
+	pipeline.Inputs = nil
+
+	return nil
+}
+
+func identity(p *config.Pipeline) string {
+	if p.Name != "" {
+		return p.Name
+	}
+	if p.Uses != "" {
+		return p.Uses
+	}
+	return "???"
+}
+
+func (c *Compiled) gatherDeps(ctx context.Context, pipeline *config.Pipeline) error {
+	log := clog.FromContext(ctx)
+
+	id := identity(pipeline)
+
+	if pipeline.If != "" {
+		if result, err := cond.Evaluate(pipeline.If); err != nil {
+			return fmt.Errorf("evaluating conditional %q: %w", pipeline.If, err)
+		} else if !result {
+			return nil
+		}
+	}
+
+	if pipeline.Needs != nil {
+		for _, pkg := range pipeline.Needs.Packages {
+			log.Infof("  adding package %q for pipeline %q", pkg, id)
+		}
+		c.Needs = append(c.Needs, pipeline.Needs.Packages...)
+
+		pipeline.Needs = nil
+	}
+
+	for _, p := range pipeline.Pipeline {
+		if err := c.gatherDeps(ctx, &p); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/build/sca_interface.go
+++ b/pkg/build/sca_interface.go
@@ -71,7 +71,10 @@ func (scabi *SCABuildInterface) Filesystem() (sca.SCAFS, error) {
 
 // Options returns the configured SCA engine options for the package being built.
 func (scabi *SCABuildInterface) Options() config.PackageOption {
-	return scabi.PackageBuild.Options
+	if scabi.PackageBuild.Options == nil {
+		return config.PackageOption{}
+	}
+	return *scabi.PackageBuild.Options
 }
 
 // BaseDependencies returns the base dependencies for the package being built.

--- a/pkg/build/test_test.go
+++ b/pkg/build/test_test.go
@@ -156,7 +156,7 @@ func TestConfigurationLoad(t *testing.T) {
 					Name:    "hello",
 					Version: "world",
 				},
-				Test: config.Test{
+				Test: &config.Test{
 					Pipeline: []config.Pipeline{
 						{
 							Name: "hello",
@@ -165,25 +165,25 @@ func TestConfigurationLoad(t *testing.T) {
 					}},
 				Subpackages: []config.Subpackage{{
 					Name: "cats",
-					Test: config.Test{
+					Test: &config.Test{
 						Pipeline: []config.Pipeline{{
 							Runs: "cats are angry",
 						}}},
 				}, {
 					Name: "dogs",
-					Test: config.Test{
+					Test: &config.Test{
 						Pipeline: []config.Pipeline{{
 							Runs: "dogs are loyal",
 						}}},
 				}, {
 					Name: "turtles",
-					Test: config.Test{
+					Test: &config.Test{
 						Pipeline: []config.Pipeline{{
 							Runs: "turtles are slow",
 						}}},
 				}, {
 					Name: "donatello",
-					Test: config.Test{
+					Test: &config.Test{
 						Pipeline: []config.Pipeline{
 							{
 								Runs: "donatello's color is purple",
@@ -195,7 +195,7 @@ func TestConfigurationLoad(t *testing.T) {
 						}},
 				}, {
 					Name: "leonardo",
-					Test: config.Test{Pipeline: []config.Pipeline{
+					Test: &config.Test{Pipeline: []config.Pipeline{
 						{
 							Runs: "leonardo's color is blue",
 						},
@@ -206,7 +206,7 @@ func TestConfigurationLoad(t *testing.T) {
 					}},
 				}, {
 					Name: "michelangelo",
-					Test: config.Test{Pipeline: []config.Pipeline{
+					Test: &config.Test{Pipeline: []config.Pipeline{
 						{
 							Runs: "michelangelo's color is orange",
 						},
@@ -217,7 +217,7 @@ func TestConfigurationLoad(t *testing.T) {
 					}},
 				}, {
 					Name: "raphael",
-					Test: config.Test{Pipeline: []config.Pipeline{
+					Test: &config.Test{Pipeline: []config.Pipeline{
 						{
 							Runs: "raphael's color is red",
 						},
@@ -228,7 +228,7 @@ func TestConfigurationLoad(t *testing.T) {
 					}},
 				}, {
 					Name: "simple",
-					Test: config.Test{Pipeline: []config.Pipeline{
+					Test: &config.Test{Pipeline: []config.Pipeline{
 						{
 							Runs: "simple-runs",
 						}, {
@@ -245,7 +245,7 @@ func TestConfigurationLoad(t *testing.T) {
 					Name:    "py3-pandas",
 					Version: "2.1.3",
 				},
-				Test: config.Test{
+				Test: &config.Test{
 					Environment: types.ImageConfiguration{
 						Contents: types.ImageContents{
 							Packages: []string{"busybox", "python-3"},

--- a/pkg/cli/commands.go
+++ b/pkg/cli/commands.go
@@ -59,6 +59,7 @@ func New() *cobra.Command {
 	cmd.AddCommand(Build())
 	cmd.AddCommand(Bump())
 	cmd.AddCommand(Completion())
+	cmd.AddCommand(Compile())
 	cmd.AddCommand(Convert())
 	cmd.AddCommand(Index())
 	cmd.AddCommand(Keygen())

--- a/pkg/cli/compile.go
+++ b/pkg/cli/compile.go
@@ -1,0 +1,200 @@
+// Copyright 2024 Chainguard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	apko_types "chainguard.dev/apko/pkg/build/types"
+	"chainguard.dev/melange/pkg/build"
+	"github.com/spf13/cobra"
+	"go.opentelemetry.io/otel"
+)
+
+func Compile() *cobra.Command {
+	var buildDate string
+	var workspaceDir string
+	var pipelineDir string
+	var sourceDir string
+	var cacheDir string
+	var cacheSource string
+	var apkCacheDir string
+	var guestDir string
+	var signingKey string
+	var generateIndex bool
+	var emptyWorkspace bool
+	var stripOriginName bool
+	var outDir string
+	var archstr string
+	var extraKeys []string
+	var extraRepos []string
+	var dependencyLog string
+	var overlayBinSh string
+	var envFile string
+	var varsFile string
+	var purlNamespace string
+	var buildOption []string
+	var logPolicy []string
+	var createBuildLog bool
+	var debug bool
+	var debugRunner bool
+	var interactive bool
+	var remove bool
+	var runner string
+	var failOnLintWarning bool
+	var cpu, memory string
+	var timeout time.Duration
+	var extraPackages []string
+
+	cmd := &cobra.Command{
+		Use:     "compile",
+		Short:   "Compile a YAML configuration file",
+		Long:    `Compile a YAML configuration file.`,
+		Example: `  melange compile [config.yaml]`,
+		Args:    cobra.MinimumNArgs(0),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+
+			arch := apko_types.ParseArchitecture(archstr)
+			options := []build.Option{
+				build.WithArch(arch),
+				build.WithBuildDate(buildDate),
+				build.WithWorkspaceDir(workspaceDir),
+				// Order matters, so add any specified pipelineDir before
+				// builtin pipelines.
+				build.WithPipelineDir(pipelineDir),
+				build.WithPipelineDir(BuiltinPipelineDir),
+				build.WithCacheDir(cacheDir),
+				build.WithCacheSource(cacheSource),
+				build.WithPackageCacheDir(apkCacheDir),
+				build.WithGuestDir(guestDir),
+				build.WithSigningKey(signingKey),
+				build.WithGenerateIndex(generateIndex),
+				build.WithEmptyWorkspace(emptyWorkspace),
+				build.WithOutDir(outDir),
+				build.WithExtraKeys(extraKeys),
+				build.WithExtraRepos(extraRepos),
+				build.WithExtraPackages(extraPackages),
+				build.WithDependencyLog(dependencyLog),
+				build.WithBinShOverlay(overlayBinSh),
+				build.WithStripOriginName(stripOriginName),
+				build.WithEnvFile(envFile),
+				build.WithVarsFile(varsFile),
+				build.WithNamespace(purlNamespace),
+				build.WithEnabledBuildOptions(buildOption),
+				build.WithCreateBuildLog(createBuildLog),
+				build.WithDebug(debug),
+				build.WithDebugRunner(debugRunner),
+				build.WithInteractive(interactive),
+				build.WithRemove(remove),
+				build.WithLogPolicy(logPolicy),
+				build.WithFailOnLintWarning(failOnLintWarning),
+				build.WithCPU(cpu),
+				build.WithMemory(memory),
+				build.WithTimeout(timeout),
+			}
+
+			if len(args) > 0 {
+				options = append(options, build.WithConfig(args[0]))
+
+				if sourceDir == "" {
+					sourceDir = filepath.Dir(args[0])
+				}
+			}
+
+			if sourceDir != "" {
+				options = append(options, build.WithSourceDir(sourceDir))
+			}
+
+			if auth, ok := os.LookupEnv("HTTP_AUTH"); !ok {
+				// Fine, no auth.
+			} else if parts := strings.SplitN(auth, ":", 4); len(parts) != 4 {
+				return fmt.Errorf("HTTP_AUTH must be in the form 'basic:REALM:USERNAME:PASSWORD' (got %d parts)", len(parts))
+			} else if parts[0] != "basic" {
+				return fmt.Errorf("HTTP_AUTH must be in the form 'basic:REALM:USERNAME:PASSWORD' (got %q for first part)", parts[0])
+			} else {
+				domain, user, pass := parts[1], parts[2], parts[3]
+				options = append(options, build.WithAuth(domain, user, pass))
+			}
+
+			return CompileCmd(ctx, options...)
+		},
+	}
+
+	cmd.Flags().StringVar(&archstr, "arch", "", "architectures to compile for")
+	if err := cmd.MarkFlagRequired("arch"); err != nil {
+		panic(err)
+	}
+
+	cmd.Flags().StringVar(&buildDate, "build-date", "", "date used for the timestamps of the files inside the image")
+	cmd.Flags().StringVar(&workspaceDir, "workspace-dir", "", "directory used for the workspace at /home/build")
+	cmd.Flags().StringVar(&pipelineDir, "pipeline-dir", "", "directory used to extend defined built-in pipelines")
+	cmd.Flags().StringVar(&sourceDir, "source-dir", "", "directory used for included sources")
+	cmd.Flags().StringVar(&cacheDir, "cache-dir", "./melange-cache/", "directory used for cached inputs")
+	cmd.Flags().StringVar(&cacheSource, "cache-source", "", "directory or bucket used for preloading the cache")
+	cmd.Flags().StringVar(&apkCacheDir, "apk-cache-dir", "", "directory used for cached apk packages (default is system-defined cache directory)")
+	cmd.Flags().StringVar(&guestDir, "guest-dir", "", "directory used for the build environment guest")
+	cmd.Flags().StringVar(&signingKey, "signing-key", "", "key to use for signing")
+	cmd.Flags().StringVar(&envFile, "env-file", "", "file to use for preloaded environment variables")
+	cmd.Flags().StringVar(&varsFile, "vars-file", "", "file to use for preloaded build configuration variables")
+	cmd.Flags().BoolVar(&generateIndex, "generate-index", true, "whether to generate APKINDEX.tar.gz")
+	cmd.Flags().BoolVar(&emptyWorkspace, "empty-workspace", false, "whether the build workspace should be empty")
+	cmd.Flags().BoolVar(&stripOriginName, "strip-origin-name", false, "whether origin names should be stripped (for bootstrap)")
+	cmd.Flags().StringVar(&outDir, "out-dir", "./packages/", "directory where packages will be output")
+	cmd.Flags().StringVar(&dependencyLog, "dependency-log", "", "log dependencies to a specified file")
+	cmd.Flags().StringVar(&overlayBinSh, "overlay-binsh", "", "use specified file as /bin/sh overlay in build environment")
+	cmd.Flags().StringVar(&purlNamespace, "namespace", "unknown", "namespace to use in package URLs in SBOM (eg wolfi, alpine)")
+	cmd.Flags().StringSliceVar(&buildOption, "build-option", []string{}, "build options to enable")
+	cmd.Flags().StringSliceVar(&logPolicy, "log-policy", []string{"builtin:stderr"}, "logging policy to use")
+	cmd.Flags().StringVar(&runner, "runner", "", fmt.Sprintf("which runner to use to enable running commands, default is based on your platform. Options are %q", build.GetAllRunners()))
+	cmd.Flags().StringSliceVarP(&extraKeys, "keyring-append", "k", []string{}, "path to extra keys to include in the build environment keyring")
+	cmd.Flags().StringSliceVarP(&extraRepos, "repository-append", "r", []string{}, "path to extra repositories to include in the build environment")
+	cmd.Flags().StringSliceVar(&extraPackages, "package-append", []string{}, "extra packages to install for each of the build environments")
+	cmd.Flags().BoolVar(&createBuildLog, "create-build-log", false, "creates a package.log file containing a list of packages that were built by the command")
+	cmd.Flags().BoolVar(&debug, "debug", false, "enables debug logging of build pipelines")
+	cmd.Flags().BoolVar(&debugRunner, "debug-runner", false, "when enabled, the builder pod will persist after the build succeeds or fails")
+	cmd.Flags().BoolVarP(&interactive, "interactive", "i", false, "when enabled, attaches stdin with a tty to the pod on failure")
+	cmd.Flags().BoolVar(&remove, "rm", false, "clean up intermediate artifacts (e.g. container images)")
+	cmd.Flags().BoolVar(&failOnLintWarning, "fail-on-lint-warning", false, "turns linter warnings into failures")
+	cmd.Flags().StringVar(&cpu, "cpu", "", "default CPU resources to use for builds")
+	cmd.Flags().StringVar(&memory, "memory", "", "default memory resources to use for builds")
+	cmd.Flags().DurationVar(&timeout, "timeout", 0, "default timeout for builds")
+
+	return cmd
+}
+
+func CompileCmd(ctx context.Context, opts ...build.Option) error {
+	ctx, span := otel.Tracer("melange").Start(ctx, "CompileCmd")
+	defer span.End()
+
+	bc, err := build.New(ctx, opts...)
+	if err != nil {
+		return err
+	}
+
+	defer bc.Close(ctx)
+
+	if err := bc.Compile(ctx); err != nil {
+		return fmt.Errorf("failed to compile package: %w", err)
+	}
+
+	return json.NewEncoder(os.Stdout).Encode(bc.Configuration)
+}

--- a/pkg/cli/scan.go
+++ b/pkg/cli/scan.go
@@ -434,7 +434,10 @@ func (s *scaImpl) Filesystem() (sca.SCAFS, error) {
 }
 
 func (s *scaImpl) Options() config.PackageOption {
-	return s.pb.Options
+	if s.pb.Options == nil {
+		return config.PackageOption{}
+	}
+	return *s.pb.Options
 }
 
 func (s *scaImpl) BaseDependencies() config.Dependencies {

--- a/pkg/convert/apkbuild/apkbuild.go
+++ b/pkg/convert/apkbuild/apkbuild.go
@@ -341,8 +341,13 @@ func (c ApkConvertor) mapconvert() {
 
 	// triggers
 	if c.Apkbuild.Triggers != nil {
-		c.GeneratedMelangeConfig.Package.Scriptlets.Trigger.Paths = []string{"FIXME"}
-		c.GeneratedMelangeConfig.Package.Scriptlets.Trigger.Script = "FIXME"
+		scriptlets := config.Scriptlets{
+			Trigger: config.Trigger{
+				Paths:  []string{"FIXME"},
+				Script: "FIXME",
+			},
+		}
+		c.GeneratedMelangeConfig.Package.Scriptlets = &scriptlets
 	}
 
 	// if c.Apkbuild.Funcs["build"] != nil {

--- a/pkg/linter/linter_test.go
+++ b/pkg/linter/linter_test.go
@@ -27,14 +27,14 @@ import (
 	linter_defaults "chainguard.dev/melange/pkg/linter/defaults"
 )
 
-func checksOnly(onlyLint string) config.Checks {
+func checksOnly(onlyLint string) *config.Checks {
 	checksDisabled := []string{}
 	for _, lint := range linter_defaults.GetDefaultLinters(linter_defaults.LinterClassBuild) {
 		if lint != onlyLint {
 			checksDisabled = append(checksDisabled, lint)
 		}
 	}
-	return config.Checks{
+	return &config.Checks{
 		Enabled:  []string{onlyLint},
 		Disabled: checksDisabled,
 	}
@@ -607,7 +607,7 @@ func Test_disableDefaultLinter(t *testing.T) {
 			Name:    "testdisable",
 			Version: "4.2.0",
 			Epoch:   0,
-			Checks: config.Checks{
+			Checks: &config.Checks{
 				Disabled: []string{"usrlocal"},
 			},
 		},

--- a/pkg/sbom/generator.go
+++ b/pkg/sbom/generator.go
@@ -24,10 +24,6 @@ import (
 	"go.opentelemetry.io/otel"
 )
 
-func NewGenerator() *Generator {
-	return &Generator{}
-}
-
 type Spec struct {
 	Path            string
 	PackageName     string
@@ -41,10 +37,8 @@ type Spec struct {
 	SourceDateEpoch time.Time
 }
 
-type Generator struct{}
-
-// GenerateSBOM runs the main SBOM generation process
-func (g *Generator) GenerateSBOM(ctx context.Context, spec *Spec) error {
+// Generate runs the main SBOM generation process.
+func Generate(ctx context.Context, spec *Spec) error {
 	_, span := otel.Tracer("melange").Start(ctx, "GenerateSBOM")
 	defer span.End()
 	log := clog.FromContext(ctx)

--- a/pkg/sca/sca_test.go
+++ b/pkg/sca/sca_test.go
@@ -63,7 +63,10 @@ func (th *testHandle) Filesystem() (SCAFS, error) {
 }
 
 func (th *testHandle) Options() config.PackageOption {
-	return th.cfg.Package.Options
+	if th.cfg.Package.Options == nil {
+		return config.PackageOption{}
+	}
+	return *th.cfg.Package.Options
 }
 
 func (th *testHandle) BaseDependencies() config.Dependencies {

--- a/pkg/util/map_subst.go
+++ b/pkg/util/map_subst.go
@@ -16,6 +16,7 @@ package util
 
 import (
 	"fmt"
+	"strconv"
 
 	"chainguard.dev/melange/pkg/cond"
 )
@@ -30,6 +31,27 @@ func MutateStringFromMap(with map[string]string, input string) (string, error) {
 		nk := fmt.Sprintf("${{%s}}", key)
 		if val, ok := with[nk]; ok {
 			return val, nil
+		}
+
+		return "", fmt.Errorf("variable %s not defined", key)
+	}
+
+	return cond.Subst(input, lookupWith)
+}
+
+// Given a string and a map, replace the variables in the string with quoted values in the map.
+// Currently, an "if" statement in a melange config can only have quoted strings or ${{variables}}
+// as comparision values with == and !=. If we want to be able to resolve an "if" that can be fed
+// back into melange, we need to maintain that requirement, so all variables get quoted once replaced.
+func MutateAndQuoteStringFromMap(with map[string]string, input string) (string, error) {
+	lookupWith := func(key string) (string, error) {
+		if val, ok := with[key]; ok {
+			return val, nil
+		}
+
+		nk := fmt.Sprintf("${{%s}}", key)
+		if val, ok := with[nk]; ok {
+			return strconv.Quote(val), nil
 		}
 
 		return "", fmt.Errorf("variable %s not defined", key)


### PR DESCRIPTION
This also adds a compile subcommand to melange that outputs the fully rendered melange yaml as JSON to stdout for a build.

See https://github.com/chainguard-dev/melange/issues/1056

As an example, if you want to check that you've got the right mangled version for `jed.yaml`:

```yaml
package:
  name: jed
  version: 0.99.19
  epoch: 0

var-transforms:
  - from: ${{package.version}}
    match: \.(\d+)$
    replace: -$1
    to: mangled-package-version

pipeline:
  - uses: fetch
    with:
      uri: https://www.jedsoft.org/releases/jed/jed-${{vars.mangled-package-version}}.tar.gz
      expected-sha256: 5eed5fede7a95f18b33b7b32cb71be9d509c6babc1483dd5c58b1a169f2bdf52
```

```
melange compile --pipeline-dir ./pipelines/ --arch x86_64 jed.yaml 2>/dev/null | jq '.pipeline[0].with'
{
  "expected-sha256": "5eed5fede7a95f18b33b7b32cb71be9d509c6babc1483dd5c58b1a169f2bdf52",
  "purl-name": "jed",
  "purl-version": "0.99.19",
  "uri": "https://www.jedsoft.org/releases/jed/jed-0.99-19.tar.gz"
}
```