### PR TITLE
feat(pipelines/split): Allow specifying additional library directories

### DIFF
--- a/pkg/build/pipelines/split/dev.yaml
+++ b/pkg/build/pipelines/split/dev.yaml
@@ -10,6 +10,11 @@ inputs:
       The package to split development files from
     required: false
 
+  libdirs:
+    description: |
+      Additional library directories to split development files from
+    required: false
+
 pipeline:
   - runs: |
       PACKAGE_DIR="${{targets.destdir}}"
@@ -25,15 +30,13 @@ pipeline:
       cd "$PACKAGE_DIR" || exit 0
 
       libdirs=usr/
-      [ -d lib/ ] && libdirs="lib/ $libdirs"
-      [ -d lib64/ ] && libdirs="lib64/ $libdirs"
+      [ -d lib/ ] && libdirs="lib/ ${{inputs.libdirs}} $libdirs"
       for i in usr/include usr/lib/pkgconfig usr/share/pkgconfig \
         usr/share/aclocal usr/share/gettext \
         usr/bin/*-config usr/bin/*_config usr/share/vala/vapi \
         usr/share/gir-[0-9]* usr/share/qt*/mkspecs \
         usr/lib/qt*/mkspecs usr/lib/cmake \
         usr/lib/glade/modules usr/share/glade/catalogs \
-        usr/local/*/include usr/local/*/lib64 \
         $(find . -name include -type d) \
         $(find $libdirs -name '*.a' 2>/dev/null) \
         $(find $libdirs -name '*.[cho]' \

--- a/pkg/build/pipelines/split/static.yaml
+++ b/pkg/build/pipelines/split/static.yaml
@@ -10,6 +10,11 @@ inputs:
       The package to split static library files from
     required: false
 
+  libdirs:
+    description: |
+      Additional library directories to split static library files from
+    required: false
+
 pipeline:
   - runs: |
       PACKAGE_DIR="${{targets.destdir}}"
@@ -25,8 +30,7 @@ pipeline:
       cd "$PACKAGE_DIR" || exit 0
 
       libdirs=usr/
-      [ -d lib/ ] && libdirs="lib/ $libdirs"
-      [ -d lib64/ ] && libdirs="lib64/ $libdirs"
+      [ -d lib/ ] && libdirs="lib/ ${{inputs.libdirs}} $libdirs"
       for i in \
         $(find $libdirs -name '*.a' 2>/dev/null); do
             if [ -e "$PACKAGE_DIR/$i" ] || [ -L "$PACKAGE_DIR/$i" ]; then


### PR DESCRIPTION
Matching these with a wildcard doesn't fully work here, allow specifying additional library directories instead