### PR TITLE
ci: add workflow to tag releases daily

### DIFF
--- a/.github/workflows/release-scheduled.yaml
+++ b/.github/workflows/release-scheduled.yaml
@@ -1,0 +1,41 @@
+name: release
+
+on:
+  schedule:
+    - cron: '0 0 * * *' # daily at 00:00
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  release:
+    name: release
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+      - name: Check if any changes since last tag
+        id: check
+        run: |
+          git fetch --tags
+          if [ -z "$(git tag --points-at HEAD)" ]; then
+            echo "Nothing points at HEAD, bump a new tag"
+            echo "bump=yes" >> $GITHUB_OUTPUT
+          else
+            echo "A tag already points to head, don't bump"
+            echo "bump=no" >> $GITHUB_OUTPUT
+          fi
+      - name: Bump patch version and push tag
+        uses: mathieudutour/github-tag-action@a22cf08638b34d5badda920f9daf6e72c477b07b # v6.2
+        if: steps.check.outputs.bump == 'yes'
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This was adapted from wolfictl's weekly release workflow: https://github.com/wolfi-dev/wolfictl/blob/main/.github/workflows/release.yaml

...but made **_daily_**.

I believe this will produce tags, which will end up trigger the pre-existing release workflow in melange: https://github.com/chainguard-dev/melange/blob/main/.github/workflows/release.yaml
