### PR TITLE
git-checkout - try harder if getting hash from tag fails.

### DIFF
--- a/e2e-tests/test-git-checkout.yaml
+++ b/e2e-tests/test-git-checkout.yaml
@@ -8,11 +8,9 @@ environment:
     packages:
       - busybox
       - git
-      - git-daemon
 vars:
   workd: /tmp/test-git-checkout-workd
   giturl: "file:///tmp/test-git-checkout-workd/repos/my-repo"
-  gitremoteurl: "git://127.6.14.21:61421/my-repo"
 pipeline:
   - name: "Create the bogus package content"
     runs: |
@@ -25,29 +23,9 @@ pipeline:
 
       ./create-git-repo "$repo"
       touch "$repo/git-daemon-export-ok"
-  - name: "Run the git daemon"
-    runs: |
-      url=${{vars.gitremoteurl}}
-      addr=${url#git://}
-      addr=${addr%%:*}
-      port=${url#git://*:}
-      port=${port%%/*}
-      set -- git daemon --listen="$addr" --port="$port" \
-          --detach --pid-file=${{vars.workd}}/pid \
-          --log-destination=stderr \
-          --base-path="${{vars.workd}}/repos/" "${{vars.workd}}/repos/"
-      echo "running daemon:" "$@"
-      "$@"
-      read pid < ${{vars.workd}}/pid
-      echo "pid is $pid"
-
-      vr() { echo "$@" 1>&2; "$@"; }
-      vr git clone "${{vars.giturl}}" my.git
-      vr git clone "${{vars.giturl}}" my2.git
   - runs: |
       vr() { echo "$@" 1>&2; "$@"; }
       vr git clone "${{vars.giturl}}" my3.git
-
   - name: "standard tag on branch"
     uses: git-checkout
     working-directory: standard

--- a/e2e-tests/test-git-checkout.yaml
+++ b/e2e-tests/test-git-checkout.yaml
@@ -1,0 +1,62 @@
+package:
+  name: test-git-checkout
+  version: 6.14
+  epoch: 0
+  description: This package mainly just tests git-checkout pipeline
+environment:
+  contents:
+    packages:
+      - busybox
+      - git
+      - git-daemon
+vars:
+  workd: /tmp/test-git-checkout-workd
+  giturl: "file:///tmp/test-git-checkout-workd/repos/my-repo"
+  gitremoteurl: "git://127.6.14.21:61421/my-repo"
+pipeline:
+  - name: "Create the bogus package content"
+    runs: |
+      echo "package does not do anything" > "${{targets.contextdir}}/README"
+  - name: "Create a git repo"
+    runs: |
+      rm -Rf ${{vars.workd}}
+      mkdir -p ${{vars.workd}}/repos
+      repo=${{vars.workd}}/repos/my-repo
+
+      ./create-git-repo "$repo"
+      touch "$repo/git-daemon-export-ok"
+  - name: "Run the git daemon"
+    runs: |
+      url=${{vars.gitremoteurl}}
+      addr=${url#git://}
+      addr=${addr%%:*}
+      port=${url#git://*:}
+      port=${port%%/*}
+      set -- git daemon --listen="$addr" --port="$port" \
+          --detach --pid-file=${{vars.workd}}/pid \
+          --log-destination=stderr \
+          --base-path="${{vars.workd}}/repos/" "${{vars.workd}}/repos/"
+      echo "running daemon:" "$@"
+      "$@"
+      read pid < ${{vars.workd}}/pid
+      echo "pid is $pid"
+
+      vr() { echo "$@" 1>&2; "$@"; }
+      vr git clone "${{vars.giturl}}" my.git
+      vr git clone "${{vars.giturl}}" my2.git
+  - runs: |
+      vr() { echo "$@" 1>&2; "$@"; }
+      vr git clone "${{vars.giturl}}" my3.git
+
+  - name: "standard tag on branch"
+    uses: git-checkout
+    working-directory: standard
+    with:
+      repository: ${{vars.giturl}}
+      tag: 2.0
+      expected-commit: 3dfc3dd573b814be48c07f7f8ae3c19a23b69865
+  - name: "check standard tag on branch"
+    working-directory: standard
+    runs: |
+      hash=$(git rev-parse --verify HEAD)
+      [ "$hash" = 3dfc3dd573b814be48c07f7f8ae3c19a23b69865 ]

--- a/e2e-tests/test-git-checkout.yaml
+++ b/e2e-tests/test-git-checkout.yaml
@@ -38,3 +38,117 @@ pipeline:
     runs: |
       hash=$(git rev-parse --verify HEAD)
       [ "$hash" = 3dfc3dd573b814be48c07f7f8ae3c19a23b69865 ]
+      cd ..
+      rm -Rf standard
+  - name: "standard no-working-directory"
+    uses: git-checkout
+    with:
+      repository: ${{vars.giturl}}
+      tag: 2.0
+      expected-commit: 3dfc3dd573b814be48c07f7f8ae3c19a23b69865
+  - name: "check standard no-working-directory"
+    runs: |
+      hash=$(git rev-parse --verify HEAD)
+      [ "$hash" = 3dfc3dd573b814be48c07f7f8ae3c19a23b69865 ]
+      [ -f create-git-repo ] ||
+         { echo "create-git-repo did not exist"; exit 1; }
+  - name: "destination"
+    uses: git-checkout
+    working-directory: destination-base
+    with:
+      repository: ${{vars.giturl}}
+      tag: 2.0
+      expected-commit: 3dfc3dd573b814be48c07f7f8ae3c19a23b69865
+      destination: dest
+  - name: "check destination"
+    working-directory: destination-base
+    runs: |
+      cd dest
+      hash=$(git rev-parse --verify HEAD)
+      [ "$hash" = 3dfc3dd573b814be48c07f7f8ae3c19a23b69865 ]
+      cd ../..
+      rm -R destination-base
+  - name: "depth 1"
+    uses: git-checkout
+    working-directory: depth-1
+    with:
+      repository: ${{vars.giturl}}
+      tag: 2.0
+      expected-commit: 3dfc3dd573b814be48c07f7f8ae3c19a23b69865
+  - name: "check depth 1"
+    working-directory: depth-1
+    runs: |
+      if out=$(git show HEAD^ 2>&1); then
+          echo "git show HEAD^ should not succeed on checkout with depth 1"
+          exit 1
+      fi
+      hash=$(git rev-parse --verify HEAD)
+      [ "$hash" = 3dfc3dd573b814be48c07f7f8ae3c19a23b69865 ]
+      cd ..
+      rm -R depth-1
+  - name: "depth -1"
+    working-directory: depth-neg-1
+    uses: git-checkout
+    with:
+      depth: -1
+      repository: ${{vars.giturl}}
+      tag: 2.0
+      expected-commit: 3dfc3dd573b814be48c07f7f8ae3c19a23b69865
+  - name: "check depth -1"
+    working-directory: depth-neg-1
+    runs: |
+      out=$(git show HEAD^ 2>&1) || {
+          echo "git show HEAD^ failed on depth -1 checkout"
+          echo "it should pass"
+          exit 1
+      }
+      hash=$(git rev-parse --verify HEAD)
+      [ "$hash" = 3dfc3dd573b814be48c07f7f8ae3c19a23b69865 ]
+      cd ..
+      rm -R depth-neg-1
+  - name: "branch without expected"
+    working-directory: branch-no-expected
+    uses: git-checkout
+    with:
+      repository: ${{vars.giturl}}
+      branch: 1.x
+  - name: "check branch without expected"
+    working-directory: branch-no-expected
+    runs: |
+      hash=$(git rev-parse --verify HEAD)
+      [ "$hash" = 4b1593d8d8038f8c0ce1e2c608c9dd89066a2a0f ]
+      cd ..
+      rm -R branch-no-expected
+  # for an annotated tag you can point to either the commit
+  # or the tag object hash object
+  - name: "annotated hash"
+    uses: git-checkout
+    working-directory: annotated-hash
+    with:
+      repository: ${{vars.giturl}}
+      tag: 2.0-annotated
+      expected-commit: 4ce5bdbf45a68a166d931dd1247878829b5c0113
+  - name: "check annotated hash"
+    working-directory: annotated-hash
+    runs: |
+      git show-ref --tags -d
+      hash=$(git rev-parse --verify HEAD)
+      [ "$hash" = 3dfc3dd573b814be48c07f7f8ae3c19a23b69865 ]
+      cd ..
+      rm -R annotated-hash
+  # special case with clone --branch if there is a tag and a branch
+  # with the same name.
+  - name: "tag and branch same name"
+    uses: git-checkout
+    working-directory: tag-and-branch
+    with:
+      repository: ${{vars.giturl}}
+      tag: dev
+      expected-commit: 2b9bb894348794bc840a2ee7553d54a1c80b9278
+  - name: "check tag and branch same name"
+    working-directory: tag-and-branch
+    runs: |
+      hash=$(git rev-parse --verify HEAD)
+      [ "$hash" = 2b9bb894348794bc840a2ee7553d54a1c80b9278 ]
+      cd ..
+      rm -R tag-and-branch

--- a/e2e-tests/test-git-checkout/create-git-repo
+++ b/e2e-tests/test-git-checkout/create-git-repo
@@ -1,0 +1,101 @@
+#!/bin/sh
+# create a repository with known hashes
+set -e
+MYDATE="Fri, 14 Jun 2024 15:21:36 -0000"
+TEMP_D=""
+
+fail() { echo "$@" 1>&2; exit 1; }
+
+wfile() {
+    name="$1" content="$2"
+    rm -f "$name"
+    printf "%s\n" "$content" > "$name"
+}
+
+gcommit() {
+    GIT_COMMITTER_DATE="$MYDATE" git commit \
+        --date="$MYDATE" "$@"
+}
+
+gtag() {
+    GIT_AUTHOR_DATE="$MYDATE" \
+        GIT_COMMITTER_DATE="$MYDATE" git tag "$@"
+}
+
+v() {
+    echo "execute:" "$@"
+    "$@"
+}
+
+cleanup() { rm -Rf "$TEMP_D"; TEMP_D=""; }
+
+TEMP_D=$(mktemp -d)
+trap cleanup EXIT
+
+dest="$1"
+if [ -e "$dest" ]; then
+    fail "do not give existing dir for dest"
+fi
+startd="$PWD"
+
+cd "$TEMP_D"
+export HOME="$PWD"
+workdir="$PWD/my-repo"
+export LC_ALL=C.UTF-8
+
+git config --global user.name "Melange Test"
+git config --global user.email meltest@example.com
+
+mkdir "$workdir"
+cd "$workdir"
+
+v git init --initial-branch=main .
+v wfile README "hello world"
+v git add README
+v gcommit -m "first commit" README
+v wfile README "data2"
+v gcommit -m "second commit" README
+
+v git checkout -b 1.x main
+v wfile README "1.0-release content"
+v gcommit -m "release 1.0" README
+v gtag 1.0 HEAD
+v gtag --annotate --message="Release 1.0" 1.0-annotated HEAD
+
+v wfile README "1.1-release content"
+v gcommit -m "release 1.1" README
+v gtag 1.1 HEAD
+
+v wfile README "1.2-staged content"
+v gcommit -m "stage 1.2 content" README
+v gtag 1.2
+v gtag --annotate --message="Release 1.2" 1.2-annotated HEAD
+
+v git checkout -b dev main
+v wfile README "stuff on dev"
+v gcommit -m "dev branch stuff" README
+# tag with same name as branch
+# https://github.com/chainguard-dev/melange/issues/1272
+v gtag dev HEAD
+v wfile README "more stuff on dev"
+v gcommit -m "more stuff on dev" README
+
+v git checkout main
+v wfile README "mainline stuff"
+v gcommit -m "mainline stuff" README
+
+v git checkout main
+v wfile README "mainline stuff 2"
+v gcommit -m "mainline stuff 2" README
+
+v git checkout -b 2.x main^
+v wfile README "2.0-release content"
+v gcommit -m "release 2.0" README
+v gtag 2.0
+v gtag --annotate --message="Release 2.0" 2.0-annotated HEAD
+
+v git checkout main
+
+v cd "$startd"
+v mv "$workdir/.git" "$dest"
+echo "wrote git dir to $dest"

--- a/pkg/build/pipelines/git-checkout.yaml
+++ b/pkg/build/pipelines/git-checkout.yaml
@@ -39,65 +39,110 @@ inputs:
 
 pipeline:
   - runs: |
-      if [ -z "${{inputs.branch}}" ] && [ -z "${{inputs.tag}}" ]; then
-        echo "Warning (git-checkout): you have not specified a branch or tag."
-      fi
+      #!/bin/sh
+      set -e
 
-      git_clone_flags=""
-      if [ "${{inputs.recurse-submodules}}" == "true" ]; then
-        git_clone_flags="--recurse-submodules"
-      fi
+      msg() { echo "[git checkout]" "$@" 1>&2; }
+      fail() { msg FAIL "$@"; exit 1; }
+      vr() { msg "execute:" "$@"; "$@"; }
 
-      [ -n '${{inputs.branch}}' ] && clone_target='--branch ${{inputs.branch}}'
-      [ -n '${{inputs.tag}}' ] && clone_target='--branch ${{inputs.tag}}'
+      main() {
+          local repo=$1 dest=${2:-.} depth=${3:-"-1"} branch=$4
+          local tag=$5 expcommit=$6 recurse=${7:-false}
+          msg "repo='$repo' dest='$dest' depth='$depth' branch='$branch'" \
+              "tag='$tag' expcommit='$expcommit' recurse='$recurse'"
 
-      workdir=$(mktemp -d)
-      mkdir -p '${{inputs.destination}}'
-      clone_fullpath=$(realpath '${{inputs.destination}}')
+          case "$recurse" in
+              true|false) :;;
+              *) fail "recurse must be true or false, not '$recurse'"
+          esac
 
-      git config --global --add safe.directory $workdir
-      git config --global --add safe.directory $clone_fullpath
-      if [ "${{inputs.depth}}" == "-1" ]; then
-        git clone $git_clone_flags $clone_target '${{inputs.repository}}' $workdir
-      else
-        git clone $git_clone_flags $clone_target --depth '${{inputs.depth}}' '${{inputs.repository}}' $workdir
-      fi
+          [ -n "$repo" ] || fail "repository not provided"
 
-      cd $workdir
-      tar -c . | (cd $clone_fullpath && tar -x)
-      rm -rf $workdir
-      cd $clone_fullpath
-      git config --global --add safe.directory $clone_fullpath
+          if [ -z "$branch" ] && [ -z "$tag" ]; then
+              msg "Warning: you have not specified a branch or tag."
+          fi
 
-      if [ -z "${{inputs.expected-commit}}" ]; then
-        echo "Warning (git-checkout): no expected-commit"
-      elif [ -n '${{inputs.branch}}' ]; then
-        git config --global advice.detachedHead false
-        remote_commit=$(git rev-parse --verify --end-of-options "refs/heads/${{inputs.branch}}")
-        if [[ '${{inputs.expected-commit}}' != "$remote_commit" ]]; then
-          echo "Error (git-checkout): expect commit ${{inputs.expected-commit}}, got $remote_commit"
-          exit 1
-        fi
-      elif [ -n '${{inputs.tag}}' ]; then
-        # If it's a tag, then it could be a lightweight or annotated tag.
-        # Lightweight tags point directly to the commit and do not have any messages, signatures, or other data.
-        # Annotated tags point to its own git object containing the tag data, with a reference to the underlying commit.
-        # We expect most tags to be using annotated tags.
+          [ -n "$expcommit" ] ||
+              msg "Warning: no expected-commit"
 
-        # Compare direct tag value
-        remote_commit=$(git rev-parse --verify --end-of-options "refs/tags/${{inputs.tag}}")
-        if [[ '${{inputs.expected-commit}}' == "$remote_commit" ]]; then
-          exit 0
-        fi
+          local flags="" depthflag="" dest_fullpath="" workdir=""
+          local remote="origin" rcfile="" rc=""
+          [ "$recurse" = "true" ] && flags="$flags --recurse-submodules"
+          [ -n "$branch" ] && flags="--branch=$branch"
+          [ -n "$tag" ] && flags="--branch=$tag"
 
-        # Try to unpeel the tag and compare the underlying value.
-        echo "Warning (git-checkout): expected commit ${{inputs.expected-commit}}, does not match tag ${remote_commit}. Attempting to unpeel tag."
+          [ "$depth" = "-1" ] || depthflag="--depth=$depth"
 
-        unpeeled_commit=$(git rev-parse --verify --end-of-options "refs/tags/${{inputs.tag}}^{}")
-        if [[ '${{inputs.expected-commit}}' != "${unpeeled_commit}" ]]; then
-          echo "Error (git-checkout): expect commit ${{inputs.expected-commit}}, got ${unpeeled_commit}"
-          exit 1
-        fi
-      else
-        echo "Error (git-checkout): no branch or tag provided"
-      fi
+          workdir=$(mktemp -d)
+          rcfile=$(mktemp)
+          mkdir -p "$dest"
+          dest_fullpath=$(realpath "$dest")
+
+          vr git config --global --add safe.directory "$workdir"
+          vr git config --global --add safe.directory "$dest_fullpath"
+
+          vr git clone "--origin=$remote" $flags \
+              ${depthflag:+"$depthflag"} "$repo" "$workdir"
+
+          vr cd "$workdir"
+          msg "tar -c . | tar -C \"$dest_fullpath\" -x"
+          ( tar -c . ; echo $? > "$rcfile") | tar -C "$dest_fullpath" -x
+          read rc < "$rcfile" || fail "failed to read rc file"
+          [ $rc -eq 0 ] || fail "tar creation in $workdir failed"
+
+          rm -rf "$workdir"
+          vr cd "$dest_fullpath"
+          vr git config --global --add safe.directory "$dest_fullpath"
+
+          local foundcommit="" tagobj=""
+          vr git config --global advice.detachedHead false
+          if [ -z "$tag" ]; then
+              foundcommit=$(git rev-parse --verify HEAD)
+              if [ -n "$expcommit" ] && [ "$expcommit" != "$foundcommit" ]; then
+                  fail "expected commit $expcommit on ${branch:-HEAD}," \
+                      " got $foundcommit"
+              fi
+              msg "tip of ${branch:-HEAD} is commit $foundcommit"
+              return 0
+          fi
+
+          # git clone --branch=X will pick the branch X if there
+          # exists both a tag and a branch by that name.
+          # since a tag was given, we want the tag.
+          vr git fetch $remote ${depthflag:+"$depthflag"} --no-tags \
+              "+refs/tags/$tag:refs/$remote/tags/$tag"
+          vr git checkout "$remote/tags/$tag"
+
+          foundcommit=$(git rev-parse --verify HEAD)
+          if [ -z "$expcommit" ] || [ "$expcommit" = "$foundcommit" ]; then
+              msg "tag $tag is $foundcommit"
+              return 0
+          fi
+
+          # If it's a tag, then it could be a lightweight or annotated tag.
+          # Lightweight tags point directly to the commit and do not have
+          # any messages, signatures, or other data.  Annotated tags point
+          # to its own git object containing the tag data, with a reference
+          # to the underlying commit.  We expect most tags to be using
+          # annotated tags.
+          tagobj=$(git rev-parse --verify --end-of-options \
+              "refs/$remote/tags/$tag")
+          if [ "$expcommit" != "$tagobj" ]; then
+              [ "$tagobj" != "$expcommit" ] &&
+                  msg "tag object hash was $tagobj"
+              fail "Expected commit $expcommit for $tag, found $foundcommit"
+          fi
+
+          msg "Warning: The provided expected-commit ($expcommit)"
+          msg "was the hash of the annotated tag object for $tag."
+          msg "Update to set expected-commit to $foundcommit"
+
+          return 0
+      }
+
+      main \
+          "${{inputs.repository}}" "${{inputs.destination}}" \
+          "${{inputs.depth}}" "${{inputs.branch}}" \
+          "${{inputs.tag}}" "${{inputs.expected-commit}}" \
+          "${{inputs.recurse-submodules}}"


### PR DESCRIPTION
If the remote repository has a branch and a tag with the provided name (in there exists a branch in the remot with the same name as the provided tag (inputs.tag), then git rev-parse will fail with:

    fatal: Needed a single revision

If that happens, then try to get a value with:

    git ls-remote --tags origin ${tag}

Fixes #1272.
