### PR TITLE
Fix env overrides for interactive builds

### DIFF
--- a/pkg/build/pipeline_test.go
+++ b/pkg/build/pipeline_test.go
@@ -15,7 +15,6 @@
 package build
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -143,13 +142,10 @@ func Test_buildEvalRunCommand(t *testing.T) {
 	}
 
 	debugOption := 'x'
-	sysPath := "/foo"
 	workdir := "/bar"
 	fragment := "baz"
-	command := buildEvalRunCommand(context.Background(), p, debugOption, sysPath, workdir, fragment, false)
+	command := buildEvalRunCommand(p, debugOption, workdir, fragment)
 	expected := []string{"/bin/sh", "-c", `set -ex
-export PATH='/foo'
-export FOO='bar'
 [ -d '/bar' ] || mkdir -p '/bar'
 cd '/bar'
 baz

--- a/pkg/container/docker/docker_runner.go
+++ b/pkg/container/docker/docker_runner.go
@@ -215,13 +215,16 @@ func (dk *docker) waitForCommand(ctx context.Context, r io.Reader) error {
 
 // Run runs a Docker task given a Config and command string.
 // The resultant filesystem can be read from the io.ReadCloser
-func (dk *docker) Run(ctx context.Context, cfg *mcontainer.Config, args ...string) error {
+func (dk *docker) Run(ctx context.Context, cfg *mcontainer.Config, envOverride map[string]string, args ...string) error {
 	if cfg.PodID == "" {
 		return fmt.Errorf("pod not running")
 	}
 
 	environ := []string{}
 	for k, v := range cfg.Environment {
+		environ = append(environ, fmt.Sprintf("%s=%s", k, v))
+	}
+	for k, v := range envOverride {
 		environ = append(environ, fmt.Sprintf("%s=%s", k, v))
 	}
 
@@ -263,13 +266,16 @@ func (dk *docker) Run(ctx context.Context, cfg *mcontainer.Config, args ...strin
 	}
 }
 
-func (dk *docker) Debug(ctx context.Context, cfg *mcontainer.Config, args ...string) error {
+func (dk *docker) Debug(ctx context.Context, cfg *mcontainer.Config, envOverride map[string]string, args ...string) error {
 	if cfg.PodID == "" {
 		return fmt.Errorf("pod not running")
 	}
 
 	environ := []string{}
 	for k, v := range cfg.Environment {
+		environ = append(environ, fmt.Sprintf("%s=%s", k, v))
+	}
+	for k, v := range envOverride {
 		environ = append(environ, fmt.Sprintf("%s=%s", k, v))
 	}
 

--- a/pkg/container/runner.go
+++ b/pkg/container/runner.go
@@ -24,7 +24,7 @@ import (
 )
 
 type Debugger interface {
-	Debug(context.Context, *Config, ...string) error
+	Debug(ctx context.Context, cfg *Config, envOverride map[string]string, cmd ...string) error
 }
 
 type Runner interface {
@@ -36,7 +36,7 @@ type Runner interface {
 	// as a tar stream into the Loader. That image will be used as the root when StartPod() the container.
 	OCIImageLoader() Loader
 	StartPod(ctx context.Context, cfg *Config) error
-	Run(ctx context.Context, cfg *Config, cmd ...string) error
+	Run(ctx context.Context, cfg *Config, envOverride map[string]string, cmd ...string) error
 	TerminatePod(ctx context.Context, cfg *Config) error
 	// TempDir returns the base for temporary directory, or "" if whatever is provided by the system is fine
 	TempDir() string


### PR DESCRIPTION
Fixes https://github.com/chainguard-dev/melange/issues/1359

For reasons I don't understand, the bubblewrap runner would not have $PATH set in interactive builds. The way we were setting PATH was to prepend it to the shell script we execute for each step, which is kind of janky. I've shifted things around to make that overriding of the environment happen in go via arguments rather than at runtime.

This does break the ability for pipeline-specified environment variables to be evaluated at runtime, but that is actually terrifying and I don't think we want that.