### PR TITLE
fix py3-pandas-test

### DIFF
--- a/e2e-tests/py3-pandas-test.yaml
+++ b/e2e-tests/py3-pandas-test.yaml
@@ -24,5 +24,3 @@ test:
       with:
         import: ma
         from: numpy
-    - runs: |
-        python3 ./py3-pandas-test.py


### PR DESCRIPTION
This test currently fails with `/bin/sh: python3: not found`

Instead, we have `/usr/bin/python3.12` (someday `3.13`, etc.)