### PR TITLE
git-checkout: support scheduled updates

### DIFF
--- a/pkg/build/pipelines/git-checkout.yaml
+++ b/pkg/build/pipelines/git-checkout.yaml
@@ -189,8 +189,14 @@ pipeline:
           if [ -z "$tag" ]; then
               foundcommit=$(git rev-parse --verify HEAD)
               if [ -n "$expcommit" ] && [ "$expcommit" != "$foundcommit" ]; then
-                  fail "expected commit $expcommit on ${branch:-HEAD}," \
-                      " got $foundcommit"
+                  if [ "$depth" = "-1" ]; then
+                      msg "expected commit $expcommit on ${branch:-HEAD}," \
+                          "got $foundcommit, performing reset"
+                      vr git reset --hard "$expcommit"
+                  else
+                      fail "expected commit $expcommit on ${branch:-HEAD}," \
+                           "got $foundcommit, set depth to -1 to attempt a reset"
+                  fi
               fi
               msg "tip of ${branch:-HEAD} is commit $foundcommit"
               process_cherry_picks "$cherry_pick" || fail "failed to apply cherry-pick"


### PR DESCRIPTION
lifecycle now supports scheduled, periodic updates. Typically these
point at a branch checkout with an expected commit, which is fast
moving.

Instead of expecting for that commit/branch to remain static forever,
reset to it, if depth is set to -1 (full clone, rather than
shallow/single commit). And update messaging.

This will correctly build scheduled periodic packages, even as
upstream branch moves forward.

The builds will fail, if upstream rewrites branch history, or if depth
is not set to -1 (non-shallow). Meaning default behaviour of expected
commit is preserved.

Thus the typical hard-failure of:

> 2024/09/20 15:08:22 INFO [git checkout] FAIL expected commit 4a19238a0920463b9582c8593526d322ac78dc13 on release-v2.9,  got 4fb4544cea4f9be4fad23bf6bbce764738472ea6

New message is:

> 2024/09/20 17:05:56 INFO [git checkout] FAIL expected commit 4a19238a0920463b9582c8593526d322ac78dc13 on release-v2.9, got 4fb4544cea4f9be4fad23bf6bbce764738472ea6, set depth to -1 to attempt a reset

Then setting depth to -1 will result in:

> 2024/09/20 17:04:58 INFO [git checkout] expected commit 4a19238a0920463b9582c8593526d322ac78dc13 on release-v2.9, got 4fb4544cea4f9be4fad23bf6bbce764738472ea6, performing reset
> 2024/09/20 17:04:58 INFO [git checkout] execute: git reset --hard 4a19238a0920463b9582c8593526d322ac78dc13
> 2024/09/20 17:04:59 INFO HEAD is now at 4a19238a0 Charts release validation (#4424)
> 2024/09/20 17:04:59 INFO [git checkout] tip of release-v2.9 is commit 4fb4544cea4f9be4fad23bf6bbce764738472ea6

And if upstream rewrites history and drops expected commit from history, this failure will happen:

> 2024/09/20 17:04:19 INFO [git checkout] expected commit 4a19238a0920463b9582c8593526d322ac78dc14 on release-v2.9, got 4fb4544cea4f9be4fad23bf6bbce764738472ea6, performing reset
> 2024/09/20 17:04:19 INFO [git checkout] execute: git reset --hard 4a19238a0920463b9582c8593526d322ac78dc14
> 2024/09/20 17:04:19 WARN fatal: Could not parse object '4a19238a0920463b9582c8593526d322ac78dc14'.

This will help building roughly 11 packages that are already using `schdule:` update setting.
