### PR TITLE
cleanup: remove some direct imports of charm log

### DIFF
--- a/pkg/container/qemu_runner.go
+++ b/pkg/container/qemu_runner.go
@@ -43,7 +43,6 @@ import (
 	apko_cpio "chainguard.dev/apko/pkg/cpio"
 	"chainguard.dev/melange/internal/logwriter"
 	"github.com/chainguard-dev/clog"
-	"github.com/charmbracelet/log"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/tarball"
 	"go.opentelemetry.io/otel"
@@ -282,7 +281,8 @@ func (b qemuOCILoader) RemoveImage(ctx context.Context, ref string) error {
 }
 
 func createMicroVM(ctx context.Context, cfg *Config) error {
-	clog.FromContext(ctx).Debug("qemu: ssh - create ssh key pair")
+	log := clog.FromContext(ctx)
+	log.Debug("qemu: ssh - create ssh key pair")
 	pubKey, err := generateSSHKeys(ctx, cfg)
 	if err != nil {
 		return err

--- a/pkg/linter/linter.go
+++ b/pkg/linter/linter.go
@@ -29,7 +29,7 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/charmbracelet/log"
+	"github.com/chainguard-dev/clog"
 	"github.com/dustin/go-humanize"
 	"golang.org/x/exp/maps"
 	"gopkg.in/ini.v1"
@@ -570,7 +570,7 @@ func LintBuild(ctx context.Context, packageName string, path string, require, wa
 		return err
 	}
 
-	log := log.FromContext(ctx)
+	log := clog.FromContext(ctx)
 	fsys := os.DirFS(path)
 
 	if err := lintPackageFS(ctx, packageName, fsys, warn); err != nil {
@@ -582,6 +582,7 @@ func LintBuild(ctx context.Context, packageName string, path string, require, wa
 
 // Lint the given APK at the given path
 func LintAPK(ctx context.Context, path string, require, warn []string) error {
+	log := clog.FromContext(ctx)
 	if err := checkLinters(append(require, warn...)); err != nil {
 		return err
 	}


### PR DESCRIPTION
These seem to be relatively common cases where someone writes `log.Warn` and goimports chooses to import charmbracelet/log. This shouldn't be necessary when you call `log := clog.FromContext(ctx)` first.

For CLI users the result is not really any different (we use charm logging via clog anyway), but for places where this code might get embedded in another service where a different logger is used, it can be surprising.