### PR TITLE
Make installing -dev package "just work" and pull in all other dev libraries it needs

### DIFF
--- a/pkg/sca/sca.go
+++ b/pkg/sca/sca.go
@@ -441,28 +441,28 @@ func generatePkgConfigDeps(ctx context.Context, hdl SCAHandle, generated *config
 		if isInDir(path, []string{"usr/local/lib/pkgconfig/", "usr/local/share/pkgconfig/", "usr/lib/pkgconfig/", "usr/lib64/pkgconfig/", "usr/share/pkgconfig/"}) {
 			log.Infof("  found pkg-config %s for %s", pcName, path)
 			generated.Provides = append(generated.Provides, fmt.Sprintf("pc:%s=%s", pcName, hdl.Version()))
+
+			if generateRuntimePkgConfigDeps {
+				// TODO(kaniini): Capture version relationships here too.  In practice, this does not matter
+				// so much though for us.
+				for _, dep := range pkg.Requires {
+					log.Infof("  found pkg-config dependency (requires) %s for %s", dep.Identifier, path)
+					generated.Runtime = append(generated.Runtime, fmt.Sprintf("pc:%s", dep.Identifier))
+				}
+
+				for _, dep := range pkg.RequiresPrivate {
+					log.Infof("  found pkg-config dependency (requires private) %s for %s", dep.Identifier, path)
+					generated.Runtime = append(generated.Runtime, fmt.Sprintf("pc:%s", dep.Identifier))
+				}
+
+				for _, dep := range pkg.RequiresInternal {
+					log.Infof("  found pkg-config dependency (requires internal) %s for %s", dep.Identifier, path)
+					generated.Runtime = append(generated.Runtime, fmt.Sprintf("pc:%s", dep.Identifier))
+				}
+			}
 		} else {
 			log.Infof("  found vendored pkg-config %s for %s", pcName, path)
 			generated.Vendored = append(generated.Vendored, fmt.Sprintf("pc:%s=%s", pcName, hdl.Version()))
-		}
-
-		if generateRuntimePkgConfigDeps {
-			// TODO(kaniini): Capture version relationships here too.  In practice, this does not matter
-			// so much though for us.
-			for _, dep := range pkg.Requires {
-				log.Infof("  found pkg-config dependency (requires) %s for %s", dep.Identifier, path)
-				generated.Runtime = append(generated.Runtime, fmt.Sprintf("pc:%s", dep.Identifier))
-			}
-
-			for _, dep := range pkg.RequiresPrivate {
-				log.Infof("  found pkg-config dependency (requires private) %s for %s", dep.Identifier, path)
-				generated.Runtime = append(generated.Runtime, fmt.Sprintf("pc:%s", dep.Identifier))
-			}
-
-			for _, dep := range pkg.RequiresInternal {
-				log.Infof("  found pkg-config dependency (requires internal) %s for %s", dep.Identifier, path)
-				generated.Runtime = append(generated.Runtime, fmt.Sprintf("pc:%s", dep.Identifier))
-			}
 		}
 
 		return nil

--- a/pkg/sca/sca.go
+++ b/pkg/sca/sca.go
@@ -380,8 +380,10 @@ func generateSharedObjectNameDeps(ctx context.Context, hdl SCAHandle, generated 
 	return nil
 }
 
-// TODO(kaniini): Turn this feature on once enough of Wolfi is built with provider data.
-var generateRuntimePkgConfigDeps = false
+// TODO(xnox): Note remove this feature flag, once successful
+// note this can generate depends on pc: files that do not exist in
+// wolfi, however package install tests will catch that in presubmit
+var generateRuntimePkgConfigDeps = true
 
 // generatePkgConfigDeps generates a list of provided pkg-config package names and versions,
 // as well as dependency relationships.


### PR DESCRIPTION
Developer impact:

I want to compile and link against curl, i installed curl-dev and nothing works, i even installed openssl-dev and everything still does not work:

```
diff --git a/scans/curl.yaml.scan b/scans/curl.yaml.scan
index 98c235989..5260fd010 100644
--- a/scans/curl.yaml.scan
+++ b/scans/curl.yaml.scan
@@ -13,6 +13,11 @@ depend = brotli-dev
 depend = libpsl-dev
 depend = nghttp2-dev
 depend = openssl-dev
+depend = pc:libbrotlidec
+depend = pc:libnghttp2
+depend = pc:libpsl
+depend = pc:openssl
+depend = pc:zlib
 depend = so:libcurl.so.4
 provides = cmd:curl-config=8.10.1-r1
 provides = pc:libcurl=8.10.1-r1
```

With this change curl-dev automatically gains depends on openssl zlib libpsl libnghttp2 libbrotlidec dev packages to ensure that building and linking against curl-dev "just works".

- **generateRuntimePkgConfigDeps: only do so for public .pc, not vendored**
  The existing neom test case of vendored .pc files verifies this, and
  fails, when this feature is turned on.
  
  The diff is ugly, but it moves and indents the `if
  generateRuntimePkgConfigDeps{}` to be nested in the `if isInDir(){}`
  first condition for public files.
  

- **Enable pc file dependencies**
  Downloaded and extracted 1,030 .pc files from wolfi (base on 24th
  September file listing of all packages from @dustin).
  
  Executing `pkgconf --exist` on them revieled that 57 of them declare
  dependencies that do not, in fact exist.
  
  It is safe to turn pc: depends, as for vast majority of packages they
  will work correctly.
  
  For the 57 broken ones, there is now test/pkgconf pipeline, and one
  genuinely has to fix those. By either packaging libraries that are
  declared as required, ensuring those dependant libraries ship
  pkgconfig file, or patch/remove said broken pkgconfig file.
  
  Out of the sample of 1,030 .pc files, the 788 of them do have
  requirements declared. Thus they will need rebuilds to gain the
  correct dependencies. These however are in just 469 binary packages,
  some of which come from the same origin. Thus roughly at most 400 or
  so origins to rebuild.
  
  Furthermore wolfi pre-submit, install apk check will catch the broken
  -dev packages that cannot be installed.
  
  With this feature enabled, build log has:
  
  ```
  2024/09/27 23:44:24 INFO scanning for pkg-config data...
  2024/09/27 23:44:24 INFO   found pkg-config libarchive for usr/lib/pkgconfig/libarchive.pc
  ...
  2024/09/27 23:44:24 INFO   found pkg-config dependency (requires private) libcrypto for usr/lib/pkgconfig/libarchive.pc
  ...
  2024/09/27 23:44:24 INFO   runtime:
  2024/09/27 23:44:24 INFO     bzip2-dev
  2024/09/27 23:44:24 INFO     lz4-dev
  ...
  2024/09/27 23:44:24 INFO     pc:libcrypto
  ...
  2024/09/27 23:44:24 INFO     so:libarchive.so.13
  2024/09/27 23:44:24 INFO     xz-dev
  2024/09/27 23:44:24 INFO     zlib-dev
  2024/09/27 23:44:24 INFO     zstd-dev
  2024/09/27 23:44:24 INFO   provides:
  2024/09/27 23:44:24 INFO     pc:libarchive=3.7.6-r0
  ```
  
  These extra new dependency generated `pc:libcrypto` which upon
  installing libarchive-dev allows one to use it straight away for both
  dynamic and static linking.
  
  Note all of our public pc files already generated provides:
  
  ```
  $ apk info --provides openssl-dev
  openssl-dev-3.3.2-r0 provides:
  pc:libcrypto=3.3.2
  pc:libssl=3.3.2
  pc:openssl=3.3.2
  ```