### PR TITLE
sca: remove set but never used variable

### DIFF
--- a/pkg/sca/sca.go
+++ b/pkg/sca/sca.go
@@ -187,7 +187,6 @@ func generateSharedObjectNameDeps(ctx context.Context, hdl SCAHandle, generated 
 	log := clog.FromContext(ctx)
 	log.Infof("scanning for shared object dependencies...")
 
-	depends := map[string][]string{}
 	fsys, err := hdl.Filesystem()
 	if err != nil {
 		return err
@@ -310,7 +309,6 @@ func generateSharedObjectNameDeps(ctx context.Context, hdl SCAHandle, generated 
 			if strings.Contains(lib, ".so.") {
 				log.Infof("  found lib %s for %s", lib, path)
 				generated.Runtime = append(generated.Runtime, fmt.Sprintf("so:%s", lib))
-				depends[lib] = append(depends[lib], path)
 			}
 		}
 


### PR DESCRIPTION
In most programming languages compiler would raise a warning unused
variable, assigned but never used.

Or am I missing something?
