### PR TITLE
unbreak build at head from log policy removal

### DIFF
--- a/pkg/cli/compile.go
+++ b/pkg/cli/compile.go
@@ -105,7 +105,6 @@ func Compile() *cobra.Command {
 				build.WithDebugRunner(debugRunner),
 				build.WithInteractive(interactive),
 				build.WithRemove(remove),
-				build.WithLogPolicy(logPolicy),
 				build.WithFailOnLintWarning(failOnLintWarning),
 				build.WithCPU(cpu),
 				build.WithMemory(memory),


### PR DESCRIPTION
```
# chainguard.dev/melange/pkg/cli
Error: pkg/cli/compile.go:108:11: undefined: build.WithLogPolicy
```