### PR TITLE
Added information about skip-initial-tidy to go/bump

### DIFF
--- a/pkg/build/pipelines/go/bump.yaml
+++ b/pkg/build/pipelines/go/bump.yaml
@@ -20,6 +20,9 @@ inputs:
   tidy:
     default: true
     description: Run go mod tidy command before and after the bump
+  skip-initial-tidy:
+    default: false
+    description: Skip the initial go mod tidy command
   show-diff:
     default: false
     description: Show the difference between the go.mod file before and after the bump
@@ -32,4 +35,4 @@ pipeline:
       cd "${{inputs.modroot}}"
 
       # We use the --tidy flag to run go mod tidy before and after in some cases (if old versions of go are used, we need to update the go.mod format)
-      gobump --packages "${{inputs.deps}}" --replaces "${{inputs.replaces}}" --tidy=${{inputs.tidy}} --show-diff=${{inputs.show-diff}} --go-version=${{inputs.go-version}} --compat=${{inputs.tidy-compat}}
+      gobump --packages "${{inputs.deps}}" --replaces "${{inputs.replaces}}" --tidy=${{inputs.tidy}} --skip-initial-tidy=${{inputs.skip-initial-tidy}} --show-diff=${{inputs.show-diff}} --go-version=${{inputs.go-version}} --compat=${{inputs.tidy-compat}}


### PR DESCRIPTION
## Melange Pull Request Template

<!--
*** PULL REQUEST CHECKLIST: PLEASE START HERE ***

The single most important feature of melange is that we can build Wolfi.

Many changes to melange introduce a risk of breaking the build, and sometimes
these are not flushed out until a package is changed (much) later.  This
pertains to basic execution, SCA changes, linter changes, and more.
-->

Added some additional information about go/bump's skip-initial-tidy option, which I needed to use and couldn't find info on, except for https://github.com/wolfi-dev/os/blob/main/pipelines/go/bump.yaml and https://github.com/chainguard-dev/gobump. This PR essentially copies that information so its easier to find for someone looking at melange's documentation. 
