### PR TITLE
sca: make pc: provides/vendored use full package version

### DIFF
--- a/pkg/sca/sca_test.go
+++ b/pkg/sca/sca_test.go
@@ -186,14 +186,10 @@ func TestVendoredPkgConfig(t *testing.T) {
 		}),
 		Vendored: util.Dedup([]string{
 			"so:libecpg_compat.so.3=3",
-			"pc:libecpg=14.10",
-			"pc:libecpg_compat=14.10",
-			"pc:libpgtypes=14.10",
-			"pc:libpq=14.10",
-			"pc:libecpg=15.5",
-			"pc:libecpg_compat=15.5",
-			"pc:libpgtypes=15.5",
-			"pc:libpq=15.5",
+			"pc:libecpg=4604-r0",
+			"pc:libecpg_compat=4604-r0",
+			"pc:libpgtypes=4604-r0",
+			"pc:libpq=4604-r0",
 		}),
 	}
 


### PR DESCRIPTION
.pc file version can be an aribitrary string value, without any
relation to soname, nor semver.

This yields the very opaque errors

    provides = pc:gdal=3.8.5dev
    datahash = c4638ec49b51aac1fc8f1d948b06a5b6c7a9f41dca2f980629b1f12f8e8be711
    ERROR: ./packages/x86_64/gdal-3.8-dev-3.8.5-r0.apk: package file format error

Which pointlessly waste engineering time.

Node we do not generate depends on pc: provides, as currently
`wolfictl text` transitive dependencies checks are unable to resolve
these.

Fixes: https://github.com/chainguard-dev/melange/issues/1172

Note there is sense that this may have been a missfeature in abuilds
too.
