### PR TITLE
Pin the package version used during tests

### DIFF
--- a/pkg/build/compile.go
+++ b/pkg/build/compile.go
@@ -74,7 +74,8 @@ func (t *Test) Compile(ctx context.Context) error {
 		te := &cfg.Subpackages[i].Test.Environment.Contents
 
 		// Append the subpackage that we're testing to be installed.
-		te.Packages = append(te.Packages, sp.Name)
+		version := fmt.Sprintf("%s-r%d", t.Configuration.Package.Version, t.Configuration.Package.Epoch)
+		te.Packages = append(te.Packages, sp.Name+"="+version)
 
 		if err := test.CompilePipelines(ctx, sm, sp.Test.Pipeline); err != nil {
 			return fmt.Errorf("compiling subpackage %q tests: %w", sp.Name, err)
@@ -95,7 +96,8 @@ func (t *Test) Compile(ctx context.Context) error {
 		if t.Package != "" {
 			te.Packages = append(te.Packages, t.Package)
 		} else {
-			te.Packages = append(te.Packages, t.Configuration.Package.Name)
+			version := fmt.Sprintf("%s-r%d", t.Configuration.Package.Version, t.Configuration.Package.Epoch)
+			te.Packages = append(te.Packages, t.Configuration.Package.Name+"="+version)
 		}
 
 		if err := test.CompilePipelines(ctx, sm, cfg.Test.Pipeline); err != nil {

--- a/pkg/build/compile_test.go
+++ b/pkg/build/compile_test.go
@@ -71,8 +71,12 @@ func TestInheritWorkdir(t *testing.T) {
 
 func TestCompileTest(t *testing.T) {
 	test := &Test{
-		Package: "main",
 		Configuration: config.Configuration{
+			Package: config.Package{
+				Name:    "main",
+				Version: "1.2.3",
+				Epoch:   4,
+			},
 			Test: &config.Test{
 				Environment: apko_types.ImageConfiguration{
 					Contents: apko_types.ImageContents{
@@ -107,11 +111,11 @@ func TestCompileTest(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if got, want := test.Configuration.Test.Environment.Contents.Packages, []string{"main-base", "main", "main-need"}; !slices.Equal(got, want) {
+	if got, want := test.Configuration.Test.Environment.Contents.Packages, []string{"main-base", "main=1.2.3-r4", "main-need"}; !slices.Equal(got, want) {
 		t.Errorf("main test packages: want %v, got %v", want, got)
 	}
 
-	if got, want := test.Configuration.Subpackages[0].Test.Environment.Contents.Packages, []string{"subpackage-base", "subpackage", "subpackage-need"}; !slices.Equal(got, want) {
+	if got, want := test.Configuration.Subpackages[0].Test.Environment.Contents.Packages, []string{"subpackage-base", "subpackage=1.2.3-r4", "subpackage-need"}; !slices.Equal(got, want) {
 		t.Errorf("subpackage test packages: want %v, got %v", want, got)
 	}
 }


### PR DESCRIPTION
Melange allows users to define "test" pipelines which are executed via `melange test` (or `wolfictl test`), [ex](https://github.com/wolfi-dev/os/blob/main/apko.yaml):
```yaml
package:
  name: apko
  version: 0.19.2
  epoch: 0

test:
  pipeline:
    - runs: |
        apko version || exit 1
```
Melange will automatically add the package that is being tested (in this case `apko`) to the package constraints/world where the test environment is run as it's assumed that you're trying to test the package that was just built, ex:
```
2024/09/23 16:29:04 INFO image configuration:
2024/09/23 16:29:04 INFO   contents:
2024/09/23 16:29:04 INFO     build repositories: []
2024/09/23 16:29:04 INFO     runtime repositories: []
2024/09/23 16:29:04 INFO     keyring:      []
2024/09/23 16:29:04 INFO     packages:     [apko]
```

However, there is no _version_ of this package specified which means if you were to execute the tests on an older commit, or incorrectly publish a newer version of the package and then revert without withdrawing, the test will use the _latest_ version instead of the version from the config (`package.version` and `package.epoch`)

This PR adds a version constraint to ensure that `melange test` always runs against the version that was built using the matching YAML configuration, ex:
```
2024/09/23 16:30:09 INFO image configuration:
2024/09/23 16:30:09 INFO   contents:
2024/09/23 16:30:09 INFO     build repositories: []
2024/09/23 16:30:09 INFO     runtime repositories: []
2024/09/23 16:30:09 INFO     keyring:      []
2024/09/23 16:30:09 INFO     packages:     [apko=0.19.2-r0]
```