### PR TITLE
melange numpy test include python-3.12

### DIFF
--- a/e2e-tests/numpy-test.yaml
+++ b/e2e-tests/numpy-test.yaml
@@ -8,11 +8,16 @@ pipeline:
 
 # Test python/import, and python/test pipelines
 test:
+  environment:
+    # TODO(pnasrat): fix to use multiple python
+    contents:
+      packages:
+        - python-3.12
   pipeline:
     # Test import with command (python -c "import numpy")
     - uses: python/test
       with:
-        command: python -c "import numpy"
+        command: python3.12 -c "import numpy"
     # Test import directly (python -c "import numpy")
     - uses: python/import
       with:


### PR DESCRIPTION
Needed for default python until multiversion python supported see #1306

