### PR TITLE
move 'adding package %q for pipeline %q' to debug logging

### DIFF
--- a/pkg/build/compile.go
+++ b/pkg/build/compile.go
@@ -353,7 +353,7 @@ func (c *Compiled) gatherDeps(ctx context.Context, pipeline *config.Pipeline) er
 
 	if pipeline.Needs != nil {
 		for _, pkg := range pipeline.Needs.Packages {
-			log.Infof("  adding package %q for pipeline %q", pkg, id)
+			log.Debugf("  adding package %q for pipeline %q", pkg, id)
 		}
 		c.Needs = append(c.Needs, pipeline.Needs.Packages...)
 


### PR DESCRIPTION
This is extra spammy when we're loading lots of configs, like we do to construct a build graph.