### PR TITLE
fix(split pipelines): Don't split lib64 libraries

### DIFF
--- a/pkg/build/pipelines/split/dev.yaml
+++ b/pkg/build/pipelines/split/dev.yaml
@@ -26,14 +26,12 @@ pipeline:
 
       libdirs=usr/
       [ -d lib/ ] && libdirs="lib/ $libdirs"
-      [ -d lib64/ ] && libdirs="lib64/ $libdirs"
       for i in usr/include usr/lib/pkgconfig usr/share/pkgconfig \
         usr/share/aclocal usr/share/gettext \
         usr/bin/*-config usr/bin/*_config usr/share/vala/vapi \
         usr/share/gir-[0-9]* usr/share/qt*/mkspecs \
         usr/lib/qt*/mkspecs usr/lib/cmake \
         usr/lib/glade/modules usr/share/glade/catalogs \
-        usr/local/*/include usr/local/*/lib64 \
         $(find . -name include -type d) \
         $(find $libdirs -name '*.a' 2>/dev/null) \
         $(find $libdirs -name '*.[cho]' \

--- a/pkg/build/pipelines/split/static.yaml
+++ b/pkg/build/pipelines/split/static.yaml
@@ -26,7 +26,6 @@ pipeline:
 
       libdirs=usr/
       [ -d lib/ ] && libdirs="lib/ $libdirs"
-      [ -d lib64/ ] && libdirs="lib64/ $libdirs"
       for i in \
         $(find $libdirs -name '*.a' 2>/dev/null); do
             if [ -e "$PACKAGE_DIR/$i" ] || [ -L "$PACKAGE_DIR/$i" ]; then


### PR DESCRIPTION
/usr/local/\*/lib64 was added to accomodate splitting away libraries used for development. This was incorrect. Now ALL libraries in /usr/local/\*/lib64 get split away

This fixes that and removes the behavior. We add `usr/` to library paths and that is sufficient for what we need

Broken behavior introduced by me here: https://github.com/chainguard-dev/melange/pull/1472