### PR TITLE
pass --target-dir with cargo/build pipeline

### DIFF
--- a/pkg/build/pipelines/cargo/build.yaml
+++ b/pkg/build/pipelines/cargo/build.yaml
@@ -46,7 +46,7 @@ pipeline:
       cd "${{inputs.modroot}}"
 
       # Build and install package(s)
-      cargo auditable build ${{inputs.opts}}
+      cargo auditable build --target-dir target ${{inputs.opts}}
       if [[ ! -z "${{inputs.output}}" ]]; then
         install -Dm755 "${OUTPUT_PATH}/${{inputs.output}}" "${INSTALL_PATH}/${{inputs.output}}"
       else


### PR DESCRIPTION
this patch passes `--target-dir` flag with cargo at build time. 

This is required because `cargo/build` pipeline uses modroot and when we `cd` into a specific directory and invoke cargo build, the resulting binary still ends up in root of the repository at `GIT_ROOT_DIR/target/release/foo` 

After which when we use the following install command it fails to find the binary. 

```bash
OUTPUT_PATH="target/release"
install -Dm755 "${OUTPUT_PATH}/${{inputs.output}}" "${INSTALL_PATH}/${{inputs.output}}"
```

by passing `--target-dir` flag to target, we are creating the `target/release/foo` binary in the current working directory hence the install command will succeed. 

This change is looking good considering backwards compatibility with the use of this pipeline in existing package. 


### ⚠️ Alternative consideration
We change the existing `modroot` name to `manifest-path` and invoke all the commands from the root of the repository. 

we can keep using the word `modroot` as well but IMHO `manifest-path` closely aligns with cargo terminology. 
```bash
Manifest Options:
      --manifest-path <PATH>  Path to Cargo.toml
```
We then need to point this to `Cargo.toml` in different directory and the result will always be stored at root of the repository inside `target/release` or `target/debug` directory depending on the profile we are building for. 

To me, this looks like a more better solution than the proposed one but this will break one existing package because of name change https://github.com/wolfi-dev/os/blob/main/geckodriver.yaml 

_I proceeded with first option because the alternative consideration was breaking one package._ 

related: https://github.com/chainguard-dev/melange/issues/1590