### PR TITLE
Add uses and name to slog values

### DIFF
--- a/pkg/build/compile.go
+++ b/pkg/build/compile.go
@@ -206,7 +206,7 @@ func (c *Compiled) CompilePipelines(ctx context.Context, sm *SubstitutionMap, pi
 
 func (c *Compiled) compilePipeline(ctx context.Context, sm *SubstitutionMap, pipeline *config.Pipeline, parent map[string]string) error {
 	log := clog.FromContext(ctx)
-	uses, with := pipeline.Uses, maps.Clone(pipeline.With)
+	name, uses, with := pipeline.Name, pipeline.Uses, maps.Clone(pipeline.With)
 
 	if uses != "" {
 		var data []byte
@@ -239,6 +239,9 @@ func (c *Compiled) compilePipeline(ctx context.Context, sm *SubstitutionMap, pip
 				return fmt.Errorf("undefined input %q to pipeline %q", k, pipeline.Uses)
 			}
 		}
+
+		// We want to keep the original name here because loading the pipeline will overwrite it.
+		pipeline.Name = name
 	}
 
 	if parent != nil {

--- a/pkg/build/pipeline.go
+++ b/pkg/build/pipeline.go
@@ -205,6 +205,17 @@ func (r *pipelineRunner) runPipeline(ctx context.Context, pipeline *config.Pipel
 		log.Infof("running step %q", id)
 	}
 
+	slogs := []any{}
+	if pipeline.Name != "" {
+		slogs = append(slogs, "name", pipeline.Name)
+	}
+	if pipeline.Uses != "" {
+		slogs = append(slogs, "uses", pipeline.Uses)
+	}
+	if len(slogs) != 0 {
+		ctx = clog.WithLogger(ctx, log.With(slogs...))
+	}
+
 	command := buildEvalRunCommand(pipeline, debugOption, workdir, pipeline.Runs)
 	if err := r.runner.Run(ctx, r.config, envOverride, command...); err != nil {
 		if err := r.maybeDebug(ctx, pipeline.Runs, envOverride, command, workdir, err); err != nil {


### PR DESCRIPTION
I noticed while testing this that loading a pipeline via "uses" will overwrite that pipeline's name, which probably isn't what we want, so I've updated Compile() as well to keep the parent's name. This has the nice effect of allowing both "name" and "uses" to be meaningful (if you want to provide more context to why you're using the pipeline) while omitting redundant information (if we have "uses" in the slog context we don't really need to know that pipeline's "name" too).
