### PR TITLE
fix(pipelines): Use contextdir instead of destdir in a few places

### DIFF
--- a/pkg/build/pipelines/npm/install.yaml
+++ b/pkg/build/pipelines/npm/install.yaml
@@ -19,7 +19,7 @@ inputs:
   prefix:
     description: |
       The -prefix argument to pass to npm install; where /bin and /lib will be copied to.
-    default: "${{targets.destdir}}/usr/"
+    default: "${{targets.contextdir}}/usr/"
 
   overrides:
     description: |

--- a/pkg/build/pipelines/pecl/install.yaml
+++ b/pkg/build/pipelines/pecl/install.yaml
@@ -12,6 +12,6 @@ inputs:
 
 pipeline:
   - runs: |
-      make INSTALL_ROOT="${{targets.destdir}}" install
-      install -d ${{targets.destdir}}/etc/php/conf.d
-      echo "extension=${{inputs.extension}}.so" > ${{targets.destdir}}/etc/php/conf.d/${{inputs.extension}}.ini
+      make INSTALL_ROOT="${{targets.contextdir}}" install
+      install -d ${{targets.contextdir}}/etc/php/conf.d
+      echo "extension=${{inputs.extension}}.so" > ${{targets.contextdir}}/etc/php/conf.d/${{inputs.extension}}.ini

--- a/pkg/build/pipelines/perl/cleanup.yaml
+++ b/pkg/build/pipelines/perl/cleanup.yaml
@@ -6,4 +6,4 @@ needs:
 
 pipeline:
   - runs: |
-      find "${{targets.destdir}}" \( -name perllocal.pod -o -name .packlist \) -delete
+      find "${{targets.contextdir}}" \( -name perllocal.pod -o -name .packlist \) -delete

--- a/pkg/build/pipelines/ruby/clean.yaml
+++ b/pkg/build/pipelines/ruby/clean.yaml
@@ -12,6 +12,6 @@ pipeline:
         exit 1
       fi
   - runs: |
-      INSTALL_DIR=${{targets.destdir}}/$(ruby -e 'puts Gem.default_dir')
+      INSTALL_DIR=${{targets.contextdir}}/$(ruby -e 'puts Gem.default_dir')
       rm -rf ${INSTALL_DIR}/build_info \
              ${INSTALL_DIR}/cache


### PR DESCRIPTION
A few of these pipelines could otherwise be used in subpackages if they defaulted to contextdir instead of destdir. I'd imagine they already may be used in some, but no-op

## Melange Pull Request Template

<!--
*** PULL REQUEST CHECKLIST: PLEASE START HERE ***

The single most important feature of melange is that we can build Wolfi.

Many changes to melange introduce a risk of breaking the build, and sometimes
these are not flushed out until a package is changed (much) later.  This
pertains to basic execution, SCA changes, linter changes, and more.
-->

### Functional Changes

- [ ] This change can build all of Wolfi without errors (describe results in notes)

Notes:

### SCA Changes

- [ ] Examining several representative APKs show no regression / the desired effect (details in notes)

Notes:

### Linter

- [ ] The new check is clean across Wolfi
- [ ] The new check is opt-in or a warning

Notes:
