### PR TITLE
test: Drop seemingly useless mkdir -p

### DIFF
--- a/pkg/build/test.go
+++ b/pkg/build/test.go
@@ -529,10 +529,6 @@ func (t *Test) TestPackage(ctx context.Context) error {
 			}
 		}
 		pb.Subpackage = nil
-
-		if err := os.MkdirAll(filepath.Join(t.WorkspaceDir, "melange-out", sp.Name), 0o755); err != nil {
-			return err
-		}
 	}
 
 	// clean workspace dir


### PR DESCRIPTION
This happens at the end of the loop (after we run the test) and is immediately deleted after the loop completes, so this seems to be a NOP.