### PR TITLE
python/import - fix a bug in 'imports', do not require specifying python

### DIFF
--- a/e2e-tests/py3-setuptools-test.yaml
+++ b/e2e-tests/py3-setuptools-test.yaml
@@ -1,0 +1,18 @@
+package:
+  name: py3-setuptools
+  version: 70.2.0
+  epoch: 1
+  description: tests of setuptools
+  copyright:
+    - license: 'BSD-3-Clause'
+
+pipeline:
+
+test:
+  pipeline:
+    - uses: python/import
+      with:
+        imports: |
+          # this is a full line comment
+          import setuptools
+          from setuptools import version # inline comment

--- a/pkg/build/pipelines/python/import.yaml
+++ b/pkg/build/pipelines/python/import.yaml
@@ -7,8 +7,7 @@ needs:
 inputs:
   python:
     description: Which python to use
-    required: true
-    default: python3
+    default: DEFAULT
   import:
     description: |
       The package to import. Deprecated, use 'imports' instead.
@@ -21,12 +20,16 @@ inputs:
     description: |
       Commands to import packages, each line is a separate command. Example:
         from libfoo import bar
+        # test that otherthing can be imported from asdf
         from asdf import otherthing
-        import bark
+        import bark # this is like woof
+
+      full-line and inline comments are supported via '#'
     required: false
 
 pipeline:
   - runs: |
+      set +x
       PYTHON="${{inputs.python}}"
       SINGLE_IMPORT="${{inputs.import}}"
       MULTIPLE_IMPORTS="${{inputs.imports}}"
@@ -35,13 +38,28 @@ pipeline:
       perform_import() {
         command="$1"
         if $PYTHON -c "$command"; then
-          echo "\"$command\": PASS"
+          echo "$PYTHON -c \"$command\": PASS"
         else
-          echo "\"$command\": FAIL"
+          echo "$PYTHON -c \"$command\": FAIL"
           return 1
         fi
-      } 
+      }
 
+      if [ "$PYTHON" = "DEFAULT" ]; then
+          glob=/usr/bin/python3.[0-9][0-9]
+          n=0
+          for p in $glob; do
+            [ -x "$p" ] && n=$((n+1))
+          done
+          if [ "$n" -ne 1 ]; then
+            echo "FAIL: must set inputs.python: " \
+               "found $n executables matching $glob"
+            [ "$n" -eq 0 ] || echo "found:" $glob
+            exit 1
+          fi
+          echo "using python $p"
+          PYTHON=$p
+      fi
 
       if [ -n "$SINGLE_IMPORT" ] && [ -n "$MULTIPLE_IMPORTS" ]; then
         echo "Error: Cannot mix 'import' with 'imports'."
@@ -54,11 +72,18 @@ pipeline:
 
       fail_flag=0
       if [ -n "$MULTIPLE_IMPORTS" ]; then
-        echo "$MULTIPLE_IMPORTS" | while IFS= read -r cmd
-        do
+        importf=$(mktemp) || { echo "failed mktemp"; exit 1; }
+        printf "%s\n" "$MULTIPLE_IMPORTS" > "$importf" ||
+            { echo "failed to write to temp file"; exit 1; }
+
+        while read line; do
+          # Drop anything after #
+          line=${line%%#*}
+          cmd=$(set -f; echo $line) # normalize/trim whitespace
           [ -z "$cmd" ] && continue
           perform_import "$cmd" || fail_flag=1
-        done
+        done < "$importf"
+        rm -f "$importf"
       elif [ -n "$FROM_PKG" ]; then
         if [ -z "$SINGLE_IMPORT" ]; then
           echo "Error: 'from' specified without 'import'."


### PR DESCRIPTION
The following things here:
a. fix a bug that hid failure of a 'imports'
   This demonstrates the failure:

      sh -c 'fails=0; echo foo |
         while read line; do fails=$((fails+1)); echo "$fails"; done
         echo fails=$fails
         exit $fails'

   The right side of the pipeline runs in a subshell that does not
   affect the setting of 'fails' in the parent shell.

b. do not require specifying 'python' but rather use
   /usr/bin/python3.* if and only if there is only one matching
   executable.

   This is needed for new packages built that do not depend
   on python3.XX, but instead only python3.XX-base.  The latter
   does not install 'python3' symlink, so you can't just default
   to python3.

   Add a test here as py3-setuptools-test to cover this.

c. be more quiet (set +x) - otherwise output gets written to
   stderr and is very noisy with WARN messages everywhere making
   it harder to read.

d. support comments in the multiline 'imports' syntax

e. print the command executed (python -c 'thing') rather than
   just the 'import string'

## Melange Pull Request Template

<!--
*** PULL REQUEST CHECKLIST: PLEASE START HERE ***

The single most important feature of melange is that we can build Wolfi.

Many changes to melange introduce a risk of breaking the build, and sometimes
these are not flushed out until a package is changed (much) later.  This
pertains to basic execution, SCA changes, linter changes, and more.
-->

### Functional Changes

- [ ] This change can build all of Wolfi without errors (describe results in notes)

Notes:

### SCA Changes

- [ ] Examining several representative APKs show no regression / the desired effect (details in notes)

Notes:

### Linter

- [ ] The new check is clean across Wolfi
- [ ] The new check is opt-in or a warning

Notes:
