### PR TITLE
Do not add a cmd:awk dependency as nothing will ever provide cmd:awk

### DIFF
--- a/pkg/sca/sca.go
+++ b/pkg/sca/sca.go
@@ -608,7 +608,7 @@ func sonameLibver(soname string) string {
 func getShbang(fp io.Reader) (string, error) {
 	// python3 and sh are symlinks and generateCmdProviders currently only considers
 	// regular files. Since nothing will fulfill such a depend, do not generate one.
-	ignores := map[string]bool{"python3": true, "python": true, "sh": true}
+	ignores := map[string]bool{"python3": true, "python": true, "sh": true, "awk": true}
 
 	buf := make([]byte, 80)
 	blen, err := io.ReadFull(fp, buf)


### PR DESCRIPTION
Do not add a cmd:awk dependency as nothing will ever provide cmd:awk

awk is only provided by busybox or gawk.  Both of those do so with a
symlink.  That means that we have to ignore shbang that have awk or
we'll get a 'cmd:awk' dep that will never be provided.

Sad face.

Somehow we need to fix the symlink provider thing, but for
now, just this.

This was noticed in wolfi-dev/os/check.yaml . Melange said:

    Added shbang dep cmd:awk for usr/bin/checkmk
