### PR TITLE
Populate history for --interactive builds

### DIFF
--- a/pkg/build/pipeline_test.go
+++ b/pkg/build/pipeline_test.go
@@ -146,7 +146,7 @@ func Test_buildEvalRunCommand(t *testing.T) {
 	sysPath := "/foo"
 	workdir := "/bar"
 	fragment := "baz"
-	command := buildEvalRunCommand(context.Background(), p, debugOption, sysPath, workdir, fragment)
+	command := buildEvalRunCommand(context.Background(), p, debugOption, sysPath, workdir, fragment, false)
 	expected := []string{"/bin/sh", "-c", `set -ex
 export PATH='/foo'
 export FOO='bar'


### PR DESCRIPTION
This is a big quality of life improvement for debugging broken builds.