### PR TITLE
update config: add version filter prefix and contains to release monitor config block so implementations can perform the same behaviour as git and github configs

### DIFF
--- a/docs/UPDATE.md
+++ b/docs/UPDATE.md
@@ -30,6 +30,8 @@ update:
     identifier: 38 # Mandatory, ID number for release monitor
     strip-prefix: v # Optional, if the version obtained from the update service contains a prefix which should be ignored
     strip-suffix: ignore_me # Optional, if the version obtained from the update service contains a suffix which should be ignored
+    version-filter-prefix: v17.2 # Optional, filter to apply when searching versions with a prefix
+    version-filter-contains: foo # Optional, filter to apply when searching versions with any match
 ```
 
 ## GitHub
@@ -53,7 +55,9 @@ update:
     strip-prefix: v # Optional, if the version obtained from the update service contains a prefix which should be ignored
     strip-suffix: ignore_me # Optional, if the version obtained from the update service contains a suffix which should be ignored
     use-tag: true # Optional, override the default of using a GitHub release to identify related tag to fetch.  Not all projects use GitHub releases but just use tags
-    tag-filter: foo # Optional, filter to apply when searching tags on a GitHub repository, some repos maintain a mixture of tags for different major versions for example
+    tag-filter: foo # Deprecated: Use tag-filter-prefix instead
+    tag-filter-prefix: v17.2 # Optional, filter to apply when searching tags with a prefix on a GitHub repository, some repos maintain a mixture of tags for different major versions for example
+    tag-filter-contains: foo # Optional, filter to apply when searching tags with any match on a GitHub repository, some repos maintain a mixture of tags for different major versions for example
 ```
 
 ## Git
@@ -79,6 +83,8 @@ update:
   git:
     tag-filter-prefix: v17.2
     strip-prefix: v
+    strip-suffix: ignore_me
+    tag-filter-contains: foo
   schedule:
     period: daily
     reason: upstream project does not support tags or releases

--- a/pkg/build/pipelines/maven/README.md
+++ b/pkg/build/pipelines/maven/README.md
@@ -28,6 +28,7 @@ Run pombump tool to update versions and properties in a Maven POM file
 | pom | false | Path to pom.xml  | pom.xml |
 | properties | false | Properties to update / add the POM file via command line flag  |  |
 | properties-file | false | Properties file to be used for updating the POM file  | ./pombump-properties.yaml |
+| show-dependency-tree | false | Display a dependency tree for the existing pom.xml file | false |
 
 
 <!-- end:pipeline-reference-gen -->

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -518,6 +518,10 @@ type ReleaseMonitor struct {
 	StripPrefix string `json:"strip-prefix,omitempty" yaml:"strip-prefix,omitempty"`
 	// If the version in release monitor contains a suffix which should be ignored
 	StripSuffix string `json:"strip-suffix,omitempty" yaml:"strip-suffix,omitempty"`
+	// Filter to apply when searching version on a Release Monitoring
+	VersionFilterContains string `json:"version-filter-contains,omitempty" yaml:"version-filter-contains,omitempty"`
+	// Filter to apply when searching version Release Monitoring
+	VersionFilterPrefix string `json:"version-filter-prefix,omitempty" yaml:"version-filter-prefix,omitempty"`
 }
 
 // VersionHandler is an interface that defines methods for retrieving version filtering and stripping parameters.
@@ -599,6 +603,26 @@ func (ghm *GitHubMonitor) GetTagFilterPrefix() string {
 // GetTagFilterContains returns the substring filter to apply when searching tags in GitHubMonitor.
 func (ghm *GitHubMonitor) GetTagFilterContains() string {
 	return ghm.TagFilterContains
+}
+
+// GetStripPrefix returns the prefix that should be stripped from the ReleaseMonitor version.
+func (rm *ReleaseMonitor) GetStripPrefix() string {
+	return rm.StripPrefix
+}
+
+// GetStripSuffix returns the suffix that should be stripped from the ReleaseMonitor version.
+func (rm *ReleaseMonitor) GetStripSuffix() string {
+	return rm.StripSuffix
+}
+
+// GetTagFilterPrefix returns the prefix filter to apply when searching versions in ReleaseMonitor.
+func (rm *ReleaseMonitor) GetTagFilterPrefix() string {
+	return rm.VersionFilterPrefix
+}
+
+// GetTagFilterContains returns the substring filter to apply when searching versions in ReleaseMonitor.
+func (rm *ReleaseMonitor) GetTagFilterContains() string {
+	return rm.VersionFilterContains
 }
 
 // VersionTransform allows mapping the package version to an APK version

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -529,8 +529,8 @@ type ReleaseMonitor struct {
 type VersionHandler interface {
 	GetStripPrefix() string
 	GetStripSuffix() string
-	GetTagFilterPrefix() string
-	GetTagFilterContains() string
+	GetFilterPrefix() string
+	GetFilterContains() string
 }
 
 // GitHubMonitor indicates using the GitHub API
@@ -575,13 +575,13 @@ func (gm *GitMonitor) GetStripSuffix() string {
 	return gm.StripSuffix
 }
 
-// GetTagFilterPrefix returns the prefix filter to apply when searching tags in GitMonitor.
-func (gm *GitMonitor) GetTagFilterPrefix() string {
+// GetFilterPrefix returns the prefix filter to apply when searching tags in GitMonitor.
+func (gm *GitMonitor) GetFilterPrefix() string {
 	return gm.TagFilterPrefix
 }
 
-// GetTagFilterContains returns the substring filter to apply when searching tags in GitMonitor.
-func (gm *GitMonitor) GetTagFilterContains() string {
+// GetFilterContains returns the substring filter to apply when searching tags in GitMonitor.
+func (gm *GitMonitor) GetFilterContains() string {
 	return gm.TagFilterContains
 }
 
@@ -595,13 +595,13 @@ func (ghm *GitHubMonitor) GetStripSuffix() string {
 	return ghm.StripSuffix
 }
 
-// GetTagFilterPrefix returns the prefix filter to apply when searching tags in GitHubMonitor.
-func (ghm *GitHubMonitor) GetTagFilterPrefix() string {
+// GetFilterPrefix returns the prefix filter to apply when searching tags in GitHubMonitor.
+func (ghm *GitHubMonitor) GetFilterPrefix() string {
 	return ghm.TagFilterPrefix
 }
 
-// GetTagFilterContains returns the substring filter to apply when searching tags in GitHubMonitor.
-func (ghm *GitHubMonitor) GetTagFilterContains() string {
+// GetFilterContains returns the substring filter to apply when searching tags in GitHubMonitor.
+func (ghm *GitHubMonitor) GetFilterContains() string {
 	return ghm.TagFilterContains
 }
 
@@ -615,13 +615,13 @@ func (rm *ReleaseMonitor) GetStripSuffix() string {
 	return rm.StripSuffix
 }
 
-// GetTagFilterPrefix returns the prefix filter to apply when searching versions in ReleaseMonitor.
-func (rm *ReleaseMonitor) GetTagFilterPrefix() string {
+// GetFilterPrefix returns the prefix filter to apply when searching versions in ReleaseMonitor.
+func (rm *ReleaseMonitor) GetFilterPrefix() string {
 	return rm.VersionFilterPrefix
 }
 
-// GetTagFilterContains returns the substring filter to apply when searching versions in ReleaseMonitor.
-func (rm *ReleaseMonitor) GetTagFilterContains() string {
+// GetFilterContains returns the substring filter to apply when searching versions in ReleaseMonitor.
+func (rm *ReleaseMonitor) GetFilterContains() string {
 	return rm.VersionFilterContains
 }
 

--- a/pkg/config/schema.json
+++ b/pkg/config/schema.json
@@ -711,6 +711,14 @@
         "strip-suffix": {
           "type": "string",
           "description": "If the version in release monitor contains a suffix which should be ignored"
+        },
+        "version-filter-contains": {
+          "type": "string",
+          "description": "Filter to apply when searching version on a Release Monitoring"
+        },
+        "version-filter-prefix": {
+          "type": "string",
+          "description": "Filter to apply when searching version Release Monitoring"
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
NOTE:
This renames two exported interfaces so they are normalized naming
```
	GetFilterPrefix() string
	GetFilterContains() string
```

This helps keep the existing UX consistent but allows the new release monitoring config to avoid mentioning `tag`s as that would be confusing.

Example of how things will look while keeping existing UX in YAML

Git - unchanged
```yaml
update:
  enabled: true
  git:
    tag-filter-prefix: v17.2
    tag-filter-contains: foo
```

GitHub - unchanged
```yaml
update:
  enabled: true
  git:
    tag-filter-prefix: v17.2
    tag-filter-contains: foo
```

Release monitor - changed: new config will use version-filter-prefix and not tag-filter-prefix.
```yaml
update:
  enabled: true 
  release-monitor:
    identifier: 38
    version-filter-prefix: v17.2
    version-filter-contains: foo
```

### Functional Changes

- [x] This change can build all of Wolfi without errors (describe results in notes)
