### PR TITLE
fix(bubblewrap_runner): run as build 1000 by default

### DIFF
--- a/pkg/container/bubblewrap_runner.go
+++ b/pkg/container/bubblewrap_runner.go
@@ -85,6 +85,9 @@ func (bw *bubblewrap) cmd(ctx context.Context, cfg *Config, debug bool, envOverr
 		"--chdir", runnerWorkdir,
 		"--clearenv")
 
+	// Set caps as for the current thread bounding capability set.
+	baseargs = append(baseargs, "--cap-add", "all")
+
 	baseargs = append(baseargs, "--unshare-user")
 	if cfg.RunAs != "" {
 		baseargs = append(baseargs, "--uid", cfg.RunAs)

--- a/pkg/container/bubblewrap_runner.go
+++ b/pkg/container/bubblewrap_runner.go
@@ -34,7 +34,11 @@ import (
 
 var _ Debugger = (*bubblewrap)(nil)
 
-const BubblewrapName = "bubblewrap"
+const (
+	BubblewrapName = "bubblewrap"
+	DefaultUID     = "1000"
+	DefaultGID     = "1000"
+)
 
 type bubblewrap struct {
 }
@@ -88,6 +92,11 @@ func (bw *bubblewrap) cmd(ctx context.Context, cfg *Config, debug bool, envOverr
 	if cfg.RunAs != "" {
 		baseargs = append(baseargs, "--unshare-user")
 		baseargs = append(baseargs, "--uid", cfg.RunAs)
+	} else {
+		// TODO: we may want to inherit the apko.ImageConfiguration.Accounts to match passwd.
+		baseargs = append(baseargs, "--unshare-user")
+		baseargs = append(baseargs, "--uid", DefaultUID)
+		baseargs = append(baseargs, "--gid", DefaultGID)
 	}
 
 	if !debug {

--- a/pkg/container/bubblewrap_runner.go
+++ b/pkg/container/bubblewrap_runner.go
@@ -34,11 +34,7 @@ import (
 
 var _ Debugger = (*bubblewrap)(nil)
 
-const (
-	BubblewrapName = "bubblewrap"
-	DefaultUID     = "1000"
-	DefaultGID     = "1000"
-)
+const BubblewrapName = "bubblewrap"
 
 type bubblewrap struct {
 }
@@ -89,14 +85,13 @@ func (bw *bubblewrap) cmd(ctx context.Context, cfg *Config, debug bool, envOverr
 		"--chdir", runnerWorkdir,
 		"--clearenv")
 
+	baseargs = append(baseargs, "--unshare-user")
 	if cfg.RunAs != "" {
-		baseargs = append(baseargs, "--unshare-user")
 		baseargs = append(baseargs, "--uid", cfg.RunAs)
+		baseargs = append(baseargs, "--gid", cfg.RunAs)
 	} else {
-		// TODO: we may want to inherit the apko.ImageConfiguration.Accounts to match passwd.
-		baseargs = append(baseargs, "--unshare-user")
-		baseargs = append(baseargs, "--uid", DefaultUID)
-		baseargs = append(baseargs, "--gid", DefaultGID)
+		baseargs = append(baseargs, "--uid", "0")
+		baseargs = append(baseargs, "--gid", "0")
 	}
 
 	if !debug {

--- a/pkg/container/bubblewrap_runner_test.go
+++ b/pkg/container/bubblewrap_runner_test.go
@@ -1,0 +1,56 @@
+// Copyright 2024 Chainguard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package container
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/chainguard-dev/clog/slogtest"
+)
+
+func TestBubblewrapCmd(t *testing.T) {
+	tests := []struct {
+		name         string
+		config       *Config
+		expectedArgs string
+	}{
+		{
+			name:         "With default UID and GID",
+			config:       new(Config),
+			expectedArgs: fmt.Sprintf("--unshare-user --uid %s --gid %s", DefaultUID, DefaultGID),
+		},
+		{
+			name:         "With config RunAs",
+			config:       &Config{RunAs: "65536"},
+			expectedArgs: fmt.Sprintf("--unshare-user --uid %s", "65536"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := slogtest.Context(t)
+			args := make([]string, 0)
+
+			cmd := new(bubblewrap).cmd(ctx, tt.config, false, nil, args...)
+			if cmd.Args == nil {
+				t.Fatalf("cmd.Args should not be nil")
+			}
+			if !strings.Contains(strings.Join(cmd.Args, " "), tt.expectedArgs) {
+				t.Fatalf("expected %v, found %v", tt.expectedArgs, cmd.Args)
+			}
+		})
+	}
+}

--- a/pkg/container/bubblewrap_runner_test.go
+++ b/pkg/container/bubblewrap_runner_test.go
@@ -38,6 +38,11 @@ func TestBubblewrapCmd(t *testing.T) {
 			config:       &Config{RunAs: "65535"},
 			expectedArgs: fmt.Sprintf("--unshare-user --uid %s --gid %s", "65535", "65535"),
 		},
+		{
+			name:         "Set capabilities",
+			config:       new(Config),
+			expectedArgs: "--cap-add all",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/container/bubblewrap_runner_test.go
+++ b/pkg/container/bubblewrap_runner_test.go
@@ -31,17 +31,12 @@ func TestBubblewrapCmd(t *testing.T) {
 		{
 			name:         "With default UID and GID",
 			config:       new(Config),
-			expectedArgs: fmt.Sprintf("--unshare-user --uid %s --gid %s", "0", "0"),
+			expectedArgs: fmt.Sprintf("--unshare-user --uid %s --gid %s", buildUserID, buildUserID),
 		},
 		{
 			name:         "With config RunAs",
 			config:       &Config{RunAs: "65535"},
 			expectedArgs: fmt.Sprintf("--unshare-user --uid %s --gid %s", "65535", "65535"),
-		},
-		{
-			name:         "Set capabilities",
-			config:       new(Config),
-			expectedArgs: "--cap-add all",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/container/bubblewrap_runner_test.go
+++ b/pkg/container/bubblewrap_runner_test.go
@@ -31,12 +31,12 @@ func TestBubblewrapCmd(t *testing.T) {
 		{
 			name:         "With default UID and GID",
 			config:       new(Config),
-			expectedArgs: fmt.Sprintf("--unshare-user --uid %s --gid %s", DefaultUID, DefaultGID),
+			expectedArgs: fmt.Sprintf("--unshare-user --uid %s --gid %s", "0", "0"),
 		},
 		{
 			name:         "With config RunAs",
-			config:       &Config{RunAs: "65536"},
-			expectedArgs: fmt.Sprintf("--unshare-user --uid %s", "65536"),
+			config:       &Config{RunAs: "65535"},
+			expectedArgs: fmt.Sprintf("--unshare-user --uid %s --gid %s", "65535", "65535"),
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Bubblewrap pipeline is run with same uid of the user that run melange by default, mapped for the child user namespace, leading to possible consistency problems on the resulting package filesystem, while standardizing uid to 1000 or 0.
The classic example is the difference between running melange with sudo and without.

Furthermore, passwd database is already set for the uid 1000 with name build, instead of the user that is run as, when not explicitely specified. The same applies to the gid map.

### Additional context

Fixes #1570

### Functional changes

- [ ] This change can build all of Wolfi without errors (describe results in notes)

### SCA Changes

- [ ] Examining several representative APKs show no regression / the desired effect (details in notes)

Notes: