### PR TITLE
fix(pipeline): do preliminary checks for checksum invalid chars

### DIFF
--- a/pkg/build/pipeline.go
+++ b/pkg/build/pipeline.go
@@ -145,10 +145,16 @@ func validateWith(data map[string]string, inputs map[string]config.Input) (map[s
 			if !matchValidShaChars(data[k]) {
 				return data, fmt.Errorf("checksum input %q for pipeline contains invalid characters", k)
 			}
+			if len(data[k]) != 64 {
+				return data, fmt.Errorf("checksum input %q for pipeline, invalid length", k)
+			}
 		}
 		if k == "expected-sha512" && data[k] != "" {
 			if !matchValidShaChars(data[k]) {
 				return data, fmt.Errorf("checksum input %q for pipeline contains invalid characters", k)
+			}
+			if len(data[k]) != 128 {
+				return data, fmt.Errorf("checksum input %q for pipeline, invalid length", k)
 			}
 		}
 

--- a/pkg/build/pipeline.go
+++ b/pkg/build/pipeline.go
@@ -23,6 +23,7 @@ import (
 	"os/signal"
 	"path"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -140,6 +141,16 @@ func validateWith(data map[string]string, inputs map[string]config.Input) (map[s
 		if data[k] == "" {
 			data[k] = v.Default
 		}
+		if k == "expected-sha256" && data[k] != "" {
+			if !matchValidShaChars(data[k]) {
+				return data, fmt.Errorf("checksum input %q for pipeline contains invalid characters", k)
+			}
+		}
+		if k == "expected-sha512" && data[k] != "" {
+			if !matchValidShaChars(data[k]) {
+				return data, fmt.Errorf("checksum input %q for pipeline contains invalid characters", k)
+			}
+		}
 
 		if v.Required && data[k] == "" {
 			return data, fmt.Errorf("required input %q for pipeline is missing", k)
@@ -147,6 +158,11 @@ func validateWith(data map[string]string, inputs map[string]config.Input) (map[s
 	}
 
 	return data, nil
+}
+
+func matchValidShaChars(s string) bool {
+	match, _ := regexp.MatchString("^[a-fA-F0-9]+$", s)
+	return match
 }
 
 // Build a script to run as part of evalRun
@@ -275,7 +291,7 @@ func (r *pipelineRunner) maybeDebug(ctx context.Context, fragment string, envOve
 	signal.Ignore(os.Interrupt)
 
 	// Populate $HOME/.ash_history with the current command so you can hit up arrow to repeat it.
-	if err := os.WriteFile(filepath.Join(r.config.WorkspaceDir, ".ash_history"), []byte(fragment), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(r.config.WorkspaceDir, ".ash_history"), []byte(fragment), 0o644); err != nil {
 		return fmt.Errorf("failed to write history file: %w", err)
 	}
 


### PR DESCRIPTION
Fix https://github.com/chainguard-dev/internal-dev/issues/1571

We don't want to pass possible code execution to `expected-sha{256,512}`, the comparison is done in shell
this opens the possibility to inject values and/or commands.

SHA checksums only contains [0-9a-zA-Z] chars, so ensure we only have those. This will prevent any injection at that stage.

