### PR TITLE
pipelines: fix split/debug

### DIFF
--- a/pkg/build/pipelines/split/debug.yaml
+++ b/pkg/build/pipelines/split/debug.yaml
@@ -29,7 +29,7 @@ pipeline:
         if [ "$type" != ET_DYN ]; then
           continue
         fi
-        dst=${{targets.contextdir}}/usr/lib/debug/${src#"$PACKAGE_DIR"/*/}.debug
+        dst=${{targets.contextdir}}/usr/lib/debug/${src#"$PACKAGE_DIR"/}.debug
         mkdir -p "${dst%/*}"
         ino=$(stat -c %i "$src")
         if ! [ -e "$PACKAGE_DIR/.dbg-tmp/$ino" ]; then


### PR DESCRIPTION
Currently the variable substitution for the destination debug symbols
results in one level of directories being expanded and substituted
away. This breaks gdb automatic discovery of the debug symbols. Gdb is
looking for /usr/lib/debug/usr/bin/openssl.debug, whilst current
split/debug pipelines installs the dst to
/usr/lib/debug/bin/openssl.debug instead.

I think the substituition intends to strip the prefix path of the
installed file, to achieve the intended path without the leading '/',
e.g. usr/bin/openssl.debug. Thus make it do just that.
