### PR TITLE
Remove build.PipelineBuild as a concept

### DIFF
--- a/pkg/build/compile.go
+++ b/pkg/build/compile.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"fmt"
 	"maps"
+	"os"
+	"path/filepath"
 
 	"chainguard.dev/melange/pkg/cond"
 	"chainguard.dev/melange/pkg/config"
@@ -29,9 +31,13 @@ import (
 
 func (t *Test) Compile(ctx context.Context) error {
 	cfg := t.Configuration
-	pb := &PipelineBuild{
-		Test:    t,
-		Package: &cfg.Package,
+
+	// TODO: Make this parameter go away when we revisit subtitutions.
+	flavor := "gnu"
+
+	sm, err := NewSubstitutionMap(&cfg, t.Arch, flavor, nil)
+	if err != nil {
+		return err
 	}
 
 	c := &Compiled{
@@ -43,37 +49,32 @@ func (t *Test) Compile(ctx context.Context) error {
 	}
 
 	// We want to evaluate this but not accumulate its deps.
-	if err := ignore.CompilePipelines(ctx, pb, cfg.Pipeline); err != nil {
+	if err := ignore.CompilePipelines(ctx, sm, cfg.Pipeline); err != nil {
 		return fmt.Errorf("compiling main pipelines: %w", err)
 	}
 
-	if err := c.CompilePipelines(ctx, pb, cfg.Test.Pipeline); err != nil {
+	if err := c.CompilePipelines(ctx, sm, cfg.Test.Pipeline); err != nil {
 		return fmt.Errorf("compiling main pipelines: %w", err)
 	}
 
 	for i, sp := range cfg.Subpackages {
-		pb.Subpackage = &sp
-
+		sm := sm.Subpackage(&sp)
 		if sp.If != "" {
-			mutated, err := MutateWith(pb, map[string]string{})
-			if err != nil {
-				return fmt.Errorf("creating subpackage map: %w", err)
-			}
-			sp.If, err = util.MutateAndQuoteStringFromMap(mutated, sp.If)
+			sp.If, err = util.MutateAndQuoteStringFromMap(sm.Substitutions, sp.If)
 			if err != nil {
 				return fmt.Errorf("mutating subpackage if: %w", err)
 			}
 		}
 
 		// We want to evaluate this but not accumulate its deps.
-		if err := ignore.CompilePipelines(ctx, pb, sp.Pipeline); err != nil {
+		if err := ignore.CompilePipelines(ctx, sm, sp.Pipeline); err != nil {
 			return fmt.Errorf("compiling subpackage %q: %w", sp.Name, err)
 		}
 
 		test := &Compiled{
 			PipelineDirs: t.PipelineDirs,
 		}
-		if err := c.CompilePipelines(ctx, pb, sp.Test.Pipeline); err != nil {
+		if err := c.CompilePipelines(ctx, sm, sp.Test.Pipeline); err != nil {
 			return fmt.Errorf("compiling subpackage %q tests: %w", sp.Name, err)
 		}
 
@@ -104,34 +105,30 @@ func (t *Test) Compile(ctx context.Context) error {
 // Compile compiles all configuration, including tests, by loading any pipelines and substituting all variables.
 func (b *Build) Compile(ctx context.Context) error {
 	cfg := b.Configuration
-	pb := &PipelineBuild{
-		Build:   b,
-		Package: &cfg.Package,
+	sm, err := NewSubstitutionMap(&cfg, b.Arch, b.BuildFlavor(), b.EnabledBuildOptions)
+	if err != nil {
+		return err
 	}
 
 	c := &Compiled{
 		PipelineDirs: b.PipelineDirs,
 	}
 
-	if err := c.CompilePipelines(ctx, pb, cfg.Pipeline); err != nil {
+	if err := c.CompilePipelines(ctx, sm, cfg.Pipeline); err != nil {
 		return fmt.Errorf("compiling main pipelines: %w", err)
 	}
 
 	for i, sp := range cfg.Subpackages {
-		pb.Subpackage = &sp
+		sm := sm.Subpackage(&sp)
 
 		if sp.If != "" {
-			mutated, err := MutateWith(pb, map[string]string{})
-			if err != nil {
-				return fmt.Errorf("creating subpackage map: %w", err)
-			}
-			sp.If, err = util.MutateAndQuoteStringFromMap(mutated, sp.If)
+			sp.If, err = util.MutateAndQuoteStringFromMap(sm.Substitutions, sp.If)
 			if err != nil {
 				return fmt.Errorf("mutating subpackage if: %w", err)
 			}
 		}
 
-		if err := c.CompilePipelines(ctx, pb, sp.Pipeline); err != nil {
+		if err := c.CompilePipelines(ctx, sm, sp.Pipeline); err != nil {
 			return fmt.Errorf("compiling subpackage %q: %w", sp.Name, err)
 		}
 
@@ -142,7 +139,7 @@ func (b *Build) Compile(ctx context.Context) error {
 		tc := &Compiled{
 			PipelineDirs: b.PipelineDirs,
 		}
-		if err := tc.CompilePipelines(ctx, pb, sp.Test.Pipeline); err != nil {
+		if err := tc.CompilePipelines(ctx, sm, sp.Test.Pipeline); err != nil {
 			return fmt.Errorf("compiling subpackage %q tests: %w", sp.Name, err)
 		}
 
@@ -163,7 +160,7 @@ func (b *Build) Compile(ctx context.Context) error {
 			PipelineDirs: b.PipelineDirs,
 		}
 
-		if err := tc.CompilePipelines(ctx, pb, cfg.Test.Pipeline); err != nil {
+		if err := tc.CompilePipelines(ctx, sm, cfg.Test.Pipeline); err != nil {
 			return fmt.Errorf("compiling main pipelines: %w", err)
 		}
 
@@ -186,9 +183,9 @@ type Compiled struct {
 	ExternalRefs []purl.PackageURL
 }
 
-func (c *Compiled) CompilePipelines(ctx context.Context, pb *PipelineBuild, pipelines []config.Pipeline) error {
+func (c *Compiled) CompilePipelines(ctx context.Context, sm *SubstitutionMap, pipelines []config.Pipeline) error {
 	for i := range pipelines {
-		if err := c.compilePipeline(ctx, pb, &pipelines[i]); err != nil {
+		if err := c.compilePipeline(ctx, sm, &pipelines[i]); err != nil {
 			return fmt.Errorf("compiling Pipeline[%d]: %w", i, err)
 		}
 
@@ -200,7 +197,7 @@ func (c *Compiled) CompilePipelines(ctx context.Context, pb *PipelineBuild, pipe
 	return nil
 }
 
-func (c *Compiled) compilePipeline(ctx context.Context, pb *PipelineBuild, pipeline *config.Pipeline) error {
+func (c *Compiled) compilePipeline(ctx context.Context, sm *SubstitutionMap, pipeline *config.Pipeline) error {
 	log := clog.FromContext(ctx)
 	uses, with := pipeline.Uses, maps.Clone(pipeline.With)
 
@@ -212,7 +209,8 @@ func (c *Compiled) compilePipeline(ctx context.Context, pb *PipelineBuild, pipel
 
 		for _, pd := range c.PipelineDirs {
 			log.Debugf("trying to load pipeline %q from %q", uses, pd)
-			data, err = loadPipelineData(pd, uses)
+
+			data, err = os.ReadFile(filepath.Join(pd, uses+".yaml"))
 			if err == nil {
 				log.Infof("Found pipeline %s", string(data))
 				break
@@ -236,7 +234,7 @@ func (c *Compiled) compilePipeline(ctx context.Context, pb *PipelineBuild, pipel
 		return fmt.Errorf("unable to validate with: %w", err)
 	}
 
-	mutated, err := MutateWith(pb, validated)
+	mutated, err := sm.MutateWith(validated)
 	if err != nil {
 		return fmt.Errorf("mutating with: %w", err)
 	}
@@ -282,7 +280,7 @@ func (c *Compiled) compilePipeline(ctx context.Context, pb *PipelineBuild, pipel
 		p := &pipeline.Pipeline[i]
 		p.With = util.RightJoinMap(mutated, p.With)
 
-		if err := c.compilePipeline(ctx, pb, p); err != nil {
+		if err := c.compilePipeline(ctx, sm, p); err != nil {
 			return fmt.Errorf("compiling Pipeline[%d]: %w", i, err)
 		}
 	}

--- a/pkg/build/pipeline_test.go
+++ b/pkg/build/pipeline_test.go
@@ -50,30 +50,26 @@ func Test_substitutionMap(t *testing.T) {
 		{initialVersion: "1.2.3.9", match: `\.(\d+)$`, replace: "+$1", expected: "1.2.3+9"},
 	}
 	for _, tt := range tests {
-		pkg := &config.Package{
+		pkg := config.Package{
 			Name:    "foo",
 			Version: tt.initialVersion,
 		}
 
 		t.Run("sub", func(t *testing.T) {
-			pb := &PipelineBuild{
+			cfg := config.Configuration{
 				Package: pkg,
-				Build: &Build{
-					Configuration: config.Configuration{
-						VarTransforms: []config.VarTransforms{
-							{
-								From:    "${{package.version}}",
-								Match:   tt.match,
-								Replace: tt.replace,
-								To:      "mangled-package-version",
-							},
-						},
+				VarTransforms: []config.VarTransforms{
+					{
+						From:    "${{package.version}}",
+						Match:   tt.match,
+						Replace: tt.replace,
+						To:      "mangled-package-version",
 					},
 				},
 			}
-			m, err := substitutionMap(pb)
+			m, err := NewSubstitutionMap(&cfg, "", "", nil)
 			require.NoError(t, err)
-			require.Equal(t, tt.expected, m["${{vars.mangled-package-version}}"])
+			require.Equal(t, tt.expected, m.Substitutions["${{vars.mangled-package-version}}"])
 		})
 	}
 }
@@ -91,14 +87,15 @@ func Test_MutateWith(t *testing.T) {
 		epoch:   3,
 		want:    "1.2.3-r3",
 	}} {
-		pb := &PipelineBuild{
-			Package: &config.Package{
+		cfg := config.Configuration{
+			Package: config.Package{
 				Version: tc.version,
 				Epoch:   tc.epoch,
 			},
-			Build: &Build{},
 		}
-		got, err := MutateWith(pb, map[string]string{})
+		sm, err := NewSubstitutionMap(&cfg, "", "", nil)
+		require.NoError(t, err)
+		got, err := sm.MutateWith(map[string]string{})
 		if err != nil {
 			t.Fatalf("MutateWith failed with: %v", err)
 		}
@@ -111,33 +108,31 @@ func Test_MutateWith(t *testing.T) {
 
 func Test_substitutionNeedPackages(t *testing.T) {
 	ctx := slogtest.TestContextWithLogger(t)
-	pkg := &config.Package{
+	pkg := config.Package{
 		Name:    "foo",
 		Version: "1.2.3",
 	}
 
-	pb := &PipelineBuild{
+	cfg := config.Configuration{
 		Package: pkg,
-		Build: &Build{
-			PipelineDirs: []string{"pipelines"},
-			Configuration: config.Configuration{
-				Pipeline: []config.Pipeline{
-					{
-						Uses: "go/build",
-						With: map[string]string{
-							"go-package": "go-5.4.3",
-							"output":     "foo",
-							"packages":   "./bar",
-						},
-					},
+		Pipeline: []config.Pipeline{
+			{
+				Uses: "go/build",
+				With: map[string]string{
+					"go-package": "go-5.4.3",
+					"output":     "foo",
+					"packages":   "./bar",
 				},
 			},
 		},
 	}
+	pipelineDirs := []string{"pipelines"}
 
-	c := &Compiled{PipelineDirs: pb.Build.PipelineDirs}
+	c := &Compiled{PipelineDirs: pipelineDirs}
+	sm, err := NewSubstitutionMap(&cfg, "", "", nil)
+	require.NoError(t, err)
 
-	err := c.CompilePipelines(ctx, pb, pb.Build.Configuration.Pipeline)
+	err = c.CompilePipelines(ctx, sm, cfg.Pipeline)
 	require.NoError(t, err)
 	require.Equal(t, "go-5.4.3", c.Needs[0])
 }


### PR DESCRIPTION
The purpose of this struct never really made any sense to me, and it got muddied a lot when we introduced build.Test, so drop it altogether.

Instead of plumbing a pb around everywhere so we can re-instantiate a substitution map every time we want to do anything, this creates a subtitution map up from based on the build/test configuration and passes it along, cloning and augmenting it for subpackages.

This should avoid generating a good amount of garbage maps, as well.