### PR TITLE
feat(pipelines/split): Support overriding source package

### DIFF
--- a/pkg/build/pipelines/split/debug.yaml
+++ b/pkg/build/pipelines/split/debug.yaml
@@ -15,7 +15,7 @@ inputs:
 pipeline:
   - runs: |
       PACKAGE_DIR="${{targets.destdir}}"
-      if [ -n "$PACKAGE_DIR" ]; then
+      if [ -n "${{inputs.package}}" ]; then
         PACKAGE_DIR="/home/build/melange-out/${{inputs.package}}"
       fi
 

--- a/pkg/build/pipelines/split/debug.yaml
+++ b/pkg/build/pipelines/split/debug.yaml
@@ -3,28 +3,35 @@ name: Split debug files
 needs:
   packages:
     - binutils
+    - busybox
     - scanelf
 
+inputs:
+  packagedir:
+    description: |
+      The package directory to split debug files from
+    default: ${{targets.destdir}}
+
 pipeline:
-  - if: ${{targets.destdir}} != ${{targets.contextdir}}
+  - if: ${{inputs.packagedir}} != ${{targets.contextdir}}
     runs: |
-      mkdir -p "${{targets.destdir}}/.dbg-tmp"
+      mkdir -p "${{inputs.packagedir}}/.dbg-tmp"
       # note: the ${{targets.subpkgdir}} doesn't exist when the glob is evaluated
-      scanelf -Ry "${{targets.destdir}}"/* | while read type src; do
+      scanelf -Ry "${{inputs.packagedir}}"/* | while read type src; do
         if [ "$type" != ET_DYN ]; then
           continue
         fi
-        dst=${{targets.contextdir}}/usr/lib/debug/${src#"${{targets.destdir}}"/*/}.debug
+        dst=${{targets.contextdir}}/usr/lib/debug/${src#"${{inputs.packagedir}}"/*/}.debug
         mkdir -p "${dst%/*}"
         ino=$(stat -c %i "$src")
-        if ! [ -e "${{targets.destdir}}/.dbg-tmp/$ino" ]; then
-          tmp=${{targets.destdir}}/.dbg-tmp/${src##*/}
+        if ! [ -e "${{inputs.packagedir}}/.dbg-tmp/$ino" ]; then
+          tmp=${{inputs.packagedir}}/.dbg-tmp/${src##*/}
           objcopy --only-keep-debug "$src" "$dst"
           objcopy --add-gnu-debuglink="$dst" --strip-unneeded -R .comment "$src" "$tmp"
           # preserve attributes, links
           cat "$tmp" > "$src"
           rm "$tmp"
-          ln "$dst" "${{targets.destdir}}/.dbg-tmp/$ino"
+          ln "$dst" "${{inputs.packagedir}}/.dbg-tmp/$ino"
         fi
       done
-      rm -r "${{targets.destdir}}/.dbg-tmp"
+      rm -r "${{inputs.packagedir}}/.dbg-tmp"

--- a/pkg/build/pipelines/split/debug.yaml
+++ b/pkg/build/pipelines/split/debug.yaml
@@ -7,31 +7,39 @@ needs:
     - scanelf
 
 inputs:
-  packagedir:
+  package:
     description: |
-      The package directory to split debug files from
-    default: ${{targets.destdir}}
+      The package to split debug files from
+    required: false
 
 pipeline:
-  - if: ${{inputs.packagedir}} != ${{targets.contextdir}}
-    runs: |
-      mkdir -p "${{inputs.packagedir}}/.dbg-tmp"
+  - runs: |
+      PACKAGE_DIR="${{targets.destdir}}"
+      if [ -n "$PACKAGE_DIR" ]; then
+        PACKAGE_DIR="/home/build/melange-out/${{inputs.package}}"
+      fi
+
+      if [ "$PACKAGE_DIR" == "${{targets.contextdir}}" ]; then
+        echo "ERROR: Package can not split files from itself!" && exit 1
+      fi
+
+      mkdir -p "$PACKAGE_DIR/.dbg-tmp"
       # note: the ${{targets.subpkgdir}} doesn't exist when the glob is evaluated
-      scanelf -Ry "${{inputs.packagedir}}"/* | while read type src; do
+      scanelf -Ry "$PACKAGE_DIR"/* | while read type src; do
         if [ "$type" != ET_DYN ]; then
           continue
         fi
-        dst=${{targets.contextdir}}/usr/lib/debug/${src#"${{inputs.packagedir}}"/*/}.debug
+        dst=${{targets.contextdir}}/usr/lib/debug/${src#"$PACKAGE_DIR"/*/}.debug
         mkdir -p "${dst%/*}"
         ino=$(stat -c %i "$src")
-        if ! [ -e "${{inputs.packagedir}}/.dbg-tmp/$ino" ]; then
-          tmp=${{inputs.packagedir}}/.dbg-tmp/${src##*/}
+        if ! [ -e "$PACKAGE_DIR/.dbg-tmp/$ino" ]; then
+          tmp=$PACKAGE_DIR/.dbg-tmp/${src##*/}
           objcopy --only-keep-debug "$src" "$dst"
           objcopy --add-gnu-debuglink="$dst" --strip-unneeded -R .comment "$src" "$tmp"
           # preserve attributes, links
           cat "$tmp" > "$src"
           rm "$tmp"
-          ln "$dst" "${{inputs.packagedir}}/.dbg-tmp/$ino"
+          ln "$dst" "$PACKAGE_DIR/.dbg-tmp/$ino"
         fi
       done
-      rm -r "${{inputs.packagedir}}/.dbg-tmp"
+      rm -r "$PACKAGE_DIR/.dbg-tmp"

--- a/pkg/build/pipelines/split/dev.yaml
+++ b/pkg/build/pipelines/split/dev.yaml
@@ -8,7 +8,7 @@ inputs:
   packagedir:
     description: |
       The package directory to split development headers from
-    default: ${{inputs.packagedir}}
+    default: ${{targets.destdir}}
 
 pipeline:
   - if: ${{inputs.packagedir}} != ${{targets.contextdir}}

--- a/pkg/build/pipelines/split/dev.yaml
+++ b/pkg/build/pipelines/split/dev.yaml
@@ -33,6 +33,7 @@ pipeline:
         usr/share/gir-[0-9]* usr/share/qt*/mkspecs \
         usr/lib/qt*/mkspecs usr/lib/cmake \
         usr/lib/glade/modules usr/share/glade/catalogs \
+        usr/local/*/include usr/local/*/lib64 \
         $(find . -name include -type d) \
         $(find $libdirs -name '*.a' 2>/dev/null) \
         $(find $libdirs -name '*.[cho]' \

--- a/pkg/build/pipelines/split/dev.yaml
+++ b/pkg/build/pipelines/split/dev.yaml
@@ -5,16 +5,24 @@ needs:
     - busybox
 
 inputs:
-  packagedir:
+  package:
     description: |
-      The package directory to split development headers from
-    default: ${{targets.destdir}}
+      The package to split development files from
+    required: false
 
 pipeline:
-  - if: ${{inputs.packagedir}} != ${{targets.contextdir}}
-    runs: |
+  - runs: |
+      PACKAGE_DIR="${{targets.destdir}}"
+      if [ -n "$PACKAGE_DIR" ]; then
+        PACKAGE_DIR="/home/build/melange-out/${{inputs.package}}"
+      fi
+
+      if [ "$PACKAGE_DIR" == "${{targets.contextdir}}" ]; then
+        echo "ERROR: Package can not split files from itself!" && exit 1
+      fi
+
       i= j=
-      cd "${{inputs.packagedir}}" || exit 0
+      cd "$PACKAGE_DIR" || exit 0
 
       libdirs=usr/
       [ -d lib/ ] && libdirs="lib/ $libdirs"
@@ -28,11 +36,11 @@ pipeline:
         $(find $libdirs -name '*.a' 2>/dev/null) \
         $(find $libdirs -name '*.[cho]' \
           -o -name '*.prl' 2>/dev/null); do
-            if [ -e "${{inputs.packagedir}}/$i" ] || [ -L "${{inputs.packagedir}}/$i" ]; then
+            if [ -e "$PACKAGE_DIR/$i" ] || [ -L "$PACKAGE_DIR/$i" ]; then
               d="${{targets.contextdir}}/${i%/*}" # dirname $i
               mkdir -p "$d"
-              mv "${{inputs.packagedir}}/$i" "$d"
-              rmdir "${{inputs.packagedir}}/${i%/*}" 2>/dev/null || :
+              mv "$PACKAGE_DIR/$i" "$d"
+              rmdir "$PACKAGE_DIR/${i%/*}" 2>/dev/null || :
             fi
         done
 

--- a/pkg/build/pipelines/split/dev.yaml
+++ b/pkg/build/pipelines/split/dev.yaml
@@ -1,10 +1,20 @@
 name: Split development files
 
+needs:
+  packages:
+    - busybox
+
+inputs:
+  packagedir:
+    description: |
+      The package directory to split development headers from
+    default: ${{inputs.packagedir}}
+
 pipeline:
-  - if: ${{targets.destdir}} != ${{targets.contextdir}}
+  - if: ${{inputs.packagedir}} != ${{targets.contextdir}}
     runs: |
       i= j=
-      cd "${{targets.destdir}}" || exit 0
+      cd "${{inputs.packagedir}}" || exit 0
 
       libdirs=usr/
       [ -d lib/ ] && libdirs="lib/ $libdirs"
@@ -18,11 +28,11 @@ pipeline:
         $(find $libdirs -name '*.a' 2>/dev/null) \
         $(find $libdirs -name '*.[cho]' \
           -o -name '*.prl' 2>/dev/null); do
-            if [ -e "${{targets.destdir}}/$i" ] || [ -L "${{targets.destdir}}/$i" ]; then
+            if [ -e "${{inputs.packagedir}}/$i" ] || [ -L "${{inputs.packagedir}}/$i" ]; then
               d="${{targets.contextdir}}/${i%/*}" # dirname $i
               mkdir -p "$d"
-              mv "${{targets.destdir}}/$i" "$d"
-              rmdir "${{targets.destdir}}/${i%/*}" 2>/dev/null || :
+              mv "${{inputs.packagedir}}/$i" "$d"
+              rmdir "${{inputs.packagedir}}/${i%/*}" 2>/dev/null || :
             fi
         done
 

--- a/pkg/build/pipelines/split/dev.yaml
+++ b/pkg/build/pipelines/split/dev.yaml
@@ -13,7 +13,7 @@ inputs:
 pipeline:
   - runs: |
       PACKAGE_DIR="${{targets.destdir}}"
-      if [ -n "$PACKAGE_DIR" ]; then
+      if [ -n "${{inputs.package}}" ]; then
         PACKAGE_DIR="/home/build/melange-out/${{inputs.package}}"
       fi
 

--- a/pkg/build/pipelines/split/dev.yaml
+++ b/pkg/build/pipelines/split/dev.yaml
@@ -26,6 +26,7 @@ pipeline:
 
       libdirs=usr/
       [ -d lib/ ] && libdirs="lib/ $libdirs"
+      [ -d lib64/ ] && libdirs="lib64/ $libdirs"
       for i in usr/include usr/lib/pkgconfig usr/share/pkgconfig \
         usr/share/aclocal usr/share/gettext \
         usr/bin/*-config usr/bin/*_config usr/share/vala/vapi \

--- a/pkg/build/pipelines/split/infodir.yaml
+++ b/pkg/build/pipelines/split/infodir.yaml
@@ -5,17 +5,25 @@ needs:
     - busybox
 
 inputs:
-  packagedir:
+  package:
     description: |
-      The package directory to split info pages from
-    default: ${{targets.destdir}}
+      The package to split info pages files from
+    required: false
 
 pipeline:
-  - if: ${{inputs.packagedir}} != ${{targets.contextdir}}
-    runs: |
-      if [ -d "${{inputs.packagedir}}/usr/share/info" ]; then
-        rm -f "${{inputs.packagedir}}"/usr/share/info/dir
+  - runs: |
+      PACKAGE_DIR="${{targets.destdir}}"
+      if [ -n "$PACKAGE_DIR" ]; then
+        PACKAGE_DIR="/home/build/melange-out/${{inputs.package}}"
+      fi
+
+      if [ "$PACKAGE_DIR" == "${{targets.contextdir}}" ]; then
+        echo "ERROR: Package can not split files from itself!" && exit 1
+      fi
+
+      if [ -d "$PACKAGE_DIR/usr/share/info" ]; then
+        rm -f "$PACKAGE_DIR"/usr/share/info/dir
 
         mkdir -p "${{targets.contextdir}}/usr/share"
-        mv "${{inputs.packagedir}}"/usr/share/info "${{targets.contextdir}}/usr/share"
+        mv "$PACKAGE_DIR"/usr/share/info "${{targets.contextdir}}/usr/share"
       fi

--- a/pkg/build/pipelines/split/infodir.yaml
+++ b/pkg/build/pipelines/split/infodir.yaml
@@ -1,11 +1,21 @@
 name: Split GNU info pages
 
+needs:
+  packages:
+    - busybox
+
+inputs:
+  packagedir:
+    description: |
+      The package directory to split info pages from
+    default: ${{targets.destdir}}
+
 pipeline:
-  - if: ${{targets.destdir}} != ${{targets.contextdir}}
+  - if: ${{inputs.packagedir}} != ${{targets.contextdir}}
     runs: |
-      if [ -d "${{targets.destdir}}/usr/share/info" ]; then
-        rm -f "${{targets.destdir}}"/usr/share/info/dir
+      if [ -d "${{inputs.packagedir}}/usr/share/info" ]; then
+        rm -f "${{inputs.packagedir}}"/usr/share/info/dir
 
         mkdir -p "${{targets.contextdir}}/usr/share"
-        mv "${{targets.destdir}}"/usr/share/info "${{targets.contextdir}}/usr/share"
+        mv "${{inputs.packagedir}}"/usr/share/info "${{targets.contextdir}}/usr/share"
       fi

--- a/pkg/build/pipelines/split/infodir.yaml
+++ b/pkg/build/pipelines/split/infodir.yaml
@@ -13,7 +13,7 @@ inputs:
 pipeline:
   - runs: |
       PACKAGE_DIR="${{targets.destdir}}"
-      if [ -n "$PACKAGE_DIR" ]; then
+      if [ -n "${{inputs.package}}" ]; then
         PACKAGE_DIR="/home/build/melange-out/${{inputs.package}}"
       fi
 

--- a/pkg/build/pipelines/split/locales.yaml
+++ b/pkg/build/pipelines/split/locales.yaml
@@ -1,9 +1,19 @@
 name: Split locales
 
+needs:
+  packages:
+    - busybox
+
+inputs:
+  packagedir:
+    description: |
+      The package directory to split locales from
+    default: ${{targets.destdir}}
+
 pipeline:
-  - if: ${{targets.destdir}} != ${{targets.contextdir}}
+  - if: ${{inputs.packagedir}} != ${{targets.contextdir}}
     runs: |
-      if [ -d "${{targets.destdir}}"/usr/share/locale ]; then
+      if [ -d "${{inputs.packagedir}}"/usr/share/locale ]; then
         mkdir -p "${{targets.contextdir}}"/usr/share
-        mv "${{targets.destdir}}"/usr/share/locale "${{targets.contextdir}}"/usr/share/locale
+        mv "${{inputs.packagedir}}"/usr/share/locale "${{targets.contextdir}}"/usr/share/locale
       fi

--- a/pkg/build/pipelines/split/locales.yaml
+++ b/pkg/build/pipelines/split/locales.yaml
@@ -5,15 +5,23 @@ needs:
     - busybox
 
 inputs:
-  packagedir:
+  package:
     description: |
-      The package directory to split locales from
-    default: ${{targets.destdir}}
+      The package to split locales from
+    required: false
 
 pipeline:
-  - if: ${{inputs.packagedir}} != ${{targets.contextdir}}
-    runs: |
-      if [ -d "${{inputs.packagedir}}"/usr/share/locale ]; then
+  - runs: |
+      PACKAGE_DIR="${{targets.destdir}}"
+      if [ -n "$PACKAGE_DIR" ]; then
+        PACKAGE_DIR="/home/build/melange-out/${{inputs.package}}"
+      fi
+
+      if [ "$PACKAGE_DIR" == "${{targets.contextdir}}" ]; then
+        echo "ERROR: Package can not split files from itself!" && exit 1
+      fi
+
+      if [ -d "$PACKAGE_DIR"/usr/share/locale ]; then
         mkdir -p "${{targets.contextdir}}"/usr/share
-        mv "${{inputs.packagedir}}"/usr/share/locale "${{targets.contextdir}}"/usr/share/locale
+        mv "$PACKAGE_DIR"/usr/share/locale "${{targets.contextdir}}"/usr/share/locale
       fi

--- a/pkg/build/pipelines/split/locales.yaml
+++ b/pkg/build/pipelines/split/locales.yaml
@@ -13,7 +13,7 @@ inputs:
 pipeline:
   - runs: |
       PACKAGE_DIR="${{targets.destdir}}"
-      if [ -n "$PACKAGE_DIR" ]; then
+      if [ -n "${{inputs.package}}" ]; then
         PACKAGE_DIR="/home/build/melange-out/${{inputs.package}}"
       fi
 

--- a/pkg/build/pipelines/split/manpages.yaml
+++ b/pkg/build/pipelines/split/manpages.yaml
@@ -1,9 +1,19 @@
 name: Split manpages
 
+needs:
+  packages:
+    - busybox
+
+inputs:
+  packagedir:
+    description: |
+      The package directory to split manpages from
+    default: ${{targets.destdir}}
+
 pipeline:
-  - if: ${{targets.destdir}} != ${{targets.contextdir}}
+  - if: ${{inputs.packagedir}} != ${{targets.contextdir}}
     runs: |
-      if [ -d "${{targets.destdir}}/usr/share/man" ]; then
+      if [ -d "${{inputs.packagedir}}/usr/share/man" ]; then
         mkdir -p "${{targets.contextdir}}/usr/share"
-        mv "${{targets.destdir}}/usr/share/man" "${{targets.contextdir}}/usr/share"
+        mv "${{inputs.packagedir}}/usr/share/man" "${{targets.contextdir}}/usr/share"
       fi

--- a/pkg/build/pipelines/split/manpages.yaml
+++ b/pkg/build/pipelines/split/manpages.yaml
@@ -5,15 +5,23 @@ needs:
     - busybox
 
 inputs:
-  packagedir:
+  package:
     description: |
-      The package directory to split manpages from
-    default: ${{targets.destdir}}
+      The package to split manpages from
+    required: false
 
 pipeline:
-  - if: ${{inputs.packagedir}} != ${{targets.contextdir}}
-    runs: |
-      if [ -d "${{inputs.packagedir}}/usr/share/man" ]; then
+  - runs: |
+      PACKAGE_DIR="${{targets.destdir}}"
+      if [ -n "$PACKAGE_DIR" ]; then
+        PACKAGE_DIR="/home/build/melange-out/${{inputs.package}}"
+      fi
+
+      if [ "$PACKAGE_DIR" == "${{targets.contextdir}}" ]; then
+        echo "ERROR: Package can not split files from itself!" && exit 1
+      fi
+
+      if [ -d "$PACKAGE_DIR/usr/share/man" ]; then
         mkdir -p "${{targets.contextdir}}/usr/share"
-        mv "${{inputs.packagedir}}/usr/share/man" "${{targets.contextdir}}/usr/share"
+        mv "$PACKAGE_DIR/usr/share/man" "${{targets.contextdir}}/usr/share"
       fi

--- a/pkg/build/pipelines/split/manpages.yaml
+++ b/pkg/build/pipelines/split/manpages.yaml
@@ -13,7 +13,7 @@ inputs:
 pipeline:
   - runs: |
       PACKAGE_DIR="${{targets.destdir}}"
-      if [ -n "$PACKAGE_DIR" ]; then
+      if [ -n "${{inputs.package}}" ]; then
         PACKAGE_DIR="/home/build/melange-out/${{inputs.package}}"
       fi
 

--- a/pkg/build/pipelines/split/static.yaml
+++ b/pkg/build/pipelines/split/static.yaml
@@ -1,19 +1,29 @@
 name: Split static library files
 
+needs:
+  packages:
+    - busybox
+
+inputs:
+  packagedir:
+    description: |
+      The package directory to split static library files from
+    default: ${{targets.destdir}}
+
 pipeline:
-  - if: ${{targets.destdir}} != ${{targets.contextdir}}
+  - if: ${{inputs.packagedir}} != ${{targets.contextdir}}
     runs: |
       i= j=
-      cd "${{targets.destdir}}" || exit 0
+      cd "${{inputs.packagedir}}" || exit 0
 
       libdirs=usr/
       [ -d lib/ ] && libdirs="lib/ $libdirs"
       for i in \
         $(find $libdirs -name '*.a' 2>/dev/null); do
-            if [ -e "${{targets.destdir}}/$i" ] || [ -L "${{targets.destdir}}/$i" ]; then
+            if [ -e "${{inputs.packagedir}}/$i" ] || [ -L "${{inputs.packagedir}}/$i" ]; then
               d="${{targets.contextdir}}/${i%/*}" # dirname $i
               mkdir -p "$d"
-              mv "${{targets.destdir}}/$i" "$d"
-              rmdir "${{targets.destdir}}/${i%/*}" 2>/dev/null || :
+              mv "${{inputs.packagedir}}/$i" "$d"
+              rmdir "${{inputs.packagedir}}/${i%/*}" 2>/dev/null || :
             fi
         done

--- a/pkg/build/pipelines/split/static.yaml
+++ b/pkg/build/pipelines/split/static.yaml
@@ -5,25 +5,33 @@ needs:
     - busybox
 
 inputs:
-  packagedir:
+  package:
     description: |
-      The package directory to split static library files from
-    default: ${{targets.destdir}}
+      The package to split static library files from
+    required: false
 
 pipeline:
-  - if: ${{inputs.packagedir}} != ${{targets.contextdir}}
-    runs: |
+  - runs: |
+      PACKAGE_DIR="${{targets.destdir}}"
+      if [ -n "$PACKAGE_DIR" ]; then
+        PACKAGE_DIR="/home/build/melange-out/${{inputs.package}}"
+      fi
+
+      if [ "$PACKAGE_DIR" == "${{targets.contextdir}}" ]; then
+        echo "ERROR: Package can not split files from itself!" && exit 1
+      fi
+
       i= j=
-      cd "${{inputs.packagedir}}" || exit 0
+      cd "$PACKAGE_DIR" || exit 0
 
       libdirs=usr/
       [ -d lib/ ] && libdirs="lib/ $libdirs"
       for i in \
         $(find $libdirs -name '*.a' 2>/dev/null); do
-            if [ -e "${{inputs.packagedir}}/$i" ] || [ -L "${{inputs.packagedir}}/$i" ]; then
+            if [ -e "$PACKAGE_DIR/$i" ] || [ -L "$PACKAGE_DIR/$i" ]; then
               d="${{targets.contextdir}}/${i%/*}" # dirname $i
               mkdir -p "$d"
-              mv "${{inputs.packagedir}}/$i" "$d"
-              rmdir "${{inputs.packagedir}}/${i%/*}" 2>/dev/null || :
+              mv "$PACKAGE_DIR/$i" "$d"
+              rmdir "$PACKAGE_DIR/${i%/*}" 2>/dev/null || :
             fi
         done

--- a/pkg/build/pipelines/split/static.yaml
+++ b/pkg/build/pipelines/split/static.yaml
@@ -26,6 +26,7 @@ pipeline:
 
       libdirs=usr/
       [ -d lib/ ] && libdirs="lib/ $libdirs"
+      [ -d lib64/ ] && libdirs="lib64/ $libdirs"
       for i in \
         $(find $libdirs -name '*.a' 2>/dev/null); do
             if [ -e "$PACKAGE_DIR/$i" ] || [ -L "$PACKAGE_DIR/$i" ]; then

--- a/pkg/build/pipelines/split/static.yaml
+++ b/pkg/build/pipelines/split/static.yaml
@@ -13,7 +13,7 @@ inputs:
 pipeline:
   - runs: |
       PACKAGE_DIR="${{targets.destdir}}"
-      if [ -n "$PACKAGE_DIR" ]; then
+      if [ -n "${{inputs.package}}" ]; then
         PACKAGE_DIR="/home/build/melange-out/${{inputs.package}}"
       fi
 


### PR DESCRIPTION
Currently, our split pipelines only support splitting targets from the main package in destdir. There are cases where this behavior could be useful for subpackages

I.E., minizip is built as part of the zlib packaging process as a subpackage. As a result, it includes development headers. As we can now override the source package, we can provide a minizip-dev subpackage without bundling it in zlib-dev

Example:

```
- name: minizip-dev
  pipeline:
    - uses: split/dev
      with:
        package: minizip
```