### PR TITLE
Add update.exclude-reason field.

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -490,6 +490,8 @@ type Update struct {
 	GitHubMonitor *GitHubMonitor `json:"github,omitempty" yaml:"github,omitempty"`
 	// The configuration block for transforming the `package.version` into an APK version
 	VersionTransform []VersionTransform `json:"version-transform,omitempty" yaml:"version-transform,omitempty"`
+	// ExcludeReason is required if enabled=false, to explain why updates are disabled.
+	ExcludeReason string `json:"exclude-reason,omitempty" yaml:"exclude-reason,omitempty"`
 }
 
 // ReleaseMonitor indicates using the API for https://release-monitoring.org/

--- a/pkg/config/schema.json
+++ b/pkg/config/schema.json
@@ -906,6 +906,10 @@
           },
           "type": "array",
           "description": "The configuration block for transforming the `package.version` into an APK version"
+        },
+        "exclude-reason": {
+          "type": "string",
+          "description": "ExcludeReason is required if enabled=false, to explain why updates are disabled."
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
## Melange Pull Request Template

<!--
*** PULL REQUEST CHECKLIST: PLEASE START HERE ***

The single most important feature of melange is that we can build Wolfi.

Many changes to melange introduce a risk of breaking the build, and sometimes
these are not flushed out until a package is changed (much) later.  This
pertains to basic execution, SCA changes, linter changes, and more.
-->

Adds ExcludeReason field for tracking why package auto updates are disabled.

Part of https://github.com/chainguard-dev/mono/issues/18290

### Functional Changes

- [x] This change can build all of Wolfi without errors (describe results in notes)

Notes:

This change does nothing on it's own. Linting rules will be added to wolfictl in another PR.

### SCA Changes

- [ ] Examining several representative APKs show no regression / the desired effect (details in notes)

Notes:

### Linter

- [ ] The new check is clean across Wolfi
- [ ] The new check is opt-in or a warning

Notes:

IIUC (somewhat confusingly), melange lint lints apks, wolfictl lint lints melange configs, so the corresponding lint rule should be added in wolfictl.
