### PR TITLE
Support multiple python imports

### DIFF
--- a/e2e-tests/py3-pandas-test.yaml
+++ b/e2e-tests/py3-pandas-test.yaml
@@ -14,5 +14,15 @@ test:
       packages:
         - busybox
   pipeline:
+    - uses: python/import
+      with:
+        imports: |
+          from numpy import ma
+          from pandas import DataFrame
+          import tzdata
+    - uses: python/import
+      with:
+        import: ma
+        from: numpy
     - runs: |
         python3 ./py3-pandas-test.py

--- a/pkg/build/pipelines/python/import.yaml
+++ b/pkg/build/pipelines/python/import.yaml
@@ -11,17 +11,70 @@ inputs:
     default: python3
   import:
     description: |
-      The package to import.
-    required: true
+      The package to import. Deprecated, use 'imports' instead.
+    required: false
   from:
     description: |
-      The package to import (from <from> import <import>).
+      The package to import from (used with 'from <from> import <import>'). Deprecated, use 'imports' instead.
+    required: false
+  imports:
+    description: |
+      Commands to import packages, each line is a separate command. Example:
+        from libfoo import bar
+        from asdf import otherthing
+        import bark
     required: false
 
 pipeline:
   - runs: |
-      if [ -n "${{inputs.from}}" ]; then
-        ${{inputs.python}} -c "from ${{inputs.from}} import ${{inputs.import}}"
+      PYTHON="${{inputs.python}}"
+      SINGLE_IMPORT="${{inputs.import}}"
+      MULTIPLE_IMPORTS="${{inputs.imports}}"
+      FROM_PKG="${{inputs.from}}"
+
+      perform_import() {
+        command="$1"
+        if $PYTHON -c "$command"; then
+          echo "\"$command\": PASS"
+        else
+          echo "\"$command\": FAIL"
+          return 1
+        fi
+      }
+
+      if [ -n "$SINGLE_IMPORT" ] && [ -n "$MULTIPLE_IMPORTS" ]; then
+        echo "Error: Cannot mix 'import' with 'imports'."
+        exit 1
+      fi
+      if [ -n "$FROM_PKG" ] && [ -n "$MULTIPLE_IMPORTS" ]; then
+        echo "Error: Cannot use 'from' with 'imports'."
+        exit 1
+      fi
+
+      fail_flag=0
+      if [ -n "$MULTIPLE_IMPORTS" ]; then
+        echo "$MULTIPLE_IMPORTS" | while IFS= read -r cmd
+        do
+          [ -z "$cmd" ] && continue
+          perform_import "$cmd" || fail_flag=1
+        done
+      elif [ -n "$FROM_PKG" ]; then
+        if [ -z "$SINGLE_IMPORT" ]; then
+          echo "Error: 'from' specified without 'import'."
+          exit 1
+        fi
+        command="from $FROM_PKG import $SINGLE_IMPORT"
+        perform_import "$command" || fail_flag=1
+      elif [ -n "$SINGLE_IMPORT" ]; then
+        perform_import "import $SINGLE_IMPORT" || fail_flag=1
       else
-        ${{inputs.python}} -c "import ${{inputs.import}}"
+        echo "No package specified for import."
+        fail_flag=1
+      fi
+
+      # Exit with non-zero status if any imports failed
+      if [ $fail_flag -eq 1 ]; then
+        exit 1
+      else
+        exit 0
       fi

--- a/pkg/build/pipelines/python/import.yaml
+++ b/pkg/build/pipelines/python/import.yaml
@@ -73,9 +73,4 @@ pipeline:
         fail_flag=1
       fi
 
-      # Exit with non-zero status if any imports failed
-      if [ $fail_flag -eq 1 ]; then
-        exit 1
-      else
-        exit 0
-      fi
+      exit $fail_flag

--- a/pkg/build/pipelines/python/import.yaml
+++ b/pkg/build/pipelines/python/import.yaml
@@ -40,7 +40,8 @@ pipeline:
           echo "\"$command\": FAIL"
           return 1
         fi
-      }
+      } 
+
 
       if [ -n "$SINGLE_IMPORT" ] && [ -n "$MULTIPLE_IMPORTS" ]; then
         echo "Error: Cannot mix 'import' with 'imports'."


### PR DESCRIPTION
cc/ @smoser @pnasrat 

Seems to work!

`make melange && export MELANGE=$PWD/melange && cd e2e-tests && ./run-tests py3-pandas-test.yaml`

```
2024/06/30 00:02:36 INFO running the main test pipeline
2024/06/30 00:02:36 INFO running step "Test a python package import, with optional from clause"
2024/06/30 00:02:36 INFO "from numpy import ma": PASS
2024/06/30 00:02:36 WARN /usr/lib/python3.12/site-packages/dateutil/zoneinfo/__init__.py:26: UserWarning: I/O error(2): No such file or directory
2024/06/30 00:02:36 WARN   warnings.warn("I/O error({0}): {1}".format(e.errno, e.strerror))
2024/06/30 00:02:36 INFO "from pandas import DataFrame": PASS
2024/06/30 00:02:36 INFO "import tzdata": PASS
2024/06/30 00:02:36 INFO running step "Test a python package import, with optional from clause"
2024/06/30 00:02:37 INFO "from numpy import ma": PASS
2024/06/30 00:02:37 WARN /usr/lib/python3.12/site-packages/dateutil/zoneinfo/__init__.py:26: UserWarning: I/O error(2): No such file or directory
2024/06/30 00:02:37 WARN   warnings.warn("I/O error({0}): {1}".format(e.errno, e.strerror))
PASS: py3-pandas-test.yaml
```