### PR TITLE
melange convert python: use normalized names

### DIFF
--- a/pkg/convert/python/python.go
+++ b/pkg/convert/python/python.go
@@ -193,8 +193,8 @@ func normalizeName(packageName string) string {
 	// Normalize python packaging names
 	// See https://packaging.python.org/en/latest/specifications/name-normalization/#name-normalization
 	re := regexp.MustCompile("[-_.]+")
-    name := strings.ToLower(re.ReplaceAllString(packageName, "-"))
-    return name
+	name := strings.ToLower(re.ReplaceAllString(packageName, "-"))
+	return name
 }
 
 func stripDep(dep string) (string, error) {
@@ -219,7 +219,7 @@ func (c *PythonContext) findDep(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-    p.Info.Name = normalizeName(p.Info.Name)
+	p.Info.Name = normalizeName(p.Info.Name)
 
 	log.Infof("[%s] %s Add to generate list", c.ToCheck[0], p.Info.Name)
 	c.ToCheck = c.ToCheck[1:]
@@ -240,7 +240,7 @@ func (c *PythonContext) findDep(ctx context.Context) error {
 			continue
 		}
 		dep, err = stripDep(dep)
-        dep = normalizeName(dep)
+		dep = normalizeName(dep)
 		if err != nil {
 			return err
 		}

--- a/pkg/convert/python/python_test.go
+++ b/pkg/convert/python/python_test.go
@@ -263,7 +263,7 @@ func GetJsonsPackagesForPackage(packageName string) ([]string, error) {
 	if packageName == "botocore" {
 		return []string{"botocore", "jmespath", "python-dateutil", "urllib3", "six"}, nil
 	} else if packageName == "jsonschema" {
-		return []string{"jsonschema", "attrs", "importlib-metadata", "importlib-resources", "pkgutil_resolve_name", "pyrsistent", "typing-extensions", "zipp"}, nil
+		return []string{"jsonschema", "attrs", "importlib-metadata", "importlib-resources", "pkgutil-resolve-name", "pyrsistent", "typing-extensions", "zipp"}, nil
 	} else if packageName == "typing-extensions" {
 		return []string{"typing-extensions"}, nil
 	}


### PR DESCRIPTION
without this we try to add py3-Jinja2 or py3-MarkupSafe each time

Signed-off-by: Pris Nasrat <pris.nasrat@chainguard.dev>
