### PR TITLE
qemu: reduce logspam for qemu runner

### DIFF
--- a/pkg/container/qemu_runner.go
+++ b/pkg/container/qemu_runner.go
@@ -76,9 +76,8 @@ func (bw *qemu) Name() string {
 
 // Run runs a Qemu task given a Config and command string.
 func (bw *qemu) Run(ctx context.Context, cfg *Config, envOverride map[string]string, args ...string) error {
-	clog.InfoContextf(ctx, "running command %s", strings.Join(args, " "))
-
 	log := clog.FromContext(ctx)
+	log.Debugf("running command %s", strings.Join(args, " "))
 	stdout, stderr := logwriter.New(log.Info), logwriter.New(log.Warn)
 	defer stdout.Close()
 	defer stderr.Close()

--- a/pkg/container/qemu_runner.go
+++ b/pkg/container/qemu_runner.go
@@ -783,7 +783,7 @@ func sendSSHCommand(ctx context.Context, user, address string,
 	clog.FromContext(ctx).Infof("running (%d) %v", len(command), cmd)
 	err = session.Run(cmd)
 	if err != nil {
-		clog.FromContext(ctx).Errorf("Failed to run command %v: %s", command, err)
+		clog.FromContext(ctx).Errorf("Failed to run command: %v", err)
 		return err
 	}
 


### PR DESCRIPTION
This doesn't need to be printed each time. If you care, you can `--log-level=debug`