### PR TITLE
allow passing more than one opts to cargo build

### DIFF
--- a/pkg/build/pipelines/cargo/build.yaml
+++ b/pkg/build/pipelines/cargo/build.yaml
@@ -14,7 +14,7 @@ inputs:
       the apk will be in prefix / install-dir / output
 
   opts:
-    default: "--release"
+    default: --release
     description: |
       Options to pass to cargo build. Defaults to release
 

--- a/pkg/build/pipelines/cargo/build.yaml
+++ b/pkg/build/pipelines/cargo/build.yaml
@@ -46,7 +46,7 @@ pipeline:
       cd "${{inputs.modroot}}"
 
       # Build and install package(s)
-      cargo auditable build "${{inputs.opts}}"
+      cargo auditable build ${{inputs.opts}}
       if [[ ! -z "${{inputs.output}}" ]]; then
         install -Dm755 "${OUTPUT_PATH}/${{inputs.output}}" "${INSTALL_PATH}/${{inputs.output}}"
       else


### PR DESCRIPTION
In the current pipeline, the build fails because cargo doesn't recognizes all the input options we're passing and fails.

```bash
# Build and install package(s)
cargo auditable build "--release --frozen --package=linkerd2-proxy"
~ # cargo auditable build "--release --frozen --package=linkerd2-proxy"
error: unexpected argument '--release --frozen --package' found

  tip: a similar argument exists: '--release'

Usage: cargo build --release

For more information, try '--help'.
```
removing quotes will make it recognizable. 
this is tested using the following command after building melange again. 
```bash
make melange
```

write a melange config with custom opts `opts: --release --no-default-features -vv`

<details><summary>Details</summary>
<p>

```yaml
package:
  name: linkerd-await
  version: 0.2.9
  epoch: 2
  description: "A program that blocks on linkerd readiness"
  copyright:
    - license: Apache-2.0

environment:
  contents:
    packages:
      - build-base

pipeline:
  - uses: git-checkout
    with:
      repository: https://github.com/linkerd/linkerd-await
      tag: release/v${{package.version}}
      expected-commit: 6a1c017f93f0268bc31c291746e2e7a0a882c65f

  - name: build linkerd-await
    uses: cargo/build
    with:
      modroot: .
      opts: --release --no-default-features -vv
      output: linkerd-await
      install-dir: lib/linkerd

  - uses: strip

update:
  enabled: true
  github:
    identifier: linkerd/linkerd-await
    strip-prefix: release/v

test:
  pipeline:
    - runs: |
        /usr/lib/linkerd/linkerd-await --version | grep ${{package.version}}
```

</p>
</details> 

invoke the build command after this. 
```bash
./melange build foo.yaml --arch=x86_64 --repository-append /home/user/second-os/packages --keyring-append /home/user/second-os/local-melange.rsa.pub -k https://packages.wolfi.dev/os/wolfi-signing.rsa.pub -r https://packages.wolfi.dev/os
```