### PR TITLE
fix split debug

### DIFF
--- a/pkg/build/pipelines/split/debug.yaml
+++ b/pkg/build/pipelines/split/debug.yaml
@@ -29,7 +29,7 @@ pipeline:
         if [ "$type" != ET_DYN ]; then
           continue
         fi
-        dst=${{targets.contextdir}}/usr/lib/debug/${src#"$PACKAGE_DIR"/*/}.debug
+        dst=${{targets.contextdir}}/usr/lib/debug/${src#"$PACKAGE_DIR"/}.debug
         mkdir -p "${dst%/*}"
         ino=$(stat -c %i "$src")
         if ! [ -e "$PACKAGE_DIR/.dbg-tmp/$ino" ]; then


### PR DESCRIPTION
- **generateRuntimePkgConfigDeps: only do so for public .pc, not vendored**
  The existing neom test case of vendored .pc files verifies this, and
  fails, when this feature is turned on.
  
  The diff is ugly, but it moves and indents the `if
  generateRuntimePkgConfigDeps{}` to be nested in the `if isInDir(){}`
  first condition for public files.
  

- **Enable pc file dependencies**
  Downloaded and extracted 1,030 .pc files from wolfi (base on 24th
  September file listing of all packages from @dustin).
  
  Executing `pkgconf --exist` on them revieled that 57 of them declare
  dependencies that do not, in fact exist.
  
  It is safe to turn pc: depends, as for vast majority of packages they
  will work correctly.
  
  For the 57 broken ones, there is now test/pkgconf pipeline, and one
  genuinely has to fix those. By either packaging libraries that are
  declared as required, ensuring those dependant libraries ship
  pkgconfig file, or patch/remove said broken pkgconfig file.
  
  Out of the sample of 1,030 .pc files, the 788 of them do have
  requirements declared. Thus they will need rebuilds to gain the
  correct dependencies. These however are in just 469 binary packages,
  some of which come from the same origin. Thus roughly at most 400 or
  so origins to rebuild.
  
  Furthermore wolfi pre-submit, install apk check will catch the broken
  -dev packages that cannot be installed.
  
  With this feature enabled, build log has:
  
  ```
  2024/09/27 23:44:24 INFO scanning for pkg-config data...
  2024/09/27 23:44:24 INFO   found pkg-config libarchive for usr/lib/pkgconfig/libarchive.pc
  ...
  2024/09/27 23:44:24 INFO   found pkg-config dependency (requires private) libcrypto for usr/lib/pkgconfig/libarchive.pc
  ...
  2024/09/27 23:44:24 INFO   runtime:
  2024/09/27 23:44:24 INFO     bzip2-dev
  2024/09/27 23:44:24 INFO     lz4-dev
  ...
  2024/09/27 23:44:24 INFO     pc:libcrypto
  ...
  2024/09/27 23:44:24 INFO     so:libarchive.so.13
  2024/09/27 23:44:24 INFO     xz-dev
  2024/09/27 23:44:24 INFO     zlib-dev
  2024/09/27 23:44:24 INFO     zstd-dev
  2024/09/27 23:44:24 INFO   provides:
  2024/09/27 23:44:24 INFO     pc:libarchive=3.7.6-r0
  ```
  
  These extra new dependency generated `pc:libcrypto` which upon
  installing libarchive-dev allows one to use it straight away for both
  dynamic and static linking.
  
  Note all of our public pc files already generated provides:
  
  ```
  $ apk info --provides openssl-dev
  openssl-dev-3.3.2-r0 provides:
  pc:libcrypto=3.3.2
  pc:libssl=3.3.2
  pc:openssl=3.3.2
  ```
  

- **pipelines: fix split/debug**
  Currently the variable substitution for the destination debug symbols
  results in one level of directories being expanded and substituted
  away. This breaks gdb automatic discovery of the debug symbols. Gdb is
  looking for /usr/lib/debug/usr/bin/openssl.debug, whilst current
  split/debug pipelines installs the dst to
  /usr/lib/debug/bin/openssl.debug instead.
  
  I think the substituition intends to strip the prefix path of the
  installed file, to achieve the intended path without the leading '/',
  e.g. usr/bin/openssl.debug. Thus make it do just that.
  