### PR TITLE
fix: ignore resource requests for the docker runner

### DIFF
--- a/pkg/container/docker/docker_runner.go
+++ b/pkg/container/docker/docker_runner.go
@@ -39,7 +39,6 @@ import (
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/empty"
 	image_spec "github.com/opencontainers/image-spec/specs-go/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 var _ mcontainer.Debugger = (*docker)(nil)
@@ -98,23 +97,7 @@ func (dk *docker) StartPod(ctx context.Context, cfg *mcontainer.Config) error {
 	}
 
 	hostConfig := &container.HostConfig{
-		Mounts:    mounts,
-		Resources: container.Resources{},
-	}
-
-	if cfg.CPU != "" {
-		res, err := resource.ParseQuantity(cfg.CPU)
-		if err != nil {
-			return fmt.Errorf("parsing CPU resource: %w", err)
-		}
-		hostConfig.Resources.NanoCPUs = int64(res.AsApproximateFloat64() * 1000000000)
-	}
-	if cfg.Memory != "" {
-		res, err := resource.ParseQuantity(cfg.Memory)
-		if err != nil {
-			return fmt.Errorf("parsing memory resource: %w", err)
-		}
-		hostConfig.Resources.Memory = res.Value()
+		Mounts: mounts,
 	}
 
 	platform := &image_spec.Platform{


### PR DESCRIPTION
We use the `resources:` block to tell us what resources to give it when we run the build in a K8s pod (via wolfictl)

It's been causing problems for the docker runner though, since some builds may request more resources than the local machine has, which fails the build.

This change drops support for resource requests in the docker runner, and as far as Melange is concerned, the resources block is now just informational. It's up to `wolfictl build` to make actual use of it.