### PR TITLE
drop ntia e2e test

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -53,9 +53,7 @@ jobs:
             echo ::group::sbom.json
             cat sbom.json
             echo ::endgroup::
-            docker run --rm -v $(pwd)/sbom.json:/sbom.json cgr.dev/chainguard/ntia-conformance-checker --file /sbom.json
 
-            # TODO: Make this an image.
             docker run --rm -v $(pwd)/sbom.json:/sbom.json --entrypoint "sh" cgr.dev/chainguard/wolfi-base -c "apk add spdx-tools-java && tools-java Verify /sbom.json"
           done
 


### PR DESCRIPTION
That public image has been pulled, and we don't really need it anyway since we rely on the SPDX check to tell us whether SBOMs are valid.