### PR TITLE
chore(autoconf/configure): Generate configuration with autoreconf when configuration doesn't exist

### DIFF
--- a/pkg/build/pipelines/autoconf/configure.yaml
+++ b/pkg/build/pipelines/autoconf/configure.yaml
@@ -1,5 +1,10 @@
 name: Run autoconf configure script
 
+needs:
+  packages:
+    - autoconf
+    - automake
+
 inputs:
   dir:
     description: |

--- a/pkg/build/pipelines/autoconf/configure.yaml
+++ b/pkg/build/pipelines/autoconf/configure.yaml
@@ -29,6 +29,12 @@ inputs:
 pipeline:
   - runs: |
       cd ${{inputs.dir}}
+
+      # Attempt to generate configuration if one does not exist
+      if [[ ! -f ./configure && -f ./configure.ac ]]; then
+          autoreconf -vfi
+      fi
+
       ./configure \
         --host=${{inputs.host}} \
         --build=${{inputs.build}} \

--- a/pkg/convert/apkbuild/apkbuild.go
+++ b/pkg/convert/apkbuild/apkbuild.go
@@ -430,8 +430,6 @@ func (c ApkConvertor) buildEnvironment(additionalRepositories, additionalKeyring
 	env := apkotypes.ImageConfiguration{
 		Contents: apkotypes.ImageContents{
 			Packages: []string{
-				"autoconf",
-				"automake",
 				"build-base",
 				"busybox",
 				"ca-certificates-bundle",


### PR DESCRIPTION
Verifies the absence of ./configure and that ./configure.ac is present before attempting to generate the configuration with autoreconf

Also - currently, autoconf and automake are added everywhere we utilize our autoconf pipelines. Just make them packages required by the autoconf/configure pipeline

### Functional Changes

- [x] This change can build all of Wolfi without errors (describe results in notes)

Notes:

### SCA Changes

- [x] Examining several representative APKs show no regression / the desired effect (details in notes)

Notes:

### Linter

- [x] The new check is clean across Wolfi
- [ ] The new check is opt-in or a warning

Notes:
