### PR TITLE
fix(qemu): fix failing test pipeline when using qemu runner

### DIFF
--- a/pkg/build/test.go
+++ b/pkg/build/test.go
@@ -350,7 +350,6 @@ func (t *Test) TestPackage(ctx context.Context) error {
 		}...)
 	}
 
-
 	// Filter out any subpackages with false If conditions.
 	t.Configuration.Subpackages = slices.DeleteFunc(t.Configuration.Subpackages, func(sp config.Subpackage) bool {
 		result, err := shouldRun(sp.If)
@@ -420,7 +419,7 @@ func (t *Test) TestPackage(ctx context.Context) error {
 		log.Info("No source directory specified, skipping workspace population")
 	} else {
 		// Prepare workspace directory
-		if err := os.MkdirAll(t.WorkspaceDir, 0755); err != nil {
+		if err := os.MkdirAll(t.WorkspaceDir, 0o755); err != nil {
 			return fmt.Errorf("mkdir -p %s: %w", t.WorkspaceDir, err)
 		}
 
@@ -594,7 +593,7 @@ func (t *Test) guestFS(ctx context.Context, suffix string) (apkofs.FullFS, error
 	// Test by having a suffix, so we get a clean guest directory for each of
 	// them.
 	guestDir := fmt.Sprintf("%s-%s", t.GuestDir, suffix)
-	if err := os.MkdirAll(guestDir, 0755); err != nil {
+	if err := os.MkdirAll(guestDir, 0o755); err != nil {
 		return nil, fmt.Errorf("mkdir -p %s: %w", guestDir, err)
 	}
 

--- a/pkg/build/test.go
+++ b/pkg/build/test.go
@@ -344,6 +344,13 @@ func (t *Test) TestPackage(ctx context.Context) error {
 		return fmt.Errorf("compiling test pipelines: %w", err)
 	}
 
+	if t.Runner.Name() == container.QemuName {
+		t.ExtraTestPackages = append(t.ExtraTestPackages, []string{
+			"melange-microvm-init",
+		}...)
+	}
+
+
 	// Filter out any subpackages with false If conditions.
 	t.Configuration.Subpackages = slices.DeleteFunc(t.Configuration.Subpackages, func(sp config.Subpackage) bool {
 		result, err := shouldRun(sp.If)
@@ -562,6 +569,7 @@ func (t *Test) buildWorkspaceConfig(ctx context.Context, imgRef, pkgName string,
 		PackageName:  pkgName,
 		Mounts:       mounts,
 		Capabilities: caps,
+		WorkspaceDir: t.WorkspaceDir,
 		Environment:  map[string]string{},
 		RunAs:        imgcfg.Accounts.RunAs,
 	}

--- a/pkg/build/test_test.go
+++ b/pkg/build/test_test.go
@@ -59,6 +59,7 @@ func TestBuildWorkspaceConfig(t *testing.T) {
 		Environment:  map[string]string{"HOME": "/root"},
 		PackageName:  testPkgName,
 		ImgRef:       testImgRef,
+		WorkspaceDir: "/workspace",
 		Capabilities: container.Capabilities{Networking: true},
 		Mounts: []container.BindMount{
 			{Source: testWorkspaceDir, Destination: homeBuild},


### PR DESCRIPTION
Until now `melange test` was failing with QEMU runners
This fixes the behaviour thanks to the investigation of @maxgio92 :+1: 

EDIT: depends on https://github.com/wolfi-dev/os/pull/30922