### PR TITLE
cleanup glow up

### DIFF
--- a/docs/md/melange_build.md
+++ b/docs/md/melange_build.md
@@ -34,7 +34,6 @@ melange build [flags]
       --build-option strings                                    build options to enable
       --cache-dir string                                        directory used for cached inputs (default "./melange-cache/")
       --cache-source string                                     directory or bucket used for preloading the cache
-      --cleanup                                                 when enabled, the temp dir used for the guest will be cleaned up after completion (default true)
       --cpu string                                              default CPU resources to use for builds
       --create-build-log                                        creates a package.log file containing a list of packages that were built by the command
       --debug                                                   enables debug logging of build pipelines
@@ -59,7 +58,7 @@ melange build [flags]
       --package-append strings                                  extra packages to install for each of the build environments
       --pipeline-dir string                                     directory used to extend defined built-in pipelines
   -r, --repository-append strings                               path to extra repositories to include in the build environment
-      --rm                                                      clean up intermediate artifacts (e.g. container images)
+      --rm                                                      clean up intermediate artifacts (e.g. container images, temp dirs) (default true)
       --runner string                                           which runner to use to enable running commands, default is based on your platform. Options are ["bubblewrap" "docker" "qemu"]
       --signing-key string                                      key to use for signing
       --source-dir string                                       directory used for included sources

--- a/docs/md/melange_test.md
+++ b/docs/md/melange_test.md
@@ -32,7 +32,6 @@ melange test [flags]
       --arch strings                  architectures to build for (e.g., x86_64,ppc64le,arm64) -- default is all, unless specified in config
       --cache-dir string              directory used for cached inputs
       --cache-source string           directory or bucket used for preloading the cache
-      --cleanup                       when enabled, the temp dir used for the guest will be cleaned up after completion (default true)
       --debug                         enables debug logging of test pipelines (sets -x for steps)
       --debug-runner                  when enabled, the builder pod will persist after the build succeeds or fails
       --env-file string               file to use for preloaded environment variables
@@ -43,6 +42,7 @@ melange test [flags]
       --overlay-binsh string          use specified file as /bin/sh overlay in build environment
       --pipeline-dirs strings         directories used to extend defined built-in pipelines
   -r, --repository-append strings     path to extra repositories to include in the build environment
+      --rm                            clean up intermediate artifacts (e.g. container images, temp dirs) (default true)
       --runner string                 which runner to use to enable running commands, default is based on your platform. Options are ["bubblewrap" "docker" "qemu"]
       --source-dir string             directory used for included sources
       --test-option strings           build options to enable

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -67,7 +67,6 @@ type Build struct {
 	PipelineDirs          []string
 	SourceDir             string
 	GuestDir              string
-	Cleanup               bool
 	SigningKey            string
 	SigningPassphrase     string
 	Namespace             string
@@ -705,7 +704,7 @@ func (b *Build) BuildPackage(ctx context.Context) error {
 		}
 		b.GuestDir = guestDir
 
-		if b.Cleanup {
+		if b.Remove {
 			defer os.RemoveAll(guestDir)
 		}
 	}

--- a/pkg/build/options.go
+++ b/pkg/build/options.go
@@ -299,7 +299,7 @@ func WithInteractive(interactive bool) Option {
 }
 
 // WithRemove indicates whether the the build will clean up after itself.
-// This includes deleting any intermediate artifacts like container images.
+// This includes deleting any intermediate artifacts like container images and temp workspace and guest dirs.
 func WithRemove(remove bool) Option {
 	return func(b *Build) error {
 		b.Remove = remove
@@ -381,14 +381,6 @@ func WithLibcFlavorOverride(libc string) Option {
 func WithIgnoreSignatures(ignore bool) Option {
 	return func(b *Build) error {
 		b.IgnoreSignatures = ignore
-		return nil
-	}
-}
-
-// WithCleanup indicates whether to clean up the build environment after the build is complete.
-func WithCleanup(c bool) Option {
-	return func(b *Build) error {
-		b.Cleanup = c
 		return nil
 	}
 }

--- a/pkg/build/test.go
+++ b/pkg/build/test.go
@@ -51,7 +51,7 @@ type Test struct {
 	PipelineDirs      []string
 	SourceDir         string
 	GuestDir          string
-	Cleanup           bool
+	Remove            bool
 	Arch              apko_types.Architecture
 	ExtraKeys         []string
 	ExtraRepos        []string
@@ -384,7 +384,7 @@ func (t *Test) TestPackage(ctx context.Context) error {
 		}
 		t.GuestDir = guestDir
 
-		if t.Cleanup {
+		if t.Remove {
 			defer os.RemoveAll(guestDir)
 		}
 	}

--- a/pkg/build/test_options.go
+++ b/pkg/build/test_options.go
@@ -198,9 +198,9 @@ func WithTestAuth(domain, user, pass string) TestOption {
 }
 
 // If true, the test will clean up the test environment after the test is complete.
-func WithTestCleanup(c bool) TestOption {
+func WithTestRemove(c bool) TestOption {
 	return func(t *Test) error {
-		t.Cleanup = c
+		t.Remove = c
 		return nil
 	}
 }

--- a/pkg/cli/test.go
+++ b/pkg/cli/test.go
@@ -79,6 +79,7 @@ func test() *cobra.Command {
 				build.WithTestDebug(debug),
 				build.WithTestDebugRunner(debugRunner),
 				build.WithTestInteractive(interactive),
+				build.WithTestRemove(remove),
 			}
 
 			if len(args) > 0 {

--- a/pkg/cli/test.go
+++ b/pkg/cli/test.go
@@ -48,7 +48,7 @@ func test() *cobra.Command {
 	var interactive bool
 	var runner string
 	var extraTestPackages []string
-	var cleanup bool
+	var remove bool
 
 	cmd := &cobra.Command{
 		Use:     "test",
@@ -58,7 +58,7 @@ func test() *cobra.Command {
 		Args:    cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
-			r, err := getRunner(ctx, runner)
+			r, err := getRunner(ctx, runner, remove)
 			if err != nil {
 				return err
 			}
@@ -79,7 +79,6 @@ func test() *cobra.Command {
 				build.WithTestDebug(debug),
 				build.WithTestDebugRunner(debugRunner),
 				build.WithTestInteractive(interactive),
-				build.WithTestCleanup(cleanup),
 			}
 
 			if len(args) > 0 {
@@ -131,7 +130,7 @@ func test() *cobra.Command {
 	cmd.Flags().BoolVarP(&interactive, "interactive", "i", false, "when enabled, attaches stdin with a tty to the pod on failure")
 	cmd.Flags().StringSliceVarP(&extraRepos, "repository-append", "r", []string{}, "path to extra repositories to include in the build environment")
 	cmd.Flags().StringSliceVar(&extraTestPackages, "test-package-append", []string{}, "extra packages to install for each of the test environments")
-	cmd.Flags().BoolVar(&cleanup, "cleanup", true, "when enabled, the temp dir used for the guest will be cleaned up after completion")
+	cmd.Flags().BoolVar(&remove, "rm", true, "clean up intermediate artifacts (e.g. container images, temp dirs)")
 
 	return cmd
 }

--- a/pkg/container/bubblewrap_runner.go
+++ b/pkg/container/bubblewrap_runner.go
@@ -37,11 +37,12 @@ var _ Debugger = (*bubblewrap)(nil)
 const BubblewrapName = "bubblewrap"
 
 type bubblewrap struct {
+	remove bool // if true, clean up temp dirs on close.
 }
 
 // BubblewrapRunner returns a Bubblewrap Runner implementation.
-func BubblewrapRunner() Runner {
-	return &bubblewrap{}
+func BubblewrapRunner(remove bool) Runner {
+	return &bubblewrap{remove: remove}
 }
 
 func (bw *bubblewrap) Close() error {
@@ -139,7 +140,7 @@ func (bw *bubblewrap) TestUsability(ctx context.Context) bool {
 
 // OCIImageLoader used to load OCI images in, if needed. bubblewrap does not need it.
 func (bw *bubblewrap) OCIImageLoader() Loader {
-	return &bubblewrapOCILoader{}
+	return &bubblewrapOCILoader{remove: bw.remove}
 }
 
 // TempDir returns the base for temporary directory. For bubblewrap, this is empty.
@@ -169,7 +170,10 @@ func (bw *bubblewrap) WorkspaceTar(ctx context.Context, cfg *Config) (io.ReadClo
 	return nil, nil
 }
 
-type bubblewrapOCILoader struct{}
+type bubblewrapOCILoader struct {
+	remove   bool
+	guestDir string
+}
 
 func (b bubblewrapOCILoader) LoadImage(ctx context.Context, layer v1.Layer, arch apko_types.Architecture, bc *apko_build.Context) (ref string, err error) {
 	_, span := otel.Tracer("melange").Start(ctx, "bubblewrap.LoadImage")
@@ -181,6 +185,7 @@ func (b bubblewrapOCILoader) LoadImage(ctx context.Context, layer v1.Layer, arch
 	if err != nil {
 		return ref, fmt.Errorf("failed to create guest dir: %w", err)
 	}
+	b.guestDir = guestDir
 	rc, err := layer.Uncompressed()
 	if err != nil {
 		return ref, fmt.Errorf("failed to read layer tarball: %w", err)
@@ -227,5 +232,8 @@ func (b bubblewrapOCILoader) LoadImage(ctx context.Context, layer v1.Layer, arch
 
 func (b bubblewrapOCILoader) RemoveImage(ctx context.Context, ref string) error {
 	clog.FromContext(ctx).Infof("removing image path %s", ref)
+	if b.remove {
+		os.RemoveAll(b.guestDir)
+	}
 	return os.RemoveAll(ref)
 }

--- a/pkg/container/bubblewrap_runner.go
+++ b/pkg/container/bubblewrap_runner.go
@@ -175,7 +175,7 @@ type bubblewrapOCILoader struct {
 	guestDir string
 }
 
-func (b bubblewrapOCILoader) LoadImage(ctx context.Context, layer v1.Layer, arch apko_types.Architecture, bc *apko_build.Context) (ref string, err error) {
+func (b *bubblewrapOCILoader) LoadImage(ctx context.Context, layer v1.Layer, arch apko_types.Architecture, bc *apko_build.Context) (ref string, err error) {
 	_, span := otel.Tracer("melange").Start(ctx, "bubblewrap.LoadImage")
 	defer span.End()
 
@@ -230,7 +230,7 @@ func (b bubblewrapOCILoader) LoadImage(ctx context.Context, layer v1.Layer, arch
 	return guestDir, nil
 }
 
-func (b bubblewrapOCILoader) RemoveImage(ctx context.Context, ref string) error {
+func (b *bubblewrapOCILoader) RemoveImage(ctx context.Context, ref string) error {
 	clog.FromContext(ctx).Infof("removing image path %s", ref)
 	if b.remove {
 		os.RemoveAll(b.guestDir)


### PR DESCRIPTION
Followup to #1529 

`melange build` already had a `--rm` flag (default `false`) that cleaned up containers after execution. Instead of adding a redundant `--cleanup` flag, we can just repurpose that, and make it default `true`.

This also pipes `remove` to the bubblewrap runner which creates temp guest dirs. 

This also adds `--rm` (default `true`) to `melange test`, which wasn't wired up before and so was always false.