### PR TITLE
fix: allow running docker runner as non-root user

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -164,6 +164,10 @@ func New(ctx context.Context, opts ...Option) (*Build, error) {
 		if err != nil {
 			return nil, fmt.Errorf("unable to create workspace dir: %w", err)
 		}
+		err = os.Chmod(tmpdir, 0o755)
+		if err != nil {
+			return nil, fmt.Errorf("unable to change permissions to workspace directory: %w", err)
+		}
 		b.WorkspaceDir = tmpdir
 	}
 
@@ -731,6 +735,10 @@ func (b *Build) BuildPackage(ctx context.Context) error {
 		if err != nil {
 			return fmt.Errorf("unable to make guest directory: %w", err)
 		}
+		err = os.Chmod(guestDir, 0o755)
+		if err != nil {
+			return fmt.Errorf("unable to change permissions to guest directory: %w", err)
+		}
 		b.GuestDir = guestDir
 
 		if b.Remove {
@@ -860,6 +868,11 @@ func (b *Build) BuildPackage(ctx context.Context) error {
 	// run any pipelines for subpackages
 	for _, sp := range b.Configuration.Subpackages {
 		sp := sp
+
+		if err := os.MkdirAll(filepath.Join(b.WorkspaceDir, melangeOutputDirName, sp.Name), 0o755); err != nil {
+			return err
+		}
+
 		if !b.isBuildLess() {
 			log.Infof("running pipeline for subpackage %s", sp.Name)
 
@@ -868,10 +881,6 @@ func (b *Build) BuildPackage(ctx context.Context) error {
 			if err := pr.runPipelines(ctx, sp.Pipeline); err != nil {
 				return fmt.Errorf("unable to run subpackage %s pipeline: %w", sp.Name, err)
 			}
-		}
-
-		if err := os.MkdirAll(filepath.Join(b.WorkspaceDir, melangeOutputDirName, sp.Name), 0o755); err != nil {
-			return err
 		}
 
 		// add the main package to the linter queue

--- a/pkg/build/pipelines/git-checkout.yaml
+++ b/pkg/build/pipelines/git-checkout.yaml
@@ -161,7 +161,8 @@ pipeline:
 
           [ "$depth" = "-1" ] || depthflag="--depth=$depth"
 
-          workdir=$(mktemp -d)
+          workdir=$(mktemp -u)
+          mkdir $workdir
           rcfile=$(mktemp)
           mkdir -p "$dest"
           dest_fullpath=$(realpath "$dest")


### PR DESCRIPTION
## Melange Pull Request Template

<!--
*** PULL REQUEST CHECKLIST: PLEASE START HERE ***

The single most important feature of melange is that we can build Wolfi.

Many changes to melange introduce a risk of breaking the build, and sometimes
these are not flushed out until a package is changed (much) later.  This
pertains to basic execution, SCA changes, linter changes, and more.
-->

### Functional Changes

- [ ] This change can build all of Wolfi without errors (describe results in notes)

Notes:

### SCA Changes

- [ ] Examining several representative APKs show no regression / the desired effect (details in notes)

Notes:

### Linter

- [ ] The new check is clean across Wolfi
- [ ] The new check is opt-in or a warning

Notes:
