### PR TITLE
chore(pipelines/fetch): Print expected and found checksums

### DIFF
--- a/pkg/build/pipelines/fetch.yaml
+++ b/pkg/build/pipelines/fetch.yaml
@@ -88,9 +88,19 @@ pipeline:
       fi
 
       if [ "${{inputs.expected-sha256}}" != "" ]; then
-        printf "%s  %s\n" '${{inputs.expected-sha256}}' $bn | sha256sum -c
+        printf "fetch: Expected sha256: ${{inputs.expected-sha256}}\n"
+        sum=$(sha256sum $bn | awk '{print $1}')
+        if [ "${{inputs.expected-sha256}}" != "$sum" ]; then
+          printf "fetch: Expected sha256 does not match found: $sum\n"
+          exit 1
+        fi
       else
-        printf "%s  %s\n" '${{inputs.expected-sha512}}' $bn | sha512sum -c
+        printf "fetch: Expected sha512: ${{inputs.expected-sha512}}\n"
+        sum=$(sha512sum $bn | awk '{print $1}')
+        if [ "${{inputs.expected-sha512}}" != "$sum" ]; then
+          printf "fetch: Expected sha512 does not match found: $sum\n"
+          exit 1
+        fi
       fi
 
       if [ "${{inputs.extract}}" = "true" ]; then


### PR DESCRIPTION
Print the checksums as a part of the pipeline as it is helpful to not have to validate the checksum all over again when correcting it