### PR TITLE
bublewrap_runner: add /sys mount

### DIFF
--- a/pkg/container/bubblewrap_runner.go
+++ b/pkg/container/bubblewrap_runner.go
@@ -83,6 +83,7 @@ func (bw *bubblewrap) cmd(ctx context.Context, cfg *Config, debug bool, envOverr
 	baseargs = append(baseargs, "--unshare-pid", "--die-with-parent",
 		"--dev", "/dev",
 		"--proc", "/proc",
+		"--ro-bind", "/sys", "/sys",
 		"--chdir", runnerWorkdir,
 		"--clearenv")
 


### PR DESCRIPTION
schroot, choort, rpmbuild, docker, lxd, incus, systemd-nspawn, qemu
VMs, and bare-metal machines all have /sys (sysfs) mounted.

During test pipelines some of the software we build and run, tries to
use /sys which is expected to be available and currently fails. Fix
this compatability by providing /sys in the bubblewrap sandbox, by
making it look ever so slightly like a normal chroot.

This fixes running jemalloc test pipeline with stress-ng under
bubblewrap runner.
