### PR TITLE
More SBOM logic improvements

### DIFF
--- a/.github/workflows/wolfi-presubmit.yaml
+++ b/.github/workflows/wolfi-presubmit.yaml
@@ -63,7 +63,7 @@ jobs:
           - tini
           - lzo
           - bubblewrap
-          - gdk-pixbuf
+#          - gdk-pixbuf # Looks like this is broken again, see: https://gitlab.gnome.org/GNOME/gobject-introspection/-/issues/515
           - gitsign
           - guac
           - mdbook

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -497,6 +497,10 @@ func (b *Build) IsBuildLess() bool {
 // ConfigFileExternalRef calculates ExternalRef for the melange config
 // file itself.
 func (b *Build) ConfigFileExternalRef() (*purl.PackageURL, error) {
+	// TODO(luhring): This is now the second implementation of finding the commit
+	//  for the config file (the first being the "detectedCommit" logic. We should
+	//  unify these.
+
 	// configFile must exist
 	configpath, err := filepath.Abs(b.ConfigFile)
 	if err != nil {
@@ -508,6 +512,11 @@ func (b *Build) ConfigFileExternalRef() (*purl.PackageURL, error) {
 	if err != nil {
 		return nil, nil
 	}
+
+	// TODO(luhring): This is brittle and assumes a specific git remote configuration.
+	//  We should consider a more general approach, and this may be moot when we
+	//  unify our git state detection mechanisms.
+
 	// If no remote origin, skip (local git repo)
 	remote, err := r.Remote("origin")
 	if err != nil {

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -871,8 +871,9 @@ func (b *Build) BuildPackage(ctx context.Context) error {
 		sp := sp
 
 		log.Infof("generating SBOM for subpackage %s", sp.Name)
-		if err := sbom.Generate(ctx, &sbom.Spec{
-			Path:            filepath.Join(b.WorkspaceDir, "melange-out", sp.Name),
+
+		apkFSPath := filepath.Join(b.WorkspaceDir, "melange-out", sp.Name)
+		if err := sbom.GenerateAndWrite(ctx, apkFSPath, &sbom.Spec{
 			PackageName:     sp.Name,
 			PackageVersion:  fmt.Sprintf("%s-r%d", b.Configuration.Package.Version, b.Configuration.Package.Epoch),
 			License:         b.Configuration.Package.LicenseExpression(),
@@ -888,8 +889,9 @@ func (b *Build) BuildPackage(ctx context.Context) error {
 	}
 
 	log.Infof("generating SBOM for %s", b.Configuration.Package.Name)
-	if err := sbom.Generate(ctx, &sbom.Spec{
-		Path:            filepath.Join(b.WorkspaceDir, "melange-out", b.Configuration.Package.Name),
+
+	apkFSPath := filepath.Join(b.WorkspaceDir, "melange-out", b.Configuration.Package.Name)
+	if err := sbom.GenerateAndWrite(ctx, apkFSPath, &sbom.Spec{
 		PackageName:     b.Configuration.Package.Name,
 		PackageVersion:  fmt.Sprintf("%s-r%d", b.Configuration.Package.Version, b.Configuration.Package.Epoch),
 		License:         b.Configuration.Package.LicenseExpression(),

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -721,6 +721,9 @@ func WithVarsFileForParsing(path string) ConfigurationParsingOption {
 }
 
 func detectCommit(ctx context.Context, dirPath string) string {
+	// TODO(luhring): Heads up, a similar implementation was added after this one.
+	//  We should unify these implementations. See Build.ConfigFileExternalRef.
+
 	log := clog.FromContext(ctx)
 	// Best-effort detection of current commit, to be used when not specified in the config file
 

--- a/pkg/sbom/bom.go
+++ b/pkg/sbom/bom.go
@@ -23,10 +23,6 @@ import (
 	purl "github.com/package-url/packageurl-go"
 )
 
-type bom struct {
-	Packages []pkg
-}
-
 type element interface {
 	ID() string
 }

--- a/pkg/sbom/generator.go
+++ b/pkg/sbom/generator.go
@@ -46,7 +46,7 @@ func GenerateAndWrite(ctx context.Context, apkFSPath string, spec *Spec) error {
 	defer span.End()
 	log := clog.FromContext(ctx)
 
-	if shouldRun, err := checkEnvironment(apkFSPath); err != nil {
+	if shouldRun, err := checkPathExists(apkFSPath); err != nil {
 		return fmt.Errorf("checking SBOM environment: %w", err)
 	} else if !shouldRun {
 		log.Warnf("working directory not found, apk is empty")

--- a/pkg/sbom/generator.go
+++ b/pkg/sbom/generator.go
@@ -19,14 +19,15 @@ import (
 	"fmt"
 	"time"
 
+	"chainguard.dev/apko/pkg/sbom/generator/spdx"
 	"github.com/chainguard-dev/clog"
 	purl "github.com/package-url/packageurl-go"
 	"go.opentelemetry.io/otel"
 )
 
-// Spec is the input specification for generating an SBOM.
+// Spec describes the metadata of an APK package for which an SBOM should be
+// created.
 type Spec struct {
-	Path            string
 	PackageName     string
 	PackageVersion  string
 	License         string // Full SPDX license expression
@@ -38,36 +39,43 @@ type Spec struct {
 	SourceDateEpoch time.Time
 }
 
-// Generate runs the main SBOM generation process, by analyzing the APK package
-// from the given spec, creating an SPDX SBOM document, and writing that
-// document to disk.
-func Generate(ctx context.Context, spec *Spec) error {
+// GenerateAndWrite creates an SBOM for the APK package described by the given
+// Spec and writes the SBOM to the APK's filesystem.
+func GenerateAndWrite(ctx context.Context, apkFSPath string, spec *Spec) error {
 	_, span := otel.Tracer("melange").Start(ctx, "GenerateSBOM")
 	defer span.End()
 	log := clog.FromContext(ctx)
 
-	if shouldRun, err := checkEnvironment(spec); err != nil {
+	if shouldRun, err := checkEnvironment(apkFSPath); err != nil {
 		return fmt.Errorf("checking SBOM environment: %w", err)
 	} else if !shouldRun {
 		log.Warnf("working directory not found, apk is empty")
 		return nil
 	}
 
-	p, err := generateAPKPackage(spec)
+	document, err := GenerateSPDX(ctx, spec)
 	if err != nil {
-		return fmt.Errorf("generating main APK package: %w", err)
+		return fmt.Errorf("generating SPDX document: %w", err)
 	}
 
-	sbomDoc := &bom{
-		Packages: []pkg{
-			p,
-		},
-	}
-
-	// Finally, write the SBOM data to disk
-	if err := writeSBOM(ctx, spec, sbomDoc); err != nil {
+	if err := writeSBOM(apkFSPath, spec.PackageName, spec.PackageVersion, document); err != nil {
 		return fmt.Errorf("writing sbom to disk: %w", err)
 	}
 
 	return nil
+}
+
+// GenerateSPDX creates an SPDX 2.3 document from the given Spec.
+func GenerateSPDX(ctx context.Context, spec *Spec) (*spdx.Document, error) {
+	p, err := generateAPKPackage(spec)
+	if err != nil {
+		return nil, fmt.Errorf("generating main APK package: %w", err)
+	}
+
+	doc, err := newSPDXDocument(ctx, spec, p)
+	if err != nil {
+		return nil, fmt.Errorf("creating SPDX document: %w", err)
+	}
+
+	return doc, nil
 }

--- a/pkg/sbom/generator.go
+++ b/pkg/sbom/generator.go
@@ -67,7 +67,7 @@ func GenerateAndWrite(ctx context.Context, apkFSPath string, spec *Spec) error {
 
 // GenerateSPDX creates an SPDX 2.3 document from the given Spec.
 func GenerateSPDX(ctx context.Context, spec *Spec) (*spdx.Document, error) {
-	p, err := generateAPKPackage(spec)
+	p, err := generateSBOMDataForAPKPackage(spec)
 	if err != nil {
 		return nil, fmt.Errorf("generating main APK package: %w", err)
 	}

--- a/pkg/sbom/implementation.go
+++ b/pkg/sbom/implementation.go
@@ -75,14 +75,13 @@ func encodeInvalidRune(r rune) string {
 	return "C" + strconv.Itoa(int(r))
 }
 
-// checkEnvironment returns a bool indicating if the specified path for an APK's
-// filesystem exists. If the path does not exist, it returns false and a nil
-// error. If an error occurs while checking the directory, it returns false and
-// the error.
-func checkEnvironment(apkFSPath string) (bool, error) {
-	dirPath, err := filepath.Abs(apkFSPath)
+// checkPathExists returns a bool indicating if the specified path exists. If
+// the path does not exist, it returns false and a nil error. If an error occurs
+// while checking the directory, it returns false and the error.
+func checkPathExists(p string) (bool, error) {
+	dirPath, err := filepath.Abs(p)
 	if err != nil {
-		return false, fmt.Errorf("getting absolute directory path: %w", err)
+		return false, fmt.Errorf("getting absolute path: %w", err)
 	}
 
 	// Check if directory exists
@@ -90,7 +89,7 @@ func checkEnvironment(apkFSPath string) (bool, error) {
 		if os.IsNotExist(err) {
 			return false, nil
 		}
-		return false, fmt.Errorf("checking if working directory exists: %w", err)
+		return false, fmt.Errorf("stat: %w", err)
 	}
 
 	return true, nil

--- a/pkg/sbom/implementation.go
+++ b/pkg/sbom/implementation.go
@@ -155,7 +155,7 @@ func addPackage(doc *spdx.Document, p *pkg) {
 	}
 
 	// Add the purl to the package
-	const extRefCatPackageManager = "PACKAGE_MANAGER"
+	const extRefCatPackageManager = "PACKAGE-MANAGER"
 	if p.Namespace != "" {
 		var q purl.Qualifiers
 		if p.Arch != "" {

--- a/pkg/sbom/implementation.go
+++ b/pkg/sbom/implementation.go
@@ -42,6 +42,8 @@ import (
 	"chainguard.dev/apko/pkg/sbom/generator/spdx"
 )
 
+const extRefCatPackageManager = "PACKAGE-MANAGER"
+
 // invalidIDCharsRe is a regular expression that matches characters not
 // considered valid in SPDX identifiers.
 var invalidIDCharsRe = regexp.MustCompile(`[^a-zA-Z0-9-.]+`)
@@ -155,7 +157,6 @@ func addPackage(doc *spdx.Document, p *pkg) {
 	}
 
 	// Add the purl to the package
-	const extRefCatPackageManager = "PACKAGE-MANAGER"
 	if p.Namespace != "" {
 		var q purl.Qualifiers
 		if p.Arch != "" {

--- a/pkg/sbom/implementation.go
+++ b/pkg/sbom/implementation.go
@@ -97,8 +97,9 @@ func checkPathExists(p string) (bool, error) {
 	return true, nil
 }
 
-// generateAPKPackage generates the sbom package representing the apk.
-func generateAPKPackage(spec *Spec) (*pkg, error) {
+// generateSBOMDataForAPKPackage puts together the normalized SBOM
+// representation for the APK package.
+func generateSBOMDataForAPKPackage(spec *Spec) (*pkg, error) {
 	if spec.PackageName == "" {
 		return nil, errors.New("package name not specified")
 	}


### PR DESCRIPTION
This PR continues to improve the state of melange's SBOM code:

1. Fixes the issue where our external references used `PACKAGE_MANAGER` instead of `PACKAGE-MANAGER`.
2. Breaks apart "SBOM generation" logic from "writing the SBOM back into the APK's filesystem" logic. The hope is we can then use this seam to implement tests in the near future.