### PR TITLE
fix: pc provides

### DIFF
--- a/pkg/sca/sca.go
+++ b/pkg/sca/sca.go
@@ -439,7 +439,7 @@ func generatePkgConfigDeps(ctx context.Context, hdl SCAHandle, generated *config
 		pcName := filepath.Base(path)
 		pcName, _ = strings.CutSuffix(pcName, ".pc")
 
-		if isInDir(path, []string{"lib/pkgconfig/", "usr/lib/pkgconfig/", "lib64/pkgconfig/", "usr/lib64/pkgconfig/"}) {
+		if isInDir(path, []string{"usr/local/lib/pkgconfig/", "usr/local/share/pkgconfig/", "usr/lib/pkgconfig/", "usr/lib64/pkgconfig/", "usr/share/pkgconfig/"}) {
 			log.Infof("  found pkg-config %s for %s", pcName, path)
 			generated.Provides = append(generated.Provides, fmt.Sprintf("pc:%s=%s", pcName, hdl.Version()))
 		} else {


### PR DESCRIPTION
As discovered in https://github.com/chainguard-dev/melange/pull/1522
and ongoing test pipelines of pc files discrepancy discovered between
wolfi configured pkgconf and what melange generates.

In wolfi https://github.com/wolfi-dev/os/blob/9ad9b181cee6bc20fd090b942c2355990724bf7c/pkgconf.yaml#L39

```
 --with-pkg-config-dir=/usr/local/lib/pkgconfig:/usr/local/share/pkgconfig:/usr/lib/pkgconfig:/usr/share/pkgconfig \
```

pkgconf is configured to look for the above paths. But melange looks at different set of paths.

pkgconf installs pc-files into "usr/lib" ("usr/lib64" is acceptable too, because of lib64->lib link in base layout) and into "usr/share". However "usr/share" is not considered public by melange, but should be. As "architecture independent" pc files are there, for example for header-only libraries.

Align locations acceptable by our pkgconf to match locations to also be considred by melage as public for pc: dependencies and provides.

This will unblock rebuilding xorgproto, and unblock merging and enabling automatic pc depends.

Impact on wolfi
===============

These locations have no pc files in wolfi:

```
$ grep -e ':/lib64/pkgconfig' -e ':/lib/pkgconfig' -e ':/usr/local/pkgconfig' FILES | wc -l
0
```

These newly added locations, which are accepted by pkgconf, will generate new provides:

```
$ grep -e ':/usr/local/share/pkgconfig/.*.pc' -e ':/usr/share/pkgconfig/.*.pc' FILES | sort
bash-completion-2.14.0-r1:/usr/share/pkgconfig/bash-completion.pc
Catch2-dev-3.7.1-r0:/usr/share/pkgconfig/catch2.pc
Catch2-dev-3.7.1-r0:/usr/share/pkgconfig/catch2-with-main.pc
cli11-2.4.2-r1:/usr/share/pkgconfig/CLI11.pc
eigen-dev-3.4.0-r3:/usr/share/pkgconfig/eigen3.pc
eudev-dev-3.2.14-r2:/usr/share/pkgconfig/udev.pc
fish-dev-3.7.1-r1:/usr/share/pkgconfig/fish.pc
gi-docgen-2024.1-r0:/usr/local/share/pkgconfig/gi-docgen.pc
gtk-doc-1.34.0-r0:/usr/share/pkgconfig/gtk-doc.pc
hicolor-icon-theme-0.18-r0:/usr/share/pkgconfig/default-icon-theme.pc
hwdata-dev-0.388-r0:/usr/share/pkgconfig/hwdata.pc
iso-codes-dev-4.17.0-r0:/usr/share/pkgconfig/iso-codes.pc
kmod-dev-33-r0:/usr/share/pkgconfig/kmod.pc
nlohmann-json-3.11.3-r1:/usr/share/pkgconfig/nlohmann_json.pc
py3.10-pybind11-2.13.6-r1:/usr/share/pkgconfig/pybind11.pc
py3.11-pybind11-2.13.6-r1:/usr/share/pkgconfig/pybind11.pc
py3.12-pybind11-2.13.6-r1:/usr/share/pkgconfig/pybind11.pc
py3.13-pybind11-2.13.6-r1:/usr/share/pkgconfig/pybind11.pc
py3-gi-docgen-2024.1-r0:/usr/share/pkgconfig/gi-docgen.pc
py3-pybind11-dev-2.13.4-r0:/usr/share/pkgconfig/pybind11.pc
scdoc-1.11.3-r0:/usr/share/pkgconfig/scdoc.pc
shared-mime-info-2.4-r1:/usr/share/pkgconfig/shared-mime-info.pc
spirv-headers-1.3.261.1-r2:/usr/share/pkgconfig/SPIRV-Headers.pc
subversion-dev-1.14.3-r1:/usr/share/pkgconfig/libsvn_client.pc
subversion-dev-1.14.3-r1:/usr/share/pkgconfig/libsvn_delta.pc
subversion-dev-1.14.3-r1:/usr/share/pkgconfig/libsvn_diff.pc
subversion-dev-1.14.3-r1:/usr/share/pkgconfig/libsvn_fs_fs.pc
subversion-dev-1.14.3-r1:/usr/share/pkgconfig/libsvn_fs.pc
subversion-dev-1.14.3-r1:/usr/share/pkgconfig/libsvn_fs_util.pc
subversion-dev-1.14.3-r1:/usr/share/pkgconfig/libsvn_fs_x.pc
subversion-dev-1.14.3-r1:/usr/share/pkgconfig/libsvn_ra_local.pc
subversion-dev-1.14.3-r1:/usr/share/pkgconfig/libsvn_ra.pc
subversion-dev-1.14.3-r1:/usr/share/pkgconfig/libsvn_ra_serf.pc
subversion-dev-1.14.3-r1:/usr/share/pkgconfig/libsvn_ra_svn.pc
subversion-dev-1.14.3-r1:/usr/share/pkgconfig/libsvn_repos.pc
subversion-dev-1.14.3-r1:/usr/share/pkgconfig/libsvn_subr.pc
subversion-dev-1.14.3-r1:/usr/share/pkgconfig/libsvn_wc.pc
systemd-dev-256.6-r2:/usr/share/pkgconfig/systemd.pc
systemd-dev-256.6-r2:/usr/share/pkgconfig/udev.pc
util-macros-1.20.1-r0:/usr/share/pkgconfig/xorg-macros.pc
wayland-protocols-1.37-r0:/usr/share/pkgconfig/wayland-protocols.pc
xbitmaps-dev-1.1.3-r1:/usr/share/pkgconfig/xbitmaps.pc
xcb-proto-1.17.0-r1:/usr/share/pkgconfig/xcb-proto.pc
xkeyboard-config-dev-2.43-r0:/usr/share/pkgconfig/xkeyboard-config.pc
xorgproto-2024.1-r1:/usr/share/pkgconfig/applewmproto.pc
xorgproto-2024.1-r1:/usr/share/pkgconfig/bigreqsproto.pc
xorgproto-2024.1-r1:/usr/share/pkgconfig/compositeproto.pc
xorgproto-2024.1-r1:/usr/share/pkgconfig/damageproto.pc
xorgproto-2024.1-r1:/usr/share/pkgconfig/dmxproto.pc
xorgproto-2024.1-r1:/usr/share/pkgconfig/dpmsproto.pc
xorgproto-2024.1-r1:/usr/share/pkgconfig/dri2proto.pc
xorgproto-2024.1-r1:/usr/share/pkgconfig/dri3proto.pc
xorgproto-2024.1-r1:/usr/share/pkgconfig/fixesproto.pc
xorgproto-2024.1-r1:/usr/share/pkgconfig/fontsproto.pc
xorgproto-2024.1-r1:/usr/share/pkgconfig/glproto.pc
xorgproto-2024.1-r1:/usr/share/pkgconfig/inputproto.pc
xorgproto-2024.1-r1:/usr/share/pkgconfig/kbproto.pc
xorgproto-2024.1-r1:/usr/share/pkgconfig/presentproto.pc
xorgproto-2024.1-r1:/usr/share/pkgconfig/randrproto.pc
xorgproto-2024.1-r1:/usr/share/pkgconfig/recordproto.pc
xorgproto-2024.1-r1:/usr/share/pkgconfig/renderproto.pc
xorgproto-2024.1-r1:/usr/share/pkgconfig/resourceproto.pc
xorgproto-2024.1-r1:/usr/share/pkgconfig/scrnsaverproto.pc
xorgproto-2024.1-r1:/usr/share/pkgconfig/videoproto.pc
xorgproto-2024.1-r1:/usr/share/pkgconfig/xcmiscproto.pc
xorgproto-2024.1-r1:/usr/share/pkgconfig/xextproto.pc
xorgproto-2024.1-r1:/usr/share/pkgconfig/xf86bigfontproto.pc
xorgproto-2024.1-r1:/usr/share/pkgconfig/xf86dgaproto.pc
xorgproto-2024.1-r1:/usr/share/pkgconfig/xf86driproto.pc
xorgproto-2024.1-r1:/usr/share/pkgconfig/xf86vidmodeproto.pc
xorgproto-2024.1-r1:/usr/share/pkgconfig/xineramaproto.pc
xorgproto-2024.1-r1:/usr/share/pkgconfig/xproto.pc
xorgproto-2024.1-r1:/usr/share/pkgconfig/xwaylandproto.pc
xtrans-1.5.0-r2:/usr/share/pkgconfig/xtrans.pc
yajl-dev-2.1.0-r4:/usr/share/pkgconfig/yajl.pc
```

Which are currently missing.
