### PR TITLE
Pin the package version with ~ rather than =.

### DIFF
--- a/pkg/build/compile.go
+++ b/pkg/build/compile.go
@@ -75,7 +75,7 @@ func (t *Test) Compile(ctx context.Context) error {
 
 		// Append the subpackage that we're testing to be installed.
 		version := fmt.Sprintf("%s-r%d", t.Configuration.Package.Version, t.Configuration.Package.Epoch)
-		te.Packages = append(te.Packages, sp.Name+"="+version)
+		te.Packages = append(te.Packages, sp.Name+"~"+version)
 
 		if err := test.CompilePipelines(ctx, sm, sp.Test.Pipeline); err != nil {
 			return fmt.Errorf("compiling subpackage %q tests: %w", sp.Name, err)
@@ -97,7 +97,7 @@ func (t *Test) Compile(ctx context.Context) error {
 			te.Packages = append(te.Packages, t.Package)
 		} else {
 			version := fmt.Sprintf("%s-r%d", t.Configuration.Package.Version, t.Configuration.Package.Epoch)
-			te.Packages = append(te.Packages, t.Configuration.Package.Name+"="+version)
+			te.Packages = append(te.Packages, t.Configuration.Package.Name+"~"+version)
 		}
 
 		if err := test.CompilePipelines(ctx, sm, cfg.Test.Pipeline); err != nil {

--- a/pkg/build/compile_test.go
+++ b/pkg/build/compile_test.go
@@ -111,11 +111,11 @@ func TestCompileTest(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if got, want := test.Configuration.Test.Environment.Contents.Packages, []string{"main-base", "main=1.2.3-r4", "main-need"}; !slices.Equal(got, want) {
+	if got, want := test.Configuration.Test.Environment.Contents.Packages, []string{"main-base", "main~1.2.3-r4", "main-need"}; !slices.Equal(got, want) {
 		t.Errorf("main test packages: want %v, got %v", want, got)
 	}
 
-	if got, want := test.Configuration.Subpackages[0].Test.Environment.Contents.Packages, []string{"subpackage-base", "subpackage=1.2.3-r4", "subpackage-need"}; !slices.Equal(got, want) {
+	if got, want := test.Configuration.Subpackages[0].Test.Environment.Contents.Packages, []string{"subpackage-base", "subpackage~1.2.3-r4", "subpackage-need"}; !slices.Equal(got, want) {
 		t.Errorf("subpackage test packages: want %v, got %v", want, got)
 	}
 }


### PR DESCRIPTION
commit 57e3f4cfac3af9417db6e68ff2f6b5e8eaf7e349 (via #1518)
broke test of wolfi python packages where they relied on the test of the
'main' package to install a subpackage that `provides` the main package.

For an example, see:
https://github.com/wolfi-dev/os/blob/cd5e90dc01bc7d5/py3-fastbencode.yaml

The main package is provider-priority 0 and the subpackages
have specific provider-priorities > 0.

With the pkg=version change, we got the main package installed, which
is empty.  Using ~ gets the desired behavior even for historic
packages.
