### PR TITLE
index: stop writing APKINDEX.json

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -974,10 +974,6 @@ func (b *Build) BuildPackage(ctx context.Context) error {
 		if err := idx.GenerateIndex(ctx); err != nil {
 			return fmt.Errorf("unable to generate index: %w", err)
 		}
-
-		if err := idx.WriteJSONIndex(filepath.Join(packageDir, "APKINDEX.json")); err != nil {
-			return fmt.Errorf("unable to generate JSON index: %w", err)
-		}
 	}
 
 	return nil

--- a/pkg/index/index.go
+++ b/pkg/index/index.go
@@ -16,7 +16,6 @@ package index
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -255,25 +254,6 @@ func (idx *Index) WriteArchiveIndex(ctx context.Context, destinationFile string)
 		if err := sign.SignIndex(ctx, idx.SigningKey, idx.IndexFile); err != nil {
 			return fmt.Errorf("failed to sign apk index: %w", err)
 		}
-	}
-
-	return nil
-}
-
-func (idx *Index) WriteJSONIndex(destinationFile string) error {
-	outFile, err := os.Create(destinationFile)
-	if err != nil {
-		return fmt.Errorf("failed to create index JSON file: %w", err)
-	}
-	defer outFile.Close()
-
-	jsonData, err := json.MarshalIndent(idx.Index, "", "  ")
-	if err != nil {
-		return fmt.Errorf("failed to write index as JSON: %w", err)
-	}
-
-	if _, err := outFile.Write(jsonData); err != nil {
-		return fmt.Errorf("failed to write index as JSON: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
It is obsolete, as only melange tool used to write it and much better
options now exist to convert .tar.gz to .json using [apkrane] tool
instead.

[apkrane]: https://github.com/jonjohnsonjr/apkrane
