### PR TITLE
enforce some more lint checks

### DIFF
--- a/docs/md/melange_build.md
+++ b/docs/md/melange_build.md
@@ -46,8 +46,8 @@ melange build [flags]
   -h, --help                                                    help for build
   -i, --interactive                                             when enabled, attaches stdin with a tty to the pod on failure
   -k, --keyring-append strings                                  path to extra keys to include in the build environment keyring
-      --lint-require strings                                    linters that must pass
-      --lint-warn strings                                       linters that will generate warnings (default [dev,documentation,empty,infodir,object,opt,python/docs,python/multiple,python/test,setuidgid,srv,strip,tempdir,usrlocal,varempty,worldwrite])
+      --lint-require strings                                    linters that must pass (default [dev,infodir,tempdir,varempty])
+      --lint-warn strings                                       linters that will generate warnings (default [object,opt,python/docs,python/multiple,python/test,setuidgid,srv,strip,usrlocal,worldwrite])
       --memory string                                           default memory resources to use for builds
       --namespace string                                        namespace to use in package URLs in SBOM (eg wolfi, alpine) (default "unknown")
       --out-dir string                                          directory where packages will be output (default "./packages/")

--- a/docs/md/melange_lint.md
+++ b/docs/md/melange_lint.md
@@ -29,8 +29,8 @@ melange lint [flags]
 
 ```
   -h, --help                   help for lint
-      --lint-require strings   linters that must pass
-      --lint-warn strings      linters that will generate warnings (default [dev,documentation,empty,infodir,object,opt,python/docs,python/multiple,python/test,setuidgid,srv,strip,tempdir,usrlocal,varempty,worldwrite])
+      --lint-require strings   linters that must pass (default [dev,infodir,tempdir,varempty])
+      --lint-warn strings      linters that will generate warnings (default [object,opt,python/docs,python/multiple,python/test,setuidgid,srv,strip,usrlocal,worldwrite])
 ```
 
 ### Options inherited from parent commands

--- a/pkg/linter/linter.go
+++ b/pkg/linter/linter.go
@@ -305,9 +305,9 @@ func worldWriteableLinter(ctx context.Context, pkgname string, fsys fs.FS) error
 		mode := info.Mode()
 		if mode&0002 != 0 {
 			if mode&0111 != 0 {
-				return fmt.Errorf("world-writeable executable file found in package (security risk)")
+				return fmt.Errorf("world-writeable executable file found in package (security risk): %s")
 			}
-			return fmt.Errorf("world-writeable file found in package")
+			return fmt.Errorf("world-writeable file found in package: %s", path)
 		}
 		return nil
 	})

--- a/pkg/linter/linter.go
+++ b/pkg/linter/linter.go
@@ -305,7 +305,7 @@ func worldWriteableLinter(ctx context.Context, pkgname string, fsys fs.FS) error
 		mode := info.Mode()
 		if mode&0002 != 0 {
 			if mode&0111 != 0 {
-				return fmt.Errorf("world-writeable executable file found in package (security risk): %s")
+				return fmt.Errorf("world-writeable executable file found in package (security risk): %s", path)
 			}
 			return fmt.Errorf("world-writeable file found in package: %s", path)
 		}

--- a/pkg/linter/linter.go
+++ b/pkg/linter/linter.go
@@ -90,12 +90,12 @@ var linterMap = map[string]linter{
 	"dev": {
 		LinterFunc:      allPaths(devLinter),
 		Explain:         "If this package is creating /dev nodes, it should use udev instead; otherwise, remove any files in /dev",
-		defaultBehavior: Warn,
+		defaultBehavior: Require,
 	},
 	"documentation": {
 		LinterFunc:      allPaths(documentationLinter),
 		Explain:         "Place documentation into a separate package or remove it",
-		defaultBehavior: Warn,
+		defaultBehavior: Ignore, // TODO: Lots of packages write to READMEs, etc.
 	},
 	"opt": {
 		LinterFunc:      allPaths(optLinter),
@@ -125,7 +125,7 @@ var linterMap = map[string]linter{
 	"tempdir": {
 		LinterFunc:      allPaths(tempDirLinter),
 		Explain:         "Remove any offending files in temporary dirs in the pipeline",
-		defaultBehavior: Warn,
+		defaultBehavior: Require,
 	},
 	"usrlocal": {
 		LinterFunc:      allPaths(usrLocalLinter),
@@ -135,7 +135,7 @@ var linterMap = map[string]linter{
 	"varempty": {
 		LinterFunc:      allPaths(varEmptyLinter),
 		Explain:         "Remove any offending files in /var/empty in the pipeline",
-		defaultBehavior: Warn,
+		defaultBehavior: Require,
 	},
 	"worldwrite": {
 		LinterFunc:      worldWriteableLinter,
@@ -150,12 +150,12 @@ var linterMap = map[string]linter{
 	"infodir": {
 		LinterFunc:      allPaths(infodirLinter),
 		Explain:         "Remove /usr/share/info/dir from the package (run split/infodir)",
-		defaultBehavior: Warn,
+		defaultBehavior: Require,
 	},
 	"empty": {
 		LinterFunc:      emptyLinter,
 		Explain:         "Verify that this package is supposed to be empty; if it is, disable this linter; otherwise check the build",
-		defaultBehavior: Warn,
+		defaultBehavior: Ignore, // TODO: Needs to ignore packages that specify no-provides.
 	},
 	"python/docs": {
 		LinterFunc:      pythonDocsLinter,
@@ -587,7 +587,11 @@ func LintAPK(ctx context.Context, path string, require, warn []string) error {
 
 	var r io.Reader
 	if strings.HasPrefix(path, "http://") || strings.HasPrefix(path, "https://") {
-		resp, err := http.Get(path)
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, path, nil)
+		if err != nil {
+			return fmt.Errorf("creating HTTP request: %w", err)
+		}
+		resp, err := http.DefaultClient.Do(req)
 		if err != nil {
 			return fmt.Errorf("getting apk %q: %w", path, err)
 		}


### PR DESCRIPTION
The ones upgraded to `Require` don't currently match any packages in Wolfi.

The ones downgraded to `Ignore` are noisy and problematic.

Also plumb through `ctx` to the HTTP request to get a remote APK.