### PR TITLE
chore: unexport build pkg methods

### DIFF
--- a/pkg/build/compile.go
+++ b/pkg/build/compile.go
@@ -113,7 +113,7 @@ func (t *Test) Compile(ctx context.Context) error {
 // Compile compiles all configuration, including tests, by loading any pipelines and substituting all variables.
 func (b *Build) Compile(ctx context.Context) error {
 	cfg := b.Configuration
-	sm, err := NewSubstitutionMap(&cfg, b.Arch, b.BuildFlavor(), b.EnabledBuildOptions)
+	sm, err := NewSubstitutionMap(&cfg, b.Arch, b.buildFlavor(), b.EnabledBuildOptions)
 	if err != nil {
 		return err
 	}

--- a/pkg/build/test.go
+++ b/pkg/build/test.go
@@ -134,7 +134,7 @@ func (t *Test) Close() error {
 // Returns the imgRef for the created image, or error.
 func (t *Test) BuildGuest(ctx context.Context, imgConfig apko_types.ImageConfiguration, guestFS apkofs.FullFS) (string, error) {
 	log := clog.FromContext(ctx)
-	ctx, span := otel.Tracer("melange").Start(ctx, "BuildGuest")
+	ctx, span := otel.Tracer("melange").Start(ctx, "buildGuest")
 	defer span.End()
 
 	tmp, err := os.MkdirTemp(os.TempDir(), "apko-temp-*")
@@ -229,7 +229,7 @@ func (t *Test) IsTestless() bool {
 
 func (t *Test) PopulateCache(ctx context.Context) error {
 	log := clog.FromContext(ctx)
-	ctx, span := otel.Tracer("melange").Start(ctx, "PopulateCache")
+	ctx, span := otel.Tracer("melange").Start(ctx, "populateCache")
 	defer span.End()
 
 	if t.CacheDir == "" {
@@ -300,7 +300,7 @@ func (t *Test) PopulateCache(ctx context.Context) error {
 
 func (t *Test) PopulateWorkspace(ctx context.Context, src fs.FS) error {
 	log := clog.FromContext(ctx)
-	_, span := otel.Tracer("melange").Start(ctx, "PopulateWorkspace")
+	_, span := otel.Tracer("melange").Start(ctx, "populateWorkspace")
 	defer span.End()
 
 	if t.SourceDir == "" {


### PR DESCRIPTION
These methods are used only in the build package.

Also delete unused functions.
