### PR TITLE
git-checkout: fix recurse='true' does nothing

### DIFF
--- a/pkg/build/pipelines/git-checkout.yaml
+++ b/pkg/build/pipelines/git-checkout.yaml
@@ -68,9 +68,9 @@ pipeline:
 
           local flags="" depthflag="" dest_fullpath="" workdir=""
           local remote="origin" rcfile="" rc=""
-          [ "$recurse" = "true" ] && flags="$flags --recurse-submodules"
           [ -n "$branch" ] && flags="--branch=$branch"
           [ -n "$tag" ] && flags="--branch=$tag"
+          [ "$recurse" = "true" ] && flags="$flags --recurse-submodules"
 
           [ "$depth" = "-1" ] || depthflag="--depth=$depth"
 


### PR DESCRIPTION
It appears recurse-submodules got broken, as tag/branch reset flags
variable discarding recurse-submodule setting. Discovered with failure
to build neom.yaml in wolfi.
