### PR TITLE
cmake: switch from MinSizeRel to Release

### DIFF
--- a/pkg/build/pipelines/cmake/configure.yaml
+++ b/pkg/build/pipelines/cmake/configure.yaml
@@ -20,5 +20,5 @@ pipeline:
       cmake -B ${{inputs.output-dir}} -G Ninja \
         -DCMAKE_INSTALL_PREFIX=/usr \
         -DCMAKE_INSTALL_LIBDIR=lib \
-        -DCMAKE_BUILD_TYPE=MinSizeRel \
+        -DCMAKE_BUILD_TYPE=Release \
         ${{inputs.opts}}


### PR DESCRIPTION
It is a choice of optimisation levels to apply at build time of C/C++
code. There are choices spanning from -00 to -03 and -0s. Most
distributions build with debug symbols which are then stripped, but
otherwise apply release optimisations at -O2 or -O3 level.

This is evident from dpkg-buildflags & debhelper pipelines in
Debian-like systems, as well as rpm macros on Fedora-like systems.

In C/C++ there are code optimisations at -O2 and higher levels that
increate binary size. And compiler has an option, do not optimise
things that would increase binary size -Os (Optimize for size. -Os
enables all -O2 optimizations except those that often increase code
size).

In wolfi by default we choose to build with -O2 via build-env files,
and openssf-compiler-options. However our CMAKE pipeline switches to
MinSizeRel build type that instead compiles things to -Os level.

On performant server hardware, it means that whilst the binaries are
at most 1-3% smaller, they potentially have worse performance. A very
recent analysis done by Fedora concluded that performance gain
outweighs the binary size to even go higher to O3. See
https://fedoraproject.org/wiki/Changes/Python_built_with_gcc_O3

The level of optimisation applied to the C/C++, doesn't impact our
primary goal of delivering zero CVEs, but it can hinder our secondary
goal of being at-parity compatible with other distributions.

Switch cmake pipeline to Release build type by default.

References:
 - https://salsa.debian.org/debian/debhelper/-/blob/main/lib/Debian/Debhelper/Buildsystem/cmake.pm?ref_type=heads
 - https://src.fedoraproject.org/rpms/cmake/blob/rawhide/f/macros.cmake.in
 - https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html
 - https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html
 - https://fedoraproject.org/wiki/Changes/Python_built_with_gcc_O3
