### PR TITLE
Update doc comment for copyright.paths

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -254,7 +254,7 @@ func (cfg *Configuration) applySubstitutionsForPackages() error {
 }
 
 type Copyright struct {
-	// Optional: The license paths, typically '*'
+	// Optional: Paths the license applies to, typically '*'
 	Paths []string `json:"paths,omitempty" yaml:"paths,omitempty"`
 	// Optional: Attestations of the license
 	Attestation string `json:"attestation,omitempty" yaml:"attestation,omitempty"`


### PR DESCRIPTION
Paths seems very similar in description to LicensePath, but reading its usage this looks like it's really the paths a license applies to?