### PR TITLE
Properly detect .so files as deps

### DIFF
--- a/pkg/sca/e2e_test.go
+++ b/pkg/sca/e2e_test.go
@@ -74,6 +74,7 @@ func TestAnalyze(t *testing.T) {
 				"so:liblcms2-e69eef39.so.2.0.16",
 				"so:liblzma-13fa198c.so.5.4.5",
 				"so:libm.so.6",
+				"so:libopenblas64_p-r0-0cf96a72.3.23.dev.so",
 				"so:libopenjp2-eca49203.so.2.5.0",
 				"so:libpng16-78d422d5.so.16.40.0",
 				"so:libpthread.so.0",
@@ -131,6 +132,8 @@ func TestAnalyze(t *testing.T) {
 				"so:libm.so.6",
 				"so:libmount.so.1",
 				"so:libssl.so.3",
+				"so:libsystemd-core-256.so",
+				"so:libsystemd-shared-256.so",
 				"so:libudev.so.1",
 			},
 			Provides: []string{

--- a/pkg/sca/sca.go
+++ b/pkg/sca/sca.go
@@ -310,7 +310,7 @@ func generateSharedObjectNameDeps(ctx context.Context, hdl SCAHandle, generated 
 			if lib == "libcuda.so.1" {
 				continue
 			}
-			if strings.Contains(lib, ".so.") {
+			if strings.Contains(lib, ".so") {
 				log.Infof("  found lib %s for %s", lib, path)
 				generated.Runtime = append(generated.Runtime, fmt.Sprintf("so:%s", lib))
 			}


### PR DESCRIPTION
Fixes: https://github.com/wolfi-dev/os/issues/29828

Currently sca only adds files ending in '.so.' as valid deps. Some libraries, libgallium in mesa for example, don't have a numbered suffix and are being dropped by sca.

```
ldd usr/lib/libEGL.so.1.0.0 | grep gallium
	libgallium-24.2.3.so => not found
```

## Melange Pull Request Template

<!--
*** PULL REQUEST CHECKLIST: PLEASE START HERE ***

The single most important feature of melange is that we can build Wolfi.

Many changes to melange introduce a risk of breaking the build, and sometimes
these are not flushed out until a package is changed (much) later.  This
pertains to basic execution, SCA changes, linter changes, and more.
-->

### Functional Changes

- [X] This change can build all of Wolfi without errors (describe results in notes)

Notes:

This isn't a functional change as far as I'm ware. I didn't find issues building other packages.


### SCA Changes

- [x] Examining several representative APKs show no regression / the desired effect (details in notes)

Notes:

Previously mesa-egl was missing the dep on so:libgallium. With this change it is not. Other packages missing deps should now have them once this lands and they're rebuilt.
