### PR TITLE
wolfictl bump : handled mangled vars in updateGitCheckout tags

### DIFF
--- a/pkg/renovate/bump/bump.go
+++ b/pkg/renovate/bump/bump.go
@@ -20,6 +20,7 @@ import (
 	"crypto/sha512"
 	"fmt"
 	"os"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -217,7 +218,8 @@ func updateGitCheckout(ctx context.Context, node *yaml.Node, expectedGitSha stri
 	if err != nil {
 		log.Infof("git-checkout node does not contain a tag, assume we need to update the expected-commit sha")
 	} else {
-		if !strings.Contains(tag.Value, "${{package.version}}") {
+		versionPattern := regexp.MustCompile(`\${{vars\..+}}`)
+		if !strings.Contains(tag.Value, "${{package.version}}") && !versionPattern.MatchString(tag.Value) {
 			log.Infof("Skipping git-checkout node as it does not contain a version substitution so assuming it is not the main checkout")
 			return nil
 		}

--- a/pkg/renovate/bump/testdata/minio.yaml
+++ b/pkg/renovate/bump/testdata/minio.yaml
@@ -1,0 +1,29 @@
+package:
+  name: minio
+  version: 0.20240628.090649
+  epoch: 0
+  description: Multi-Cloud Object Storage
+  copyright:
+    - license: AGPL-3.0-or-later
+
+environment:
+  contents:
+    packages:
+      - build-base
+      - busybox
+      - ca-certificates-bundle
+      - go
+      - perl
+
+var-transforms:
+  - from: ${{package.version}}
+    match: ^0\.(\d{4})(\d{2})(\d{2})\.(\d{2})(\d{2})(\d{2})$
+    replace: RELEASE.${1}-${2}-${3}T${4}-${5}-${6}Z
+    to: mangled-package-version
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/minio/minio
+      tag: ${{vars.mangled-package-version}}
+      expected-commit: aebac9001386b034e14cb7d5f1dbb8113831b3f7


### PR DESCRIPTION
Currently the wolfitcl renovate bumps are failing for git-checkout with mangled vars in the tags https://github.com/wolfi-dev/os/pull/22892 this should enable to handle the mangled vars in the checkout tags and correctly update the commit-sha