### PR TITLE
goreleaser pipeline: --skip flag refactor

### DIFF
--- a/pkg/build/pipelines/goreleaser/build.yaml
+++ b/pkg/build/pipelines/goreleaser/build.yaml
@@ -42,7 +42,7 @@ pipeline:
   - runs: |
       #!/bin/sh
       set -eux -o pipefail
-      goreleaser_flags="--clean --skip-docker --skip-ko --skip-publish ${{inputs.args}}"
+      goreleaser_flags="--clean --skip=docker,ko,publish ${{inputs.args}}"
 
       DIR="$(dirname '${{inputs.output}}')"
       mkdir -p $DIR

--- a/pkg/build/pipelines/goreleaser/build.yaml
+++ b/pkg/build/pipelines/goreleaser/build.yaml
@@ -11,6 +11,11 @@ inputs:
     description: |
       List of space-separated args to pass to the GoReleaser `release` command.
     required: false
+  skip:
+    description: |
+      List of comma-separated skip values to pass to the GoReleaser `release` command.
+    required: true
+    default: "docker,ko,publish"
   
   output:
     description: |
@@ -42,7 +47,7 @@ pipeline:
   - runs: |
       #!/bin/sh
       set -eux -o pipefail
-      goreleaser_flags="--clean --skip=docker,ko,publish ${{inputs.args}}"
+      goreleaser_flags="--clean --skip=${{inputs.skip}} ${{inputs.args}}"
 
       DIR="$(dirname '${{inputs.output}}')"
       mkdir -p $DIR


### PR DESCRIPTION
## Melange Pull Request Template

<!--
*** PULL REQUEST CHECKLIST: PLEASE START HERE ***

The single most important feature of melange is that we can build Wolfi.

Many changes to melange introduce a risk of breaking the build, and sometimes
these are not flushed out until a package is changed (much) later.  This
pertains to basic execution, SCA changes, linter changes, and more.
-->

### Functional Changes

- [ ] This change can build all of Wolfi without errors (describe results in notes)

Notes: goreleaser new version refactored the skip flags https://github.com/goreleaser/goreleaser/blob/9786269e109eabbfb6e7220f3133ebe2bf884179/www/docs/deprecations.md?plain=1#L241. We need to replace it with `--skip=docker,ko,publish`

### Linter

- [x] The new check is clean across Wolfi
- [ ] The new check is opt-in or a warning

Notes:
