### PR TITLE
test: install exactly the package version to test

### DIFF
--- a/pkg/build/compile.go
+++ b/pkg/build/compile.go
@@ -73,8 +73,8 @@ func (t *Test) Compile(ctx context.Context) error {
 
 		te := &cfg.Subpackages[i].Test.Environment.Contents
 
-		// Append the subpackage that we're testing to be installed.
-		te.Packages = append(te.Packages, sp.Name)
+		// Append the subpackage that we're testing to be installed, at the exact version to test.
+		te.Packages = append(te.Packages, fmt.Sprintf("%s=%s-r%d", sp.Name, cfg.Package.Version, cfg.Package.Epoch))
 
 		if err := test.CompilePipelines(ctx, sm, sp.Test.Pipeline); err != nil {
 			return fmt.Errorf("compiling subpackage %q tests: %w", sp.Name, err)
@@ -95,7 +95,7 @@ func (t *Test) Compile(ctx context.Context) error {
 		if t.Package != "" {
 			te.Packages = append(te.Packages, t.Package)
 		} else {
-			te.Packages = append(te.Packages, t.Configuration.Package.Name)
+			te.Packages = append(te.Packages, fmt.Sprintf("%s=%s-r%d", t.Configuration.Package.Name, t.Configuration.Package.Version, t.Configuration.Package.Epoch))
 		}
 
 		if err := test.CompilePipelines(ctx, sm, cfg.Test.Pipeline); err != nil {

--- a/pkg/build/compile_test.go
+++ b/pkg/build/compile_test.go
@@ -71,8 +71,12 @@ func TestInheritWorkdir(t *testing.T) {
 
 func TestCompileTest(t *testing.T) {
 	test := &Test{
-		Package: "main",
 		Configuration: config.Configuration{
+			Package: config.Package{
+				Name:    "main",
+				Version: "1.2.3",
+				Epoch:   4,
+			},
 			Test: &config.Test{
 				Environment: apko_types.ImageConfiguration{
 					Contents: apko_types.ImageContents{
@@ -107,11 +111,11 @@ func TestCompileTest(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if got, want := test.Configuration.Test.Environment.Contents.Packages, []string{"main-base", "main", "main-need"}; !slices.Equal(got, want) {
+	if got, want := test.Configuration.Test.Environment.Contents.Packages, []string{"main-base", "main=1.2.3-r4", "main-need"}; !slices.Equal(got, want) {
 		t.Errorf("main test packages: want %v, got %v", want, got)
 	}
 
-	if got, want := test.Configuration.Subpackages[0].Test.Environment.Contents.Packages, []string{"subpackage-base", "subpackage", "subpackage-need"}; !slices.Equal(got, want) {
+	if got, want := test.Configuration.Subpackages[0].Test.Environment.Contents.Packages, []string{"subpackage-base", "subpackage=1.2.3-r4", "subpackage-need"}; !slices.Equal(got, want) {
 		t.Errorf("subpackage test packages: want %v, got %v", want, got)
 	}
 }


### PR DESCRIPTION
### Problem

When testing package `foo` with `melange test foo.yaml`, it can be quite easy to accidentally test an unexpected package version.

If `foo-1.2.3-r4.apk` exists in the repo, but you're working on `-r5`, but haven't built it locally yet, `melange test foo.yaml` will request `foo` as a test dependency, which will be satisfied by the old `-r4`. Tests may pass meaninglessly, or fail mysteriously.

### Solution

When testing `foo.yaml`, request exactly the package-version represented by the config. If `foo.yaml` says `epoch: 5` that means we should test `-r5`. If it hasn't been built yet, the test will fail, but at least you won't unexpectedly be testing an old version.

This was achievable with sufficiently rigorous understanding of the system, and one could request the test-time dependency `${{package.name}}-${{package.full-version}}`, but folks shouldn't have to remember that.