### PR TITLE
fix: support build.arch in var transforms

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"sort"
 	"strconv"
 	"strings"
@@ -636,6 +637,7 @@ func buildConfigMap(cfg *Configuration) map[string]string {
 		SubstitutionPackageDescription: cfg.Package.Description,
 		SubstitutionPackageEpoch:       strconv.FormatUint(cfg.Package.Epoch, 10),
 		SubstitutionPackageFullVersion: fmt.Sprintf("%s-r%d", cfg.Package.Version, cfg.Package.Epoch),
+		SubstitutionBuildArch:          apko_types.ParseArchitecture(runtime.GOARCH).ToAPK(),
 	}
 
 	for k, v := range cfg.Vars {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/chainguard-dev/clog/slogtest"
@@ -44,6 +45,14 @@ var-transforms:
     match: ^(\d+\.\d+)\.\d+$
     replace: "$1"
     to: short-package-version
+  - from: ${{build.arch}}
+    match: 'x86_64'
+    replace: 'amd64'
+    to: mangled-arch
+  - from: ${{build.arch}}
+    match: 'aarch64'
+    replace: 'arm64'
+    to: mangled-arch
 
 subpackages:
   - name: subpackage-${{vars.short-package-version}}
@@ -58,6 +67,7 @@ subpackages:
         - subpackage-bar=${{vars.bar}}
       replaces:
         - james=${{package.name}}
+  - name: build-arch-${{vars.mangled-arch}}
 
 test:
   environment:
@@ -109,6 +119,8 @@ test:
 	}, cfg.Test.Environment.Contents.Packages)
 
 	require.Equal(t, cfg.Subpackages[0].Name, "subpackage-0.0")
+
+	require.Equal(t, cfg.Subpackages[1].Name, "build-arch-"+runtime.GOARCH)
 }
 
 func Test_rangeSubstitutions(t *testing.T) {

--- a/pkg/config/vars.go
+++ b/pkg/config/vars.go
@@ -61,7 +61,6 @@ func (cfg Configuration) GetVarsFromConfig() (map[string]string, error) {
 // Perform variable substitutions from the configuration on a given map
 func (cfg Configuration) PerformVarSubstitutions(nw map[string]string) error {
 	for _, v := range cfg.VarTransforms {
-		nk := fmt.Sprintf("${{vars.%s}}", v.To)
 		from, err := util.MutateStringFromMap(nw, v.From)
 		if err != nil {
 			return err
@@ -73,6 +72,7 @@ func (cfg Configuration) PerformVarSubstitutions(nw map[string]string) error {
 		}
 
 		output := re.ReplaceAllString(from, v.Replace)
+		nk := fmt.Sprintf("${{vars.%s}}", v.To)
 		nw[nk] = output
 	}
 


### PR DESCRIPTION
Previously this failed with 

```
applying variable substitutions: variable build.arch not defined
```