### PR TITLE
cleanup: remove unnecessary utils

### DIFF
--- a/pkg/convert/apkbuild/apkbuild.go
+++ b/pkg/convert/apkbuild/apkbuild.go
@@ -24,7 +24,6 @@ import (
 	apkotypes "chainguard.dev/apko/pkg/build/types"
 	"chainguard.dev/melange/pkg/config"
 	"chainguard.dev/melange/pkg/convert/wolfios"
-	"chainguard.dev/melange/pkg/util"
 	"gitlab.alpinelinux.org/alpine/go/apkbuild"
 	"golang.org/x/exp/slices"
 	"golang.org/x/time/rate"
@@ -96,7 +95,7 @@ func (c Context) Generate(ctx context.Context, apkBuildURI, pkgName string) erro
 
 	// reverse map order, so we generate the lowest transitive dependency first
 	// this will help to build convert configs in the correct order
-	util.ReverseSlice(c.OrderedKeys)
+	slices.Reverse(c.OrderedKeys)
 
 	// loop over map and generate convert config for each
 	for i, key := range c.OrderedKeys {
@@ -229,17 +228,17 @@ func (c Context) buildMapOfDependencies(ctx context.Context, apkBuildURI, pkgNam
 func (c Context) transitiveDependencyList(convertor ApkConvertor) []string {
 	var dependencies []string
 	for _, depends := range convertor.Apkbuild.Depends {
-		if !util.Contains(dependencies, depends.Pkgname) {
+		if !slices.Contains(dependencies, depends.Pkgname) {
 			dependencies = append(dependencies, depends.Pkgname)
 		}
 	}
 	for _, depends := range convertor.Apkbuild.Makedepends {
-		if !util.Contains(dependencies, depends.Pkgname) {
+		if !slices.Contains(dependencies, depends.Pkgname) {
 			dependencies = append(dependencies, depends.Pkgname)
 		}
 	}
 	for _, depends := range convertor.Apkbuild.DependsDev {
-		if !util.Contains(dependencies, depends.Pkgname) {
+		if !slices.Contains(dependencies, depends.Pkgname) {
 			dependencies = append(dependencies, depends.Pkgname)
 		}
 	}

--- a/pkg/convert/apkbuild/apkbuild_test.go
+++ b/pkg/convert/apkbuild/apkbuild_test.go
@@ -6,11 +6,10 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
-
-	"chainguard.dev/melange/pkg/util"
 
 	rlhttp "chainguard.dev/melange/pkg/http"
 	"chainguard.dev/melange/pkg/manifest"
@@ -36,7 +35,7 @@ func TestGetApkDependencies(t *testing.T) {
 	// Start a local HTTP server
 	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		// assert requests dependency is in the list of test files
-		assert.True(t, util.Contains(filenames, req.URL.String()), "requests file does not match any test files")
+		assert.True(t, slices.Contains(filenames, req.URL.String()), "requests file does not match any test files")
 
 		// send response to be tested
 		data, err := os.ReadFile(filepath.Join("testdata", "deps", "/"+req.URL.String()))

--- a/pkg/renovate/cache/cache.go
+++ b/pkg/renovate/cache/cache.go
@@ -18,8 +18,11 @@ import (
 	"context"
 	"crypto/sha256"
 	"crypto/sha512"
+	"encoding/hex"
 	"fmt"
+	"hash"
 	"io"
+	"net/http"
 	"os"
 	"path"
 	"strings"
@@ -30,7 +33,6 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"chainguard.dev/melange/pkg/renovate"
-	"chainguard.dev/melange/pkg/util"
 )
 
 // CacheConfig contains the configuration data for a bump
@@ -136,7 +138,7 @@ func visitFetch(ctx context.Context, node *yaml.Node, cfg CacheConfig) error {
 	log.Infof("  uri: %s", uriNode.Value)
 	log.Infof("  evaluated: %s", evaluatedURI)
 
-	downloadedFile, err := util.DownloadFile(ctx, evaluatedURI)
+	downloadedFile, err := downloadFile(ctx, evaluatedURI)
 	if err != nil {
 		return err
 	}
@@ -144,13 +146,13 @@ func visitFetch(ctx context.Context, node *yaml.Node, cfg CacheConfig) error {
 	log.Infof("  fetched-as: %s", downloadedFile)
 
 	// Calculate SHA2-256 and SHA2-512 hashes.
-	fileSHA256, err := util.HashFile(downloadedFile, sha256.New())
+	fileSHA256, err := hashFile(downloadedFile, sha256.New())
 	if err != nil {
 		return err
 	}
 	log.Infof("  actual-sha256: %s", fileSHA256)
 
-	fileSHA512, err := util.HashFile(downloadedFile, sha512.New())
+	fileSHA512, err := hashFile(downloadedFile, sha512.New())
 	if err != nil {
 		return err
 	}
@@ -214,4 +216,61 @@ func addFileToCache(ctx context.Context, cfg CacheConfig, downloadedFile string,
 	log.Infof("  wrote: %s", destinationPath)
 
 	return nil
+}
+
+// downloadFile downloads a file and returns a path to it in temporary storage.
+func downloadFile(ctx context.Context, uri string) (string, error) {
+	targetFile, err := os.CreateTemp("", "melange-update-*")
+	if err != nil {
+		return "", err
+	}
+	defer targetFile.Close()
+
+	client := &http.Client{
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			// delete the referer header else redirects with sourceforge do not work well.  See https://stackoverflow.com/questions/67203383/downloading-from-sourceforge-wait-and-redirect
+			req.Header.Del("Referer")
+			return nil
+		},
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "GET", uri, nil)
+	if err != nil {
+		return "", err
+	}
+
+	// Set accept header to match the expected MIME types and avoid 403's for some servers like https://www.netfilter.org
+	req.Header.Set("Accept", "text/html")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		return "", fmt.Errorf("got %s when fetching %s", resp.Status, uri)
+	}
+
+	if _, err := io.Copy(targetFile, resp.Body); err != nil {
+		return "", err
+	}
+
+	return targetFile.Name(), nil
+}
+
+// hashFile calculates the hash for a file and returns it as a hex string.
+func hashFile(downloadedFile string, digest hash.Hash) (string, error) {
+	hashedFile, err := os.Open(downloadedFile)
+	if err != nil {
+		return "", err
+	}
+	defer hashedFile.Close()
+
+	if _, err := io.Copy(digest, hashedFile); err != nil {
+		return "", err
+	}
+
+	return hex.EncodeToString(digest.Sum(nil)), nil
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -16,73 +16,8 @@ package util
 
 import (
 	"cmp"
-	"context"
-	"encoding/hex"
-	"fmt"
-	"hash"
-	"io"
-	"net/http"
-	"os"
 	"slices"
-	"sort"
 )
-
-// DownloadFile downloads a file and returns a path to it in temporary storage.
-func DownloadFile(ctx context.Context, uri string) (string, error) {
-	targetFile, err := os.CreateTemp("", "melange-update-*")
-	if err != nil {
-		return "", err
-	}
-	defer targetFile.Close()
-
-	client := &http.Client{
-		CheckRedirect: func(req *http.Request, via []*http.Request) error {
-			// delete the referer header else redirects with sourceforge do not work well.  See https://stackoverflow.com/questions/67203383/downloading-from-sourceforge-wait-and-redirect
-			req.Header.Del("Referer")
-			return nil
-		},
-	}
-
-	req, err := http.NewRequestWithContext(ctx, "GET", uri, nil)
-	if err != nil {
-		return "", err
-	}
-
-	// Set accept header to match the expected MIME types and avoid 403's for some servers like https://www.netfilter.org
-	req.Header.Set("Accept", "text/html")
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return "", err
-	}
-
-	defer resp.Body.Close()
-
-	if resp.StatusCode != 200 {
-		return "", fmt.Errorf("got %s when fetching %s", resp.Status, uri)
-	}
-
-	if _, err := io.Copy(targetFile, resp.Body); err != nil {
-		return "", err
-	}
-
-	return targetFile.Name(), nil
-}
-
-// HashFile calculates the hash for a file and returns it as a hex string.
-func HashFile(downloadedFile string, digest hash.Hash) (string, error) {
-	hashedFile, err := os.Open(downloadedFile)
-	if err != nil {
-		return "", err
-	}
-	defer hashedFile.Close()
-
-	if _, err := io.Copy(digest, hashedFile); err != nil {
-		return "", err
-	}
-
-	return hex.EncodeToString(digest.Sum(nil)), nil
-}
 
 // Given a left and right map, perform a right join and return the result
 func RightJoinMap(left map[string]string, right map[string]string) map[string]string {
@@ -101,21 +36,6 @@ func RightJoinMap(left map[string]string, right map[string]string) map[string]st
 	}
 
 	return output
-}
-
-func ReverseSlice[T comparable](s []T) {
-	sort.SliceStable(s, func(i, j int) bool {
-		return i > j
-	})
-}
-
-func Contains[T comparable](s []T, e T) bool {
-	for _, v := range s {
-		if v == e {
-			return true
-		}
-	}
-	return false
 }
 
 // Dedup wraps slices.Sort and slices.Compact to deduplicate a slice.


### PR DESCRIPTION
`util.DownloadFile` is mainly used to get a local file which we can hash with `util.HashFile`. But, it's unnecessary to download the file to disk if it's only going to get hashed and deleted. So instead, the renovate code that just does that now does that with just `net/http` and `crypto/sha{256,512}`.

The only remaining user of `util.DownloadFile` and `util.HashFile` is the cache populator, which copies the file to another location (or to GCS), which can keep this for now.

Also remove some generic methods with stuff from stdlib `slices`.

There are more methods we can probably clean up or unexport or make `internal`, but this is a good stopping point for now.