### PR TITLE
set output to required for cargo/build pipeline

### DIFF
--- a/pkg/build/pipelines/cargo/build.yaml
+++ b/pkg/build/pipelines/cargo/build.yaml
@@ -9,6 +9,7 @@ needs:
 
 inputs:
   output:
+    required: true
     description: |
       Filename to use when writing the binary. The final install location inside
       the apk will be in prefix / install-dir / output


### PR DESCRIPTION
In some projects, we get a lot of outputs in `./target/release` directory and if we don't set output then it tries to install a lot directories which is not possible via `install` executable. 

- below is an example listing in `/target/release` directory. 
```bash
~ # ls target/release/
build        deps         examples     incremental  probe        probe.d      pub          pub.d
```

- logs from melange pipeline
```bash
2024/10/23 21:14:59 WARN install: omitting directory 'target/release/build' uses=cargo/build
2024/10/23 21:14:59 WARN install: omitting directory 'target/release/deps' uses=cargo/build
2024/10/23 21:14:59 WARN install: omitting directory 'target/release/examples' uses=cargo/build
2024/10/23 21:14:59 WARN install: omitting directory 'target/release/incremental' uses=cargo/build
```

Fixes https://github.com/chainguard-dev/melange/issues/1582

>[!NOTE]
> We still need to think about how can we support installing more than one binaries from `./target/release` directory but I'll open up another patch for that. 