### PR TITLE
python/pipelines - resolve symlink to full path.

### DIFF
--- a/pkg/build/pipelines/python/build-wheel.yaml
+++ b/pkg/build/pipelines/python/build-wheel.yaml
@@ -5,6 +5,7 @@ needs:
     - busybox
     - py3-build
     - py3-installer
+    - python3
 
 pipeline:
   - runs: |
@@ -14,6 +15,12 @@ pipeline:
       fi
 
   - runs: |
-      python3 -m build
-      python3 -m installer -d "${{targets.contextdir}}" dist/*.whl
+      python=python3
+      if p=$(command -v $python) && [ -L "$p" ]; then
+        python=$(readlink -f "$p") ||
+          { echo "failed 'readlink -f $p'"; exit 1; }
+      fi
+
+      $python -m build
+      $python -m installer -d "${{targets.contextdir}}" dist/*.whl
       find ${{targets.contextdir}} -name "*.pyc" -exec rm -rf '{}' +

--- a/pkg/build/pipelines/python/build.yaml
+++ b/pkg/build/pipelines/python/build.yaml
@@ -3,6 +3,7 @@ name: Build a Python wheel
 needs:
   packages:
     - busybox
+    - python3
 
 pipeline:
   - runs: |
@@ -12,4 +13,10 @@ pipeline:
       fi
 
   - runs: |
-      python setup.py build
+      python=python
+      if p=$(command -v $python) && [ -L "$p" ]; then
+        python=$(readlink -f "$p") ||
+          { echo "failed 'readlink -f $p'"; exit 1; }
+      fi
+
+      $python setup.py build

--- a/pkg/build/pipelines/python/install.yaml
+++ b/pkg/build/pipelines/python/install.yaml
@@ -3,6 +3,7 @@ name: Install a Python package
 needs:
   packages:
     - busybox
+    - python3
 
 pipeline:
   - runs: |
@@ -12,4 +13,10 @@ pipeline:
       fi
 
   - runs: |
-      python setup.py install --prefix=/usr --root="${{targets.contextdir}}"
+      python=python
+      if p=$(command -v $python) && [ -L "$p" ]; then
+        python=$(readlink -f "$p") ||
+          { echo "failed 'readlink -f $p'"; exit 1; }
+      fi
+
+      $python setup.py install --prefix=/usr --root="${{targets.contextdir}}"


### PR DESCRIPTION
Running 'python3 -m installer my.whl' (as gets done in build-wheel) will write shebang lines with 'python3'.

The melange SCA is ignoring symlinks in shebang at the moment, so it will not create any dependencies for that.

The larger problem here is that the python package that installs /usr/bin/foo with a shebang '#!/usr/bin/python3' will get a dependency in the SCA on python3.12-base (due to the site-packages python files), but the 'python3' may end up being python3.11. That situation would end up with broken /usr/bin/foo.

I chose to take the least invasive path here, and only change behavior when the 'python3' in the PATH is a symlink.

I *also* left the build and install pipelines calling 'python' rather than 'python3'.  I do not like that, but did not want to change it here.

