### PR TITLE
pipelines/ruby: remove signing_key by default

### DIFF
--- a/pkg/build/pipelines/ruby/build.yaml
+++ b/pkg/build/pipelines/ruby/build.yaml
@@ -39,6 +39,10 @@ pipeline:
       output_flag=''
       [ -n '${{inputs.output}}' ] && output_flag='--output ${{inputs.output}}'
 
+      # If it exist, remove the signing_key from gemspec by default since it leads to
+      # build failures as the key is not available in the build environment and is not needed.
+      sed -i '/signing_key/d' ${{inputs.gem}}.gemspec || true
+
       gem build \
         ${{inputs.gem}}.gemspec \
         ${output_flag} \


### PR DESCRIPTION
If it exist, remove the signing_key from gemspec by default since it leads to build failures as the key is not available in the build environment and is not needed.