### PR TITLE
Expose ignoreSignatures functionality

### DIFF
--- a/docs/md/melange_build.md
+++ b/docs/md/melange_build.md
@@ -44,6 +44,7 @@ melange build [flags]
       --generate-index                                          whether to generate APKINDEX.tar.gz (default true)
       --guest-dir string                                        directory used for the build environment guest
   -h, --help                                                    help for build
+      --ignore-signatures                                       ignore repository signature verification
   -i, --interactive                                             when enabled, attaches stdin with a tty to the pod on failure
   -k, --keyring-append strings                                  path to extra keys to include in the build environment keyring
       --lint-require strings                                    linters that must pass (default [dev,infodir,tempdir,varempty])

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -98,6 +98,7 @@ type Build struct {
 	DefaultMemory         string
 	DefaultTimeout        time.Duration
 	Auth                  map[string]options.Auth
+	IgnoreSignatures      bool
 
 	EnabledBuildOptions []string
 
@@ -253,7 +254,8 @@ func (b *Build) BuildGuest(ctx context.Context, imgConfig apko_types.ImageConfig
 		apko_build.WithExtraBuildRepos(b.ExtraRepos),
 		apko_build.WithExtraPackages(b.ExtraPackages),
 		apko_build.WithCacheDir(b.ApkCacheDir, false), // TODO: Replace with real offline plumbing
-		apko_build.WithTempDir(tmp))
+		apko_build.WithTempDir(tmp),
+		apko_build.WithIgnoreSignatures(b.IgnoreSignatures))
 
 	if err != nil {
 		return "", fmt.Errorf("unable to create build context: %w", err)

--- a/pkg/build/options.go
+++ b/pkg/build/options.go
@@ -369,3 +369,11 @@ func WithLibcFlavorOverride(libc string) Option {
 		return nil
 	}
 }
+
+// WithIgnoreIndexSignatures sets whether to ignore repository signature verification.
+func WithIgnoreSignatures(ignore bool) Option {
+	return func(b *Build) error {
+		b.IgnoreSignatures = ignore
+		return nil
+	}
+}

--- a/pkg/build/test.go
+++ b/pkg/build/test.go
@@ -65,6 +65,7 @@ type Test struct {
 	DebugRunner       bool
 	Interactive       bool
 	Auth              map[string]options.Auth
+	IgnoreSignatures  bool
 }
 
 func NewTest(ctx context.Context, opts ...TestOption) (*Test, error) {

--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -75,6 +75,7 @@ func buildCmd() *cobra.Command {
 	var extraPackages []string
 	var libc string
 	var lintRequire, lintWarn []string
+	var ignoreSignatures bool
 
 	var traceFile string
 
@@ -154,6 +155,7 @@ func buildCmd() *cobra.Command {
 				build.WithMemory(memory),
 				build.WithTimeout(timeout),
 				build.WithLibcFlavorOverride(libc),
+				build.WithIgnoreSignatures(ignoreSignatures),
 			}
 
 			if len(args) > 0 {
@@ -219,6 +221,7 @@ func buildCmd() *cobra.Command {
 	cmd.Flags().StringVar(&traceFile, "trace", "", "where to write trace output")
 	cmd.Flags().StringSliceVar(&lintRequire, "lint-require", linter.DefaultRequiredLinters(), "linters that must pass")
 	cmd.Flags().StringSliceVar(&lintWarn, "lint-warn", linter.DefaultWarnLinters(), "linters that will generate warnings")
+	cmd.Flags().BoolVar(&ignoreSignatures, "ignore-signatures", false, "ignore repository signature verification")
 
 	_ = cmd.Flags().Bool("fail-on-lint-warning", false, "DEPRECATED: DO NOT USE")
 	_ = cmd.Flags().MarkDeprecated("fail-on-lint-warning", "use --lint-require and --lint-warn instead")


### PR DESCRIPTION
## Melange Pull Request Template

Expose ignoreSignatures functionality from apko to melange CLI clients.
Follow up for this PR: https://github.com/chainguard-dev/apko/pull/1179

### Functional Changes

- [ ] This change can build all of Wolfi without errors (describe results in notes)

Notes: I've run the full test suite locally without issue, but do not see wolfi as an E2E test case, so leaving this unchecked as unable to verify.

### SCA Changes

- [ ] Examining several representative APKs show no regression / the desired effect (details in notes)

Notes: E2E test suite passes. Was also able to build an custom APK locally without issues.

### Linter

- [x] The new check is clean across Wolfi
- [ ] The new check is opt-in or a warning

Notes: Linter checks passed locally as well
