### PR TITLE
Create sub-package directories in WorkDir before building subpackage

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -860,6 +860,10 @@ func (b *Build) BuildPackage(ctx context.Context) error {
 	// run any pipelines for subpackages
 	for _, sp := range b.Configuration.Subpackages {
 		sp := sp
+		if err := os.MkdirAll(filepath.Join(b.WorkspaceDir, melangeOutputDirName, sp.Name), 0o755); err != nil {
+			return err
+		}
+
 		if !b.isBuildLess() {
 			log.Infof("running pipeline for subpackage %s", sp.Name)
 
@@ -868,10 +872,6 @@ func (b *Build) BuildPackage(ctx context.Context) error {
 			if err := pr.runPipelines(ctx, sp.Pipeline); err != nil {
 				return fmt.Errorf("unable to run subpackage %s pipeline: %w", sp.Name, err)
 			}
-		}
-
-		if err := os.MkdirAll(filepath.Join(b.WorkspaceDir, melangeOutputDirName, sp.Name), 0o755); err != nil {
-			return err
 		}
 
 		// add the main package to the linter queue


### PR DESCRIPTION
Moving the creation of the subpackage dir before running the pipelines means that the subpackage directory was created as the user that ran melange rather than the user that is doing the build.  Those uids can be different depending on the runner.

SBOMs are written as the uid that invoked melange.  It assumes that it can create Workspace/package-dir/var/lib/db/sbom . Previously, the 'package-dir' portion of that would sometimes get created by the uid inside the build (probably as a result of 'mkdir -p ${{targets.contextdir}}/usr/bin' or the like).  The result was that the uid running melange could not create var/lib/db/sbom because it did not have write perms to package-dir.

By creating package-dir first, we (mostly) ensure that we can later create var/lib/db/sbom, and this will succeed more often.

There is still a problem in that we assume that we can write there. Some part of the build might create var/lib/db and have all those tokens as 755 with a different uid.  The right solution is probably to do the population from inside the Runner.

This improves the situation for
https://github.com/chainguard-dev/melange/issues/1254, but does not entirely fix it.
