### PR TITLE
Revert "Use current user's ID when building via Docker"

### DIFF
--- a/pkg/container/docker/docker_runner.go
+++ b/pkg/container/docker/docker_runner.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"os/user"
 
 	"go.opentelemetry.io/otel"
 	"golang.org/x/sync/errgroup"
@@ -226,20 +225,8 @@ func (dk *docker) Run(ctx context.Context, cfg *mcontainer.Config, args ...strin
 		environ = append(environ, fmt.Sprintf("%s=%s", k, v))
 	}
 
-	// Default to the current user's UID
-	// Use a configured UID if it's not empty
-	currentUser, err := user.Current()
-	if err != nil {
-		return fmt.Errorf("failed to get current user: %w", err)
-	}
-
-	uid := currentUser.Uid
-	if cfg.RunAs != "" {
-		uid = cfg.RunAs
-	}
-
 	taskIDResp, err := dk.cli.ContainerExecCreate(ctx, cfg.PodID, container.ExecOptions{
-		User:         uid,
+		User:         cfg.RunAs,
 		Cmd:          args,
 		WorkingDir:   runnerWorkdir,
 		Env:          environ,


### PR DESCRIPTION
Reverts chainguard-dev/melange#1298

This broke a couple valid use cases, rolling back till we figure out a different fix for the original issue:

```
I'm hitting go: could not create module cache: mkdir /var/cache/melange: permission denied on my mac with v0.10.0 but building on a workstation with v0.10.0 works fine
I'm not able to test the openssh package locally with v0.10.0 but I can with v0.9.0 . The error I get with the test is No user exists for uid 501 (.. uid 1000 for the workstation)..
```