### PR TITLE
add build-base to cargo/build pipeline

### DIFF
--- a/pkg/build/pipelines/cargo/build.yaml
+++ b/pkg/build/pipelines/cargo/build.yaml
@@ -2,6 +2,7 @@ name: Compile an auditable rust binary with Cargo
 
 needs:
   packages:
+    - build-base
     - busybox
     - cargo-auditable
     - rust


### PR DESCRIPTION
compiling a simple application with rust requires cc linker so adding build-base to cargo/build pipeline so that we can omit specifying build-base at environment blocks in package level melange config.

```bash
$ docker run --name wolfi --rm -it cgr.dev/chainguard/wolfi-base:latest sh
/ # apk add rust
/ # cargo new demo
    Creating binary (application) `demo` package
note: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
/ # cd demo/
/demo # cargo build
   Compiling demo v0.1.0 (/demo)
error: linker `cc` not found
  |
  = note: No such file or directory (os error 2)

error: could not compile `demo` (bin "demo") due to 1 previous error

/demo # apk add build-base
/demo # cargo build
   Compiling demo v0.1.0 (/demo)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.13s
```

## Melange Pull Request Template

<!--
*** PULL REQUEST CHECKLIST: PLEASE START HERE ***

The single most important feature of melange is that we can build Wolfi.

Many changes to melange introduce a risk of breaking the build, and sometimes
these are not flushed out until a package is changed (much) later.  This
pertains to basic execution, SCA changes, linter changes, and more.
-->

### Functional Changes

- [x] This change can build all of Wolfi without errors (describe results in notes)

Notes:

### SCA Changes

- [ ] Examining several representative APKs show no regression / the desired effect (details in notes)

Notes:

### Linter

- [ ] The new check is clean across Wolfi
- [ ] The new check is opt-in or a warning

Notes:
