### PR TITLE
sca: never emit libcuda.so.1 runtime dep

### DIFF
--- a/pkg/sca/sca.go
+++ b/pkg/sca/sca.go
@@ -307,6 +307,10 @@ func generateSharedObjectNameDeps(ctx context.Context, hdl SCAHandle, generated 
 		}
 
 		for _, lib := range libs {
+			// Cuda is a dangling library, which must come from the host
+			if lib == "libcuda.so.1" {
+				continue
+			}
 			if strings.Contains(lib, ".so.") {
 				log.Infof("  found lib %s for %s", lib, path)
 				generated.Runtime = append(generated.Runtime, fmt.Sprintf("so:%s", lib))


### PR DESCRIPTION
libcuda.so.1 is not a real library with a stable API/ABI. Instead it
is coupled to the runtime kernel. It is typically provided inside
containers, via mounts that ultimately provide it as libcuda.so.1 ->
libcuda.so.555.34 or some such. As no packages in wolfi provide
libcuda.so.1 never emit dependency on it, as it will always make such
packages uninstallable.

This should fix ~120 or so packages that currently declare
"no-depends: true" due to this issue.
