### PR TITLE
Add redis-valkey pipelines

### DIFF
--- a/pkg/build/pipelines/redis-valkey/make.yaml
+++ b/pkg/build/pipelines/redis-valkey/make.yaml
@@ -1,0 +1,23 @@
+name: Run make for redis/valkey
+
+inputs:
+  dir:
+    description: |
+      The directory containing the codebase.
+    default: .
+  opts:
+    description: |
+      Options to pass to the make command.
+    default: ''
+
+needs:
+  packages:
+    - make
+
+pipeline:
+  - runs: |
+      export CFLAGS="$CFLAGS -DUSE_MALLOC_USABLE_SIZE ${{inputs.opts}}"
+        make \
+        BUILD_TLS=yes \
+        all -j$(nproc)
+      make install PREFIX=/usr INSTALL_BIN="${{targets.destdir}}/usr/bin"

--- a/pkg/build/pipelines/redis-valkey/subpackage-benchmark.yaml
+++ b/pkg/build/pipelines/redis-valkey/subpackage-benchmark.yaml
@@ -1,0 +1,17 @@
+name: Create benchamark subpackage for redis/valkey
+
+inputs:
+  project:
+    description: |
+      The project name (redis or valkey)
+    required: true
+
+pipeline:
+  - runs: |
+      mkdir -p "${{targets.subpkgdir}}"/usr/bin
+      mv "${{targets.destdir}}"/usr/bin/${{inputs.project}}-benchmark "${{targets.subpkgdir}}"/usr/bin/${{inputs.project}}-benchmark
+
+description: ${{inputs.project}}-benchmark utility that simulates running commands done by N clients while at the same time sending M total queries
+
+provides:
+  - ${{inputs.project}}-benchmark=${{package.full-version}}

--- a/pkg/build/pipelines/redis-valkey/subpackage-cli.yaml
+++ b/pkg/build/pipelines/redis-valkey/subpackage-cli.yaml
@@ -1,0 +1,17 @@
+name: Create cli subpackage for redis/valkey
+
+inputs:
+  project:
+    description: |
+      The project name (redis or valkey)
+    required: true
+
+pipeline:
+  - runs: |
+      mkdir -p "${{targets.subpkgdir}}"/usr/bin
+      mv "${{targets.destdir}}"/usr/bin/${{inputs.project}}-cli "${{targets.subpkgdir}}"/usr/bin/${{inputs.project}}-cli
+  
+description: ${{inputs.project}}-cli is the command line interface utility to talk with ${{inputs.project}}.
+
+provides:
+  - ${{inputs.project}}-cli=${{package.full-version}}

--- a/pkg/build/pipelines/redis-valkey/tests.yaml
+++ b/pkg/build/pipelines/redis-valkey/tests.yaml
@@ -1,0 +1,40 @@
+name: Run tests for redis/valkey
+
+needs:
+  packages:
+    - make
+
+inputs:
+  project:
+    description: |
+      The project name (redis or valkey)
+    required: true
+
+pipeline:
+  - runs: |
+      cat <<EOF >> /tmp/config
+      dbfilename dump.rdb
+      pidfile /tmp/6379.pid
+      dir /tmp/
+      EOF
+
+      ${{inputs.project}}-server /tmp/config &
+      sleep 2 # wait for ${{inputs.project}} to start
+      ${{inputs.project}}-cli SET bike:1 "Process 134" || exit 1
+      ${{inputs.project}}-cli GET bike:1 | grep 'Process 134' || exit 1
+      ${{inputs.project}}-cli exists bike:1 | grep 1 || exit 1
+      ${{inputs.project}}-cli exists bike:2 | grep 0 || exit 1
+      ${{inputs.project}}-cli save
+      # these are used in the case of symlinks in valkey packages
+      if [ "${{inputs.project}}" -eq "valkey" ]; then
+        redis-check-aof --version
+        redis-check-rdb --version
+        redis-sentinel --version
+        redis-server --version
+      fi
+      ${{inputs.project}}-check-rdb /tmp/dump.rdb
+      ${{inputs.project}}-sentinel --version
+      ${{inputs.project}}-server --version
+
+  - runs: |
+      ${{inputs.project}}-server --version | grep "jemalloc" || exit 1


### PR DESCRIPTION
This adds a pipeline to melange to reuse across repositories and versions of redis/valkey.

I've tested in wolfi and other repos with `redis` and `valkey` as the project name and everything passes.