### PR TITLE
fix(sca): Correctly check for existing Ruby runtime dependency

### DIFF
--- a/pkg/sca/sca.go
+++ b/pkg/sca/sca.go
@@ -607,7 +607,7 @@ func generateRubyDeps(ctx context.Context, hdl SCAHandle, generated *config.Depe
 		}
 
 		// This takes the X.Y part of the ruby/gems/X.Y.Z directory name as the version to pin against.
-		// If the X.Y part is not present, then rubyModuleVer will remain an empty string and
+		// If the X.Y part is not present, then rubyGemVer will remain an empty string and
 		// no dependency will be generated.
 		rubyGemVer = basename[:3]
 		return nil
@@ -622,8 +622,13 @@ func generateRubyDeps(ctx context.Context, hdl SCAHandle, generated *config.Depe
 
 	// Do not add a Ruby dependency if one already exists.
 	for _, dep := range hdl.BaseDependencies().Runtime {
-		if strings.HasPrefix(dep, "ruby") {
+		if strings.HasPrefix(dep, "ruby-") {
 			log.Warnf("%s: Ruby dependency %q already specified, consider removing it in favor of SCA-generated dependency", hdl.PackageName(), dep)
+			return nil
+		}
+
+		if dep == "ruby" {
+			log.Warnf("%s: Ruby dependency already specified", hdl.PackageName())
 			return nil
 		}
 	}


### PR DESCRIPTION
With Python, we can get away with checking for the "python" prefix in the package name as all other Python packages are prefixed with py<X.Y> instead of "python". For Ruby however, main Ruby packages follow a "ruby-<X.Y>" syntax and Ruby packages are "ruby<X.Y>"

This addresses the above by checking for "ruby-" instead of "ruby". In case a package explicitly sets "ruby" as a runtime dependency to pull in the latest version, we just skip over it

### SCA Changes

- [x] Examining several representative APKs show no regression / the desired effect (details in notes)

Notes: Ran against packages without a versioned Ruby rt dep, ran with it set, and ran with just `ruby` set