### PR TITLE
if-arch: only run the pipeline if runtime arch matches

### DIFF
--- a/.github/workflows/wolfi-presubmit.yaml
+++ b/.github/workflows/wolfi-presubmit.yaml
@@ -152,5 +152,4 @@ jobs:
             --advisories-repo-dir 'data/wolfi-advisories' \
             --advisory-filter 'resolved' \
             --require-zero \
-            packages/x86_64/${{ matrix.package }}-*.apk \
-            2> /dev/null # The error message renders strangely on GitHub Actions, and the important information is already being sent to stdout.
+            packages/x86_64/${{ matrix.package }}-*.apk

--- a/examples/if-arch.yaml
+++ b/examples/if-arch.yaml
@@ -1,0 +1,39 @@
+package:
+  name: if-arch
+  version: 0.0.1
+  epoch: 0
+  description: "an example of how if-arch works"
+  copyright:
+    - license: Not-Applicable
+
+environment:
+  contents:
+    repositories:
+      - https://packages.wolfi.dev/os
+    keyring:
+      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    packages:
+      - busybox
+
+pipeline:
+  - if-arch: x86_64
+    runs: |
+      echo "build arch is x86_64!"
+
+  - if-arch: aarch64
+    runs: |
+      echo "build arch is aarch64!"
+
+  - if-arch: amd64
+    runs: |
+      echo "OCI-style arch name for x86_64!"
+
+  - if-arch: arm64
+    runs: |
+      echo "OCI-style arch name for aarch64!"
+
+  # This shouldn't run, since the arch isn't valid
+  - if-arch: bad-architecture-name
+    runs: |
+      echo "BAD ARCHITECTURE"
+      exit 1

--- a/pkg/build/pipeline.go
+++ b/pkg/build/pipeline.go
@@ -172,6 +172,7 @@ func (r *pipelineRunner) runPipeline(ctx context.Context, pipeline *config.Pipel
 
 	if pipeline.IfArch != "" && pipeline.IfArch != r.config.Arch {
 		log.Infof("skipping pipeline %q because it is not for arch %q", identity(pipeline), r.config.Arch)
+		return false, nil
 	}
 
 	if result, err := shouldRun(pipeline.If); !result {
@@ -219,6 +220,11 @@ func (r *pipelineRunner) runPipeline(ctx context.Context, pipeline *config.Pipel
 	steps := 0
 
 	for _, p := range pipeline.Pipeline {
+		if p.IfArch != "" && p.IfArch != r.config.Arch {
+			log.Infof("skipping pipeline %q because it is not for arch %q", identity(p), r.config.Arch)
+			continue
+		}
+
 		if ran, err := r.runPipeline(ctx, &p); err != nil {
 			return false, fmt.Errorf("unable to run pipeline: %w", err)
 		} else if ran {

--- a/pkg/build/pipeline.go
+++ b/pkg/build/pipeline.go
@@ -170,8 +170,12 @@ type pipelineRunner struct {
 func (r *pipelineRunner) runPipeline(ctx context.Context, pipeline *config.Pipeline) (bool, error) {
 	log := clog.FromContext(ctx)
 
+	if pipeline.IfArch != "" && pipeline.IfArch != r.config.Arch {
+		log.Infof("skipping pipeline %q because it is not for arch %q", identity(pipeline), r.config.Arch)
+	}
+
 	if result, err := shouldRun(pipeline.If); !result {
-		return result, err
+		return false, err
 	}
 
 	debugOption := ' '

--- a/pkg/build/pipeline.go
+++ b/pkg/build/pipeline.go
@@ -221,7 +221,7 @@ func (r *pipelineRunner) runPipeline(ctx context.Context, pipeline *config.Pipel
 
 	for _, p := range pipeline.Pipeline {
 		if p.IfArch != "" && p.IfArch != r.config.Arch {
-			log.Infof("skipping pipeline %q because it is not for arch %q", identity(p), r.config.Arch)
+			log.Infof("skipping pipeline %q because it is not for arch %q", identity(&p), r.config.Arch)
 			continue
 		}
 

--- a/pkg/build/pipeline.go
+++ b/pkg/build/pipeline.go
@@ -170,8 +170,8 @@ type pipelineRunner struct {
 func (r *pipelineRunner) runPipeline(ctx context.Context, pipeline *config.Pipeline) (bool, error) {
 	log := clog.FromContext(ctx)
 
-	if pipeline.IfArch != "" && pipeline.IfArch != r.config.Arch {
-		log.Infof("skipping pipeline %q because it is not for arch %q", identity(pipeline), r.config.Arch)
+	if pipeline.IfArch != "" && pipeline.IfArch.ToAPK() != r.config.Arch.ToAPK() {
+		log.Warnf("skipping %q because runtime arch %q does not match if-arch:%q", identity(pipeline), r.config.Arch.ToAPK(), pipeline.IfArch.ToAPK())
 		return false, nil
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -28,6 +28,7 @@ import (
 	"strings"
 	"time"
 
+	"chainguard.dev/apko/pkg/build/types"
 	apko_types "chainguard.dev/apko/pkg/build/types"
 
 	"github.com/chainguard-dev/clog"
@@ -354,6 +355,9 @@ type Pipeline struct {
 	WorkDir string `json:"working-directory,omitempty" yaml:"working-directory,omitempty"`
 	// Optional: environment variables to override the apko environment
 	Environment map[string]string `json:"environment,omitempty" yaml:"environment,omitempty"`
+
+	// Optional: Only run the pipeline if the runtime architecture matches this architecture.
+	IfArch types.Architecture `json:"if-arch,omitempty" yaml:"if-arch,omitempty"`
 }
 
 type Subpackage struct {


### PR DESCRIPTION
Split out of #1449 

We need this first so we can migrate existing packages to `if-arch` before removing `if` and `assertions`.