### PR TITLE
Add test to catch duplicate package names

### DIFF
--- a/pkg/build/build_test.go
+++ b/pkg/build/build_test.go
@@ -185,6 +185,12 @@ func TestConfiguration_Load(t *testing.T) {
 			expected:            nil,
 		},
 		{
+			name:                "invalid-duplicate-package-name",
+			skipConfigCleanStep: true,
+			requireErr:          requireErrInvalidConfiguration,
+			expected:            nil,
+		},
+		{
 			name:                "env-vars-set-that-have-default-values",
 			skipConfigCleanStep: true,
 			requireErr:          require.NoError,

--- a/pkg/build/testdata/configuration_load/invalid-duplicate-package-name.melange.yaml
+++ b/pkg/build/testdata/configuration_load/invalid-duplicate-package-name.melange.yaml
@@ -1,0 +1,6 @@
+package:
+  name: hello
+  version: 1.2.3
+
+subpackages:
+  - name: hello

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1157,11 +1157,20 @@ func (cfg Configuration) validate() error {
 		return ErrInvalidConfiguration{Problem: err}
 	}
 
-	saw := map[string]int{}
+	saw := map[string]int{cfg.Package.Name: -1}
 	for i, sp := range cfg.Subpackages {
 		if extant, ok := saw[sp.Name]; ok {
-			return fmt.Errorf("saw duplicate subpackage name %q (subpackages index: %d and %d)", sp.Name, extant, i)
+			if extant == -1 {
+				return ErrInvalidConfiguration{
+					Problem: fmt.Errorf("subpackage[%d] has same name as main package: %q", i, sp.Name),
+				}
+			} else {
+				return ErrInvalidConfiguration{
+					Problem: fmt.Errorf("saw duplicate subpackage name %q (subpackages index: %d and %d)", sp.Name, extant, i),
+				}
+			}
 		}
+
 		saw[sp.Name] = i
 
 		if !packageNameRegex.MatchString(sp.Name) {


### PR DESCRIPTION
We had a test for duplicate subpackages names, but it didn't catch the case where a subpackage had the same name as the main package.