### PR TITLE
chore(pkg/cli): set default runner on linux to docker

### DIFF
--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -304,7 +304,8 @@ func getRunner(ctx context.Context, runner string, remove bool) (container.Runne
 
 	switch runtime.GOOS {
 	case "linux":
-		return container.BubblewrapRunner(remove), nil
+		// linux is the same as default, but we want to keep it explicit
+		fallthrough
 	case "darwin":
 		// darwin is the same as default, but we want to keep it explicit
 		fallthrough


### PR DESCRIPTION
Docker is already the default runner under Darwin. This is to provide consistency across different platforms, as Bubblewrap runner also runs with different uid in the userns and no capabilities, differently from both Docker and QEMU runners.

### Functional Changes

- [ ] This change can build all of Wolfi without errors (describe results in notes)

Notes:

### SCA Changes

- [ ] Examining several representative APKs show no regression / the desired effect (details in notes)

Notes:

### Linter

- [ ] The new check is clean across Wolfi
- [ ] The new check is opt-in or a warning

Notes:
