### PR TITLE
chore(cargo/build): Allow changing install dir, add busybox

### DIFF
--- a/pkg/build/pipelines/cargo/build.yaml
+++ b/pkg/build/pipelines/cargo/build.yaml
@@ -2,6 +2,7 @@ name: Compile an auditable rust binary with Cargo
 
 needs:
   packages:
+    - busybox
     - cargo-auditable
     - rust
 
@@ -29,10 +30,15 @@ inputs:
     description: |
       Installation prefix. Defaults to usr
 
+  install-dir:
+    description: |
+      Directory where binaries will be installed
+    default: bin
+
 pipeline:
   - runs: |
       # Installation directory should always be bin as we are producing a binary
-      INSTALL_PATH="${{targets.contextdir}}/${{inputs.prefix}}/bin"
+      INSTALL_PATH="${{targets.contextdir}}/${{inputs.prefix}}/${{inputs.install-dir}}"
       OUTPUT_PATH="target/release"
 
       # Enter target package directory


### PR DESCRIPTION
Previously, we defaulted to bin. Allow this to be overriden with another install directory (i.e., libexec)

Additionally, depend on busybox to avoid needing to add the package to the environment in the package file