### PR TITLE
bail out on patch application failure

### DIFF
--- a/pkg/build/pipelines/patch.yaml
+++ b/pkg/build/pipelines/patch.yaml
@@ -33,5 +33,5 @@ pipeline:
       fi
 
       grep -v -E '^(#|$)' $series | (while read patchfile; do
-        patch '-p${{inputs.strip-components}}' < $patchfile
+        patch '-p${{inputs.strip-components}}' < $patchfile || exit 1
       done)


### PR DESCRIPTION
## Melange Pull Request Template

bail out on patch failure.

when building x86_64 images on apple silicon mac, melange may fail because of patch application failure. 

silent failure seems like a bad idea! if patch application fails, then the pipeline should then fail, notifying the melange user so that the build can get a proper fix.

```
2024/09/08 16:05:02 INFO running step "Apply patches"
2024/09/08 16:05:02 WARN qemu-x86_64-static: QEMU internal SIGSEGV {code=MAPERR, addr=0x20}
2024/09/08 16:05:02 WARN Segmentation fault (core dumped)
2024/09/08 16:05:02 INFO running step "Run autoconf make"
2024/09/08 16:05:02 INFO make: Entering directory '/home/build'
2024/09/08 16:05:02 INFO /usr/bin/make -C deps -f Makefile all
2024/09/08 16:05:02 WARN qemu-x86_64-static: QEMU internal SIGSEGV {code=MAPERR, addr=0x20}
2024/09/08 16:05:03 INFO make[1]: Entering directory '/home/build/deps'
2024/09/08 16:05:03 INFO /usr/bin/make -C redis -f Makefile all
```

<!--
*** PULL REQUEST CHECKLIST: PLEASE START HERE ***

The single most important feature of melange is that we can build Wolfi.

Many changes to melange introduce a risk of breaking the build, and sometimes
these are not flushed out until a package is changed (much) later.  This
pertains to basic execution, SCA changes, linter changes, and more.
-->

### Functional Changes

~~- [ ] This change can build all of Wolfi without errors (describe results in notes)~~

Notes:

### SCA Changes

~~- [ ] Examining several representative APKs show no regression / the desired effect (details in notes)~~

Notes:

### Linter

~~- [ ] The new check is clean across Wolfi~~
~~- [ ] The new check is opt-in or a warning~~

Notes:
