### PR TITLE
feat(melange): Add sub for output directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ Melange provides the following default substitutions which can be referenced in 
 | `${{package.epoch}}`        | Package epoch                                                            |
 | `${{package.full-version}}` | `${{package.version}}-r${{package.epoch}}`                               |
 | `${{package.description}}`  | Package description                                                      |
+| `${{targets.outdir}}`       | Directory where targets will be stored                                   |
 | `${{package.contextdir}}`   | Directory where targets will be stored for main packages and subpackages |
 | `${{targets.destdir}}`      | Directory where targets will be stored for main                          |
 | `${{targets.subpkgdir}}`    | Directory where targets will be stored for subpackages                   |

--- a/pkg/build/pipeline.go
+++ b/pkg/build/pipeline.go
@@ -81,6 +81,7 @@ func NewSubstitutionMap(cfg *config.Configuration, arch apko_types.Architecture,
 		config.SubstitutionPackageVersion:     pkg.Version,
 		config.SubstitutionPackageEpoch:       strconv.FormatUint(pkg.Epoch, 10),
 		config.SubstitutionPackageFullVersion: fmt.Sprintf("%s-r%s", config.SubstitutionPackageVersion, config.SubstitutionPackageEpoch),
+		config.SubstitutionTargetsOutdir:      "/home/build/melange-out",
 		config.SubstitutionTargetsDestdir:     fmt.Sprintf("/home/build/melange-out/%s", pkg.Name),
 		config.SubstitutionTargetsContextdir:  fmt.Sprintf("/home/build/melange-out/%s", pkg.Name),
 	}

--- a/pkg/build/pipelines/split/debug.yaml
+++ b/pkg/build/pipelines/split/debug.yaml
@@ -16,7 +16,7 @@ pipeline:
   - runs: |
       PACKAGE_DIR="${{targets.destdir}}"
       if [ -n "${{inputs.package}}" ]; then
-        PACKAGE_DIR="/home/build/melange-out/${{inputs.package}}"
+        PACKAGE_DIR="${{targets.outdir}}/${{inputs.package}}"
       fi
 
       if [ "$PACKAGE_DIR" == "${{targets.contextdir}}" ]; then

--- a/pkg/build/pipelines/split/dev.yaml
+++ b/pkg/build/pipelines/split/dev.yaml
@@ -14,7 +14,7 @@ pipeline:
   - runs: |
       PACKAGE_DIR="${{targets.destdir}}"
       if [ -n "${{inputs.package}}" ]; then
-        PACKAGE_DIR="/home/build/melange-out/${{inputs.package}}"
+        PACKAGE_DIR="${{targets.outdir}}/${{inputs.package}}"
       fi
 
       if [ "$PACKAGE_DIR" == "${{targets.contextdir}}" ]; then

--- a/pkg/build/pipelines/split/infodir.yaml
+++ b/pkg/build/pipelines/split/infodir.yaml
@@ -14,7 +14,7 @@ pipeline:
   - runs: |
       PACKAGE_DIR="${{targets.destdir}}"
       if [ -n "${{inputs.package}}" ]; then
-        PACKAGE_DIR="/home/build/melange-out/${{inputs.package}}"
+        PACKAGE_DIR="${{targets.outdir}}/${{inputs.package}}"
       fi
 
       if [ "$PACKAGE_DIR" == "${{targets.contextdir}}" ]; then

--- a/pkg/build/pipelines/split/locales.yaml
+++ b/pkg/build/pipelines/split/locales.yaml
@@ -14,7 +14,7 @@ pipeline:
   - runs: |
       PACKAGE_DIR="${{targets.destdir}}"
       if [ -n "${{inputs.package}}" ]; then
-        PACKAGE_DIR="/home/build/melange-out/${{inputs.package}}"
+        PACKAGE_DIR="${{targets.outdir}}/${{inputs.package}}"
       fi
 
       if [ "$PACKAGE_DIR" == "${{targets.contextdir}}" ]; then

--- a/pkg/build/pipelines/split/manpages.yaml
+++ b/pkg/build/pipelines/split/manpages.yaml
@@ -14,7 +14,7 @@ pipeline:
   - runs: |
       PACKAGE_DIR="${{targets.destdir}}"
       if [ -n "${{inputs.package}}" ]; then
-        PACKAGE_DIR="/home/build/melange-out/${{inputs.package}}"
+        PACKAGE_DIR="${{targets.outdir}}/${{inputs.package}}"
       fi
 
       if [ "$PACKAGE_DIR" == "${{targets.contextdir}}" ]; then

--- a/pkg/build/pipelines/split/static.yaml
+++ b/pkg/build/pipelines/split/static.yaml
@@ -14,7 +14,7 @@ pipeline:
   - runs: |
       PACKAGE_DIR="${{targets.destdir}}"
       if [ -n "${{inputs.package}}" ]; then
-        PACKAGE_DIR="/home/build/melange-out/${{inputs.package}}"
+        PACKAGE_DIR="${{targets.outdir}}/${{inputs.package}}"
       fi
 
       if [ "$PACKAGE_DIR" == "${{targets.contextdir}}" ]; then

--- a/pkg/config/vars.go
+++ b/pkg/config/vars.go
@@ -27,6 +27,7 @@ const (
 	SubstitutionPackageFullVersion    = "${{package.full-version}}"
 	SubstitutionPackageEpoch          = "${{package.epoch}}"
 	SubstitutionPackageDescription    = "${{package.description}}"
+	SubstitutionTargetsOutdir         = "${{targets.outdir}}"
 	SubstitutionTargetsDestdir        = "${{targets.destdir}}"
 	SubstitutionTargetsContextdir     = "${{targets.contextdir}}"
 	SubstitutionSubPkgDir             = "${{targets.subpkgdir}}"


### PR DESCRIPTION
Adds a substitution, `targets.outdir`, for melange's output directory. Useful for when we need to reference a package outside of destination directory or subpackage directory. I.E., copying files from one subpackage to another
