### PR TITLE
convert/gem: Update convert gem to reflect the state of ruby3.3

### DIFF
--- a/docs/md/melange_convert_gem.md
+++ b/docs/md/melange_convert_gem.md
@@ -32,7 +32,7 @@ convert gem fluentd
 ```
       --base-uri-format string   URI to use for querying gems for provided package name (default "https://rubygems.org/api/v1/gems/%s.json")
   -h, --help                     help for gem
-      --ruby-version string      version of ruby to use throughout generated manifests (default "3.2")
+      --ruby-version string      version of ruby to use throughout generated manifests (default "3.3")
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
## Melange Pull Request Template

### Functional Changes

- [X] This change can build all of Wolfi without errors (describe results in notes)

Notes:
These changes are just in the gem convert pieces and won't effect builds

convert/gem: Update convert gem to reflect the state of ruby3.3
    
 Changes:
 - Update default ruby to 3.3
 - Remove keyring entries wolfictl lint rejects them
    
 ```
 ❯ wolfictl lint ruby3.2-diff-lcs.yaml
 2024/11/19 09:51:17 INFO Package: ruby3.2-diff-lcs: [forbidden-repository-used]: forbidden repository https://packages.wolfi.dev/os is used (ERROR)
 [forbidden-keyring-used]: forbidden keyring https://packages.wolfi.dev/os/wolfi-signing.rsa.pub is used (ERROR)
 ```

 - Remove README it causes build to fial
 - Remove patch people will notice when it fails and the sed in pipelines/ruby/build should account for it
 - Truncate dscription becuase it breaks index generation
 ```
 2024/11/19 10:01:40 ERRO failed to build package: unable to generate index: updating index: failed to parse package packages/aarch64/ruby3.2-diff-lcs-1.5.1-r0.apk: ini.ShadowLoad(): key-value delimiter not found: McIlroy-Hunt longest common subsequence (LCS) algorithm. It includes utilities
 ```

