### PR TITLE
Add build flag to override host libc flavor

### DIFF
--- a/docs/md/melange_build.md
+++ b/docs/md/melange_build.md
@@ -28,42 +28,43 @@ melange build [flags]
 ### Options
 
 ```
-      --apk-cache-dir string        directory used for cached apk packages (default is system-defined cache directory)
-      --arch strings                architectures to build for (e.g., x86_64,ppc64le,arm64) -- default is all, unless specified in config
-      --build-date string           date used for the timestamps of the files inside the image
-      --build-option strings        build options to enable
-      --cache-dir string            directory used for cached inputs (default "./melange-cache/")
-      --cache-source string         directory or bucket used for preloading the cache
-      --cpu string                  default CPU resources to use for builds
-      --create-build-log            creates a package.log file containing a list of packages that were built by the command
-      --debug                       enables debug logging of build pipelines
-      --debug-runner                when enabled, the builder pod will persist after the build succeeds or fails
-      --dependency-log string       log dependencies to a specified file
-      --empty-workspace             whether the build workspace should be empty
-      --env-file string             file to use for preloaded environment variables
-      --fail-on-lint-warning        turns linter warnings into failures
-      --generate-index              whether to generate APKINDEX.tar.gz (default true)
-      --guest-dir string            directory used for the build environment guest
-  -h, --help                        help for build
-  -i, --interactive                 when enabled, attaches stdin with a tty to the pod on failure
-  -k, --keyring-append strings      path to extra keys to include in the build environment keyring
-      --log-policy strings          logging policy to use (default [builtin:stderr])
-      --memory string               default memory resources to use for builds
-      --namespace string            namespace to use in package URLs in SBOM (eg wolfi, alpine) (default "unknown")
-      --out-dir string              directory where packages will be output (default "./packages/")
-      --overlay-binsh string        use specified file as /bin/sh overlay in build environment
-      --package-append strings      extra packages to install for each of the build environments
-      --pipeline-dir string         directory used to extend defined built-in pipelines
-  -r, --repository-append strings   path to extra repositories to include in the build environment
-      --rm                          clean up intermediate artifacts (e.g. container images)
-      --runner string               which runner to use to enable running commands, default is based on your platform. Options are ["bubblewrap" "docker" "lima" "kubernetes"]
-      --signing-key string          key to use for signing
-      --source-dir string           directory used for included sources
-      --strip-origin-name           whether origin names should be stripped (for bootstrap)
-      --timeout duration            default timeout for builds
-      --trace string                where to write trace output
-      --vars-file string            file to use for preloaded build configuration variables
-      --workspace-dir string        directory used for the workspace at /home/build
+      --apk-cache-dir string                                    directory used for cached apk packages (default is system-defined cache directory)
+      --arch strings                                            architectures to build for (e.g., x86_64,ppc64le,arm64) -- default is all, unless specified in config
+      --build-date string                                       date used for the timestamps of the files inside the image
+      --build-option strings                                    build options to enable
+      --cache-dir string                                        directory used for cached inputs (default "./melange-cache/")
+      --cache-source string                                     directory or bucket used for preloading the cache
+      --cpu string                                              default CPU resources to use for builds
+      --create-build-log                                        creates a package.log file containing a list of packages that were built by the command
+      --debug                                                   enables debug logging of build pipelines
+      --debug-runner                                            when enabled, the builder pod will persist after the build succeeds or fails
+      --dependency-log string                                   log dependencies to a specified file
+      --empty-workspace                                         whether the build workspace should be empty
+      --env-file string                                         file to use for preloaded environment variables
+      --fail-on-lint-warning                                    turns linter warnings into failures
+      --generate-index                                          whether to generate APKINDEX.tar.gz (default true)
+      --guest-dir string                                        directory used for the build environment guest
+  -h, --help                                                    help for build
+  -i, --interactive                                             when enabled, attaches stdin with a tty to the pod on failure
+  -k, --keyring-append strings                                  path to extra keys to include in the build environment keyring
+      --log-policy strings                                      logging policy to use (default [builtin:stderr])
+      --memory string                                           default memory resources to use for builds
+      --namespace string                                        namespace to use in package URLs in SBOM (eg wolfi, alpine) (default "unknown")
+      --out-dir string                                          directory where packages will be output (default "./packages/")
+      --overlay-binsh string                                    use specified file as /bin/sh overlay in build environment
+      --override-host-triplet-libc-substitution-flavor string   override the flavor of libc for ${{host.triplet.*}} substitutions (e.g. gnu,musl) -- default is gnu (default "gnu")
+      --package-append strings                                  extra packages to install for each of the build environments
+      --pipeline-dir string                                     directory used to extend defined built-in pipelines
+  -r, --repository-append strings                               path to extra repositories to include in the build environment
+      --rm                                                      clean up intermediate artifacts (e.g. container images)
+      --runner string                                           which runner to use to enable running commands, default is based on your platform. Options are ["bubblewrap" "docker" "lima" "kubernetes"]
+      --signing-key string                                      key to use for signing
+      --source-dir string                                       directory used for included sources
+      --strip-origin-name                                       whether origin names should be stripped (for bootstrap)
+      --timeout duration                                        default timeout for builds
+      --trace string                                            where to write trace output
+      --vars-file string                                        file to use for preloaded build configuration variables
+      --workspace-dir string                                    directory used for the workspace at /home/build
 ```
 
 ### Options inherited from parent commands

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -74,6 +74,7 @@ type Build struct {
 	EmptyWorkspace    bool
 	OutDir            string
 	Arch              apko_types.Architecture
+	Libc              string
 	ExtraKeys         []string
 	ExtraRepos        []string
 	ExtraPackages     []string
@@ -109,6 +110,7 @@ func New(ctx context.Context, opts ...Option) (*Build, error) {
 		OutDir:          ".",
 		CacheDir:        "./melange-cache/",
 		Arch:            apko_types.ParseArchitecture(runtime.GOARCH),
+		Libc:            "gnu",
 		LogPolicy:       []string{"builtin:stderr"},
 	}
 
@@ -1061,13 +1063,10 @@ func (b *Build) Summarize(ctx context.Context) {
 // BuildFlavor determines if a build context uses glibc or musl, it returns
 // "gnu" for GNU systems, and "musl" for musl systems.
 func (b *Build) BuildFlavor() string {
-	for _, dir := range []string{"lib", "lib64"} {
-		if _, err := os.Stat(filepath.Join(b.GuestDir, dir, "libc.so.6")); err == nil {
-			return "gnu"
-		}
+	if b.Libc == "" {
+		return "gnu"
 	}
-
-	return "musl"
+	return b.Libc
 }
 
 // BuildTripletGnu returns the GNU autoconf build triplet, for example

--- a/pkg/build/options.go
+++ b/pkg/build/options.go
@@ -361,3 +361,11 @@ func WithAuth(domain, user, pass string) Option {
 		return nil
 	}
 }
+
+// WithLibcFlavorOverride sets the libc flavor for the build.
+func WithLibcFlavorOverride(libc string) Option {
+	return func(b *Build) error {
+		b.Libc = libc
+		return nil
+	}
+}

--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -74,6 +74,7 @@ func Build() *cobra.Command {
 	var cpu, memory string
 	var timeout time.Duration
 	var extraPackages []string
+	var libc string
 
 	var traceFile string
 
@@ -152,6 +153,7 @@ func Build() *cobra.Command {
 				build.WithCPU(cpu),
 				build.WithMemory(memory),
 				build.WithTimeout(timeout),
+				build.WithLibcFlavorOverride(libc),
 			}
 
 			if len(args) > 0 {
@@ -200,6 +202,7 @@ func Build() *cobra.Command {
 	cmd.Flags().StringVar(&overlayBinSh, "overlay-binsh", "", "use specified file as /bin/sh overlay in build environment")
 	cmd.Flags().StringVar(&purlNamespace, "namespace", "unknown", "namespace to use in package URLs in SBOM (eg wolfi, alpine)")
 	cmd.Flags().StringSliceVar(&archstrs, "arch", nil, "architectures to build for (e.g., x86_64,ppc64le,arm64) -- default is all, unless specified in config")
+	cmd.Flags().StringVar(&libc, "override-host-triplet-libc-substitution-flavor", "gnu", "override the flavor of libc for ${{host.triplet.*}} substitutions (e.g. gnu,musl) -- default is gnu")
 	cmd.Flags().StringSliceVar(&buildOption, "build-option", []string{}, "build options to enable")
 	cmd.Flags().StringSliceVar(&logPolicy, "log-policy", []string{"builtin:stderr"}, "logging policy to use")
 	cmd.Flags().StringVar(&runner, "runner", "", fmt.Sprintf("which runner to use to enable running commands, default is based on your platform. Options are %q", build.GetAllRunners()))


### PR DESCRIPTION
This replaces the heuristic for `${{host.triplet.*}` substitutions, which relied on calling Stat() 2-4x in the guest dir for every pipeline executed.

See https://github.com/chainguard-dev/melange/issues/1056 for some more context.

In the fullness of time we'd like to remove these substitutions altogether, but for now let's just default to `gnu` which should make this a no-op for wolfi.

This is a breaking change for anyone using `melange` to build musl-based packages that also relies on the `${{host.triplet.*}}` substitutions. If that's you, I'm sorry. You can set `--override-host-triplet-libc-substitution-flavor musl` to override the default or use the `${{cross.triplet.*.*}}` substitutions instead.