### PR TITLE
python/import pipeline - find python3.7, python3.8, python3.9

### DIFF
--- a/pkg/build/pipelines/python/import.yaml
+++ b/pkg/build/pipelines/python/import.yaml
@@ -46,10 +46,10 @@ pipeline:
       }
 
       if [ "$PYTHON" = "DEFAULT" ]; then
-          glob=/usr/bin/python3.[0-9][0-9]
+          glob="/usr/bin/python3.[0-9][0-9] /usr/bin/python3.[789]"
           n=0
           for p in $glob; do
-            [ -x "$p" ] && n=$((n+1))
+            [ -x "$p" ] && n=$((n+1)) && py=$p
           done
           if [ "$n" -ne 1 ]; then
             echo "FAIL: must set inputs.python: " \
@@ -57,8 +57,8 @@ pipeline:
             [ "$n" -eq 0 ] || echo "found:" $glob
             exit 1
           fi
-          echo "using python $p"
-          PYTHON=$p
+          echo "using python $py"
+          PYTHON=$py
       fi
 
       if [ -n "$SINGLE_IMPORT" ] && [ -n "$MULTIPLE_IMPORTS" ]; then


### PR DESCRIPTION
These python versions may be found in the wild, but the previous pull request would not have 'seen' them in /usr/bin.

Things older than python3.7 are intentionally not matched.

