### PR TITLE
pipelines/cargo: ability to override the hardcoded output-dir

### DIFF
--- a/pkg/build/pipelines/cargo/build.yaml
+++ b/pkg/build/pipelines/cargo/build.yaml
@@ -36,11 +36,16 @@ inputs:
       Directory where binaries will be installed
     default: bin
 
+  output-dir:
+    description: |
+      Directory where the binaris will be placed after building. Defaults to target/release
+    default: target/release
+
 pipeline:
   - runs: |
       # Installation directory should always be bin as we are producing a binary
       INSTALL_PATH="${{targets.contextdir}}/${{inputs.prefix}}/${{inputs.install-dir}}"
-      OUTPUT_PATH="target/release"
+      OUTPUT_PATH="${{inputs.output-dir}}"
 
       # Enter target package directory
       cd "${{inputs.modroot}}"


### PR DESCRIPTION
Some projects exports the binaries to different paths so that we couldn't use the cargo/build pipeline properly.

Example case here: https://github.com/wolfi-dev/os/pull/34028

## Melange Pull Request Template

<!--
*** PULL REQUEST CHECKLIST: PLEASE START HERE ***

The single most important feature of melange is that we can build Wolfi.

Many changes to melange introduce a risk of breaking the build, and sometimes
these are not flushed out until a package is changed (much) later.  This
pertains to basic execution, SCA changes, linter changes, and more.
-->

### Functional Changes

- [ ] This change can build all of Wolfi without errors (describe results in notes)

Notes:

### SCA Changes

- [ ] Examining several representative APKs show no regression / the desired effect (details in notes)

Notes:

### Linter

- [ ] The new check is clean across Wolfi
- [ ] The new check is opt-in or a warning

Notes:
