### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Melange provides the following default substitutions which can be referenced in 
 | `${{package.full-version}}` | `${{package.version}}-r${{package.epoch}}`                               |
 | `${{package.description}}`  | Package description                                                      |
 | `${{targets.outdir}}`       | Directory where targets will be stored                                   |
-| `${{package.contextdir}}`   | Directory where targets will be stored for main packages and subpackages |
+| `${{targets.contextdir}}`   | Directory where targets will be stored for main packages and subpackages |
 | `${{targets.destdir}}`      | Directory where targets will be stored for main                          |
 | `${{targets.subpkgdir}}`    | Directory where targets will be stored for subpackages                   |
 | `${{build.arch}}`           | Architecture of current build (e.g. x86_64, aarch64)                     |


### PR DESCRIPTION
The substitution is `targets.contextdir` not `package.contextdir`.