### PR TITLE
[Draft] sca: check if runtime dependencies are vendored

### DIFF
--- a/pkg/sca/sca.go
+++ b/pkg/sca/sca.go
@@ -247,8 +247,9 @@ func generateSharedObjectNameDeps(ctx context.Context, hdl SCAHandle, generated 
 
 				for _, soname := range sonames {
 					log.Infof("  found soname %s for %s", soname, path)
-
-					generated.Runtime = append(generated.Runtime, fmt.Sprintf("so:%s", soname))
+					if isInDir(path, libDirs) {
+						generated.Runtime = append(generated.Runtime, fmt.Sprintf("so:%s", soname))
+					}
 				}
 			}
 


### PR DESCRIPTION
This fixes and issue with 288fb15cf152df1de3ab94d5b4c4202acd005d7d that too broadly added dependencies on vendored libraries.

Libreoffice for example picked up a dep to an internal library without the corresponding provides.

## Melange Pull Request Template

<!--
*** PULL REQUEST CHECKLIST: PLEASE START HERE ***

The single most important feature of melange is that we can build Wolfi.

Many changes to melange introduce a risk of breaking the build, and sometimes
these are not flushed out until a package is changed (much) later.  This
pertains to basic execution, SCA changes, linter changes, and more.
-->

### Functional Changes

- [ ] This change can build all of Wolfi without errors (describe results in notes)

Notes:

### SCA Changes

- [ ] Examining several representative APKs show no regression / the desired effect (details in notes)

Notes:

### Linter

- [ ] The new check is clean across Wolfi
- [ ] The new check is opt-in or a warning

Notes:
