### PR TITLE
Minor RELEASE.md cleanup, add git version in Summarize output.

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -8,6 +8,9 @@ To cut a release:
 4. In the dropdown, click on the `Run workflow` button.
 5. Wait for the workflow to complete successfully.
 
+After workflow completes the new release will show up in [tags](https://github.com/chainguard-dev/melange/tags)
+and [releases](https://github.com/chainguard-dev/melange/releases).
+
 ### Useful things to know
 
 #### Detecting whether a new release is needed

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -48,6 +48,7 @@ import (
 	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
 	"k8s.io/kube-openapi/pkg/util/sets"
+	"sigs.k8s.io/release-utils/version"
 
 	"chainguard.dev/melange/pkg/config"
 	"chainguard.dev/melange/pkg/container"
@@ -1081,7 +1082,7 @@ func (b *Build) SummarizePaths(ctx context.Context) {
 
 func (b *Build) summarize(ctx context.Context) {
 	log := clog.FromContext(ctx)
-	log.Infof("melange is building:")
+	log.Infof("melange %s is building:", version.GetVersionInfo().GitVersion)
 	log.Infof("  configuration file: %s", b.ConfigFile)
 	b.SummarizePaths(ctx)
 }

--- a/pkg/build/test.go
+++ b/pkg/build/test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/chainguard-dev/clog"
 	"github.com/yookoala/realpath"
 	"go.opentelemetry.io/otel"
+	"sigs.k8s.io/release-utils/version"
 
 	"chainguard.dev/melange/pkg/config"
 	"chainguard.dev/melange/pkg/container"
@@ -535,7 +536,7 @@ func (t *Test) SummarizePaths(ctx context.Context) {
 
 func (t *Test) Summarize(ctx context.Context) {
 	log := clog.FromContext(ctx)
-	log.Infof("melange is testing:")
+	log.Infof("melange %s is testing:", version.GetVersionInfo().GitVersion)
 	log.Infof("  configuration file: %s", t.ConfigFile)
 	t.SummarizePaths(ctx)
 }


### PR DESCRIPTION
2 small changes
1. add a statement that after running the release workflow it should have created a github release and tag
2. put melange version output in `Summarize` output.

Now, you'll see something like:

```
$ ./melange build --git-repo-url=github.com/wolfi-dev/os test-me.yaml  --arch=x86_64
2024/11/22 16:57:28 INFO git commit for build config not provided, attempting to detect automatically
2024/11/22 16:57:28 INFO melange v0.15.13-2-g2bf668c is building:
2024/11/22 16:57:28 INFO   configuration file: test-me.yaml
2024/11/22 16:57:28 INFO   workspace dir: /home/user/tmp/melange-workspace-2077411557
2024/11/22 16:57:28 INFO evaluating pipelines for package requirements
```