### PR TITLE
config: Whack more moles for string replacement

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -66,6 +66,8 @@ test:
       packages:
         - ${{package.name}}-config
         - replacement-provides-${{vars.short-package-version}}
+    environment:
+      LD_LIBRARY_PATH: "/usr/local/${{vars.foo}}"
 `), 0644); err != nil {
 		t.Fatal(err)
 	}
@@ -113,6 +115,8 @@ test:
 	}, cfg.Test.Environment.Contents.Packages)
 
 	require.Equal(t, cfg.Subpackages[0].Name, "subpackage-0.0")
+
+	require.Equal(t, "/usr/local/FOO", cfg.Test.Environment.Environment["LD_LIBRARY_PATH"])
 }
 
 func Test_rangeSubstitutions(t *testing.T) {


### PR DESCRIPTION
We weren't substituting anything in Test or the apko ImageConfiguration.

Fixes https://github.com/chainguard-dev/melange/issues/1478