### PR TITLE
config: Use reflection

### DIFF
--- a/pkg/config/reflect.go
+++ b/pkg/config/reflect.go
@@ -1,0 +1,57 @@
+package config
+
+import (
+	"reflect"
+	"strings"
+)
+
+// replace takes the given T and recursively walks it, replacing any strings it encounters inside structs, maps, slices, etc with the given replacer.
+func replace[T any](r *strings.Replacer, in T) T {
+	return replaceValue(r, reflect.ValueOf(in)).Interface().(T)
+}
+
+func replaceValue(r *strings.Replacer, in reflect.Value) reflect.Value {
+	switch in.Kind() {
+	case reflect.String:
+		return reflect.ValueOf(r.Replace(in.String()))
+	case reflect.Struct:
+		out := reflect.New(in.Type()).Elem()
+		for i := 0; i < in.NumField(); i++ {
+			if out.Field(i).CanSet() {
+				out.Field(i).Set(replaceValue(r, in.Field(i)))
+			}
+		}
+		return out
+	case reflect.Map:
+		if in.IsNil() {
+			return in
+		}
+		out := reflect.MakeMap(in.Type())
+		for _, key := range in.MapKeys() {
+			out.SetMapIndex(key, replaceValue(r, in.MapIndex(key)))
+		}
+		return out
+	case reflect.Slice:
+		if in.IsNil() {
+			return in
+		}
+		out := reflect.MakeSlice(in.Type(), in.Len(), in.Cap())
+		for i := 0; i < in.Len(); i++ {
+			out.Index(i).Set(replaceValue(r, in.Index(i)))
+		}
+		return out
+	case reflect.Array:
+		out := reflect.New(in.Type()).Elem()
+		for i := 0; i < in.Len(); i++ {
+			out.Index(i).Set(replaceValue(r, in.Index(i)))
+		}
+		return out
+	case reflect.Ptr:
+		if in.IsNil() {
+			return in
+		}
+		return replaceValue(r, in.Elem()).Addr()
+	default:
+		return in
+	}
+}


### PR DESCRIPTION
Our previous approach of playing whack-a-mole did not seem to work very well. This just replaces everything via reflection, with two notable exceptions:

1. Some top-level fields in Configuration are meta-fields and not meant to be replaced by anything.
2. Since subpackages support Range, we need to expand them before calling replace() on them.

This approach won't scale very well if we add sub-fields to structs that shouldn't support string replacement or if we add top-level fields to Configuration that need replacement (we will need to update this code).

One approach for dealing with both of these things would be to use struct tags to explicitly mark fields as non-replaceable and handle these exceptions in the reflection code by just skipping over them. That's more complicated than I intend for this change, so I'm going to punt on that for now, but we should consider it if this new code doesn't hold up to the test of time.