### PR TITLE
Clean up workspace dir from inside runner to avoid permission errors.

### DIFF
--- a/pkg/build/pipeline.go
+++ b/pkg/build/pipeline.go
@@ -34,6 +34,8 @@ import (
 	"github.com/chainguard-dev/clog"
 )
 
+const WorkDir = "/home/build"
+
 func (sm *SubstitutionMap) MutateWith(with map[string]string) (map[string]string, error) {
 	nw := maps.Clone(sm.Substitutions)
 
@@ -187,7 +189,7 @@ func (r *pipelineRunner) runPipeline(ctx context.Context, pipeline *config.Pipel
 		envOverride[k] = v
 	}
 
-	workdir := "/home/build"
+	workdir := WorkDir
 	if pipeline.WorkDir != "" {
 		workdir = pipeline.WorkDir
 	}


### PR DESCRIPTION
When running privileged docker as an unprivileged user, the files that are created in the WorkspaceDir are created as root. Even if the build were run as non-root, they would not necessarily be the same ownership as the user invoking melange.

As a result, WorkspaceDir would not be able to be cleaned up and melange would just leave files there to later be cleaned up with a dangerous 'sudo rm -Rf' by the user.

The change here is to clean up the WorkspaceDir from _inside_ the container, where the uid is the same as the uid that created the files.

I believe this will waste IO and/or time on the qemu runner, where /home/build isn't actually bind'd in.  Later we could expose a CleanWorkspace from the runner that was a noop in qemu.
