### PR TITLE
Adjust an e2e-test that made a bad assumption.

### DIFF
--- a/e2e-tests/py3-pandas-test.yaml
+++ b/e2e-tests/py3-pandas-test.yaml
@@ -13,6 +13,7 @@ test:
     contents:
       packages:
         - busybox
+        - python-3
   pipeline:
     - uses: python/import
       with:


### PR DESCRIPTION
Installing py3-pandas does not guarantee you a /usr/bin/python3.
This is fallout of our choice to make pythons co-installable.
More info on this https://github.com/wolfi-dev/os/issues/26818

There isn't any serious value gained in this test here
versus the pipeline import tests that are still there, so
just drop it.
