### PR TITLE
Improve comment stripping errors

### DIFF
--- a/docs/md/melange_compile.md
+++ b/docs/md/melange_compile.md
@@ -43,10 +43,13 @@ melange compile [flags]
       --env-file string             file to use for preloaded environment variables
       --fail-on-lint-warning        turns linter warnings into failures
       --generate-index              whether to generate APKINDEX.tar.gz (default true)
+      --git-commit string           commit hash of the git repository containing the build config file (defaults to detecting HEAD)
+      --git-repo-url string         URL of the git repository containing the build config file (defaults to detecting from configured git remotes)
       --guest-dir string            directory used for the build environment guest
   -h, --help                        help for compile
   -i, --interactive                 when enabled, attaches stdin with a tty to the pod on failure
   -k, --keyring-append strings      path to extra keys to include in the build environment keyring
+      --license string              license to use for the build config file itself (default "NOASSERTION")
       --log-policy strings          logging policy to use (default [builtin:stderr])
       --memory string               default memory resources to use for builds
       --namespace string            namespace to use in package URLs in SBOM (eg wolfi, alpine) (default "unknown")

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -207,9 +207,6 @@ func New(ctx context.Context, opts ...Option) (*Build, error) {
 	if b.ConfigFileRepositoryCommit == "" {
 		return nil, fmt.Errorf("config file repository commit was not set")
 	}
-	if b.Runner == nil {
-		return nil, fmt.Errorf("no runner was specified")
-	}
 
 	parsedCfg, err := config.ParseConfiguration(ctx,
 		b.ConfigFile,
@@ -717,6 +714,10 @@ func (b *Build) BuildPackage(ctx context.Context) error {
 	ctx, span := otel.Tracer("melange").Start(ctx, "BuildPackage")
 	defer span.End()
 
+	if b.Runner == nil {
+		return fmt.Errorf("no runner was specified")
+	}
+
 	b.summarize(ctx)
 
 	namespace := b.Namespace
@@ -779,7 +780,7 @@ func (b *Build) BuildPackage(ctx context.Context) error {
 
 	log.Infof("evaluating pipelines for package requirements")
 	if err := b.Compile(ctx); err != nil {
-		return fmt.Errorf("compiling build: %w", err)
+		return fmt.Errorf("compiling %s: %w", b.ConfigFile, err)
 	}
 
 	// Filter out any subpackages with false If conditions.

--- a/pkg/build/compile_test.go
+++ b/pkg/build/compile_test.go
@@ -147,4 +147,15 @@ func Test_stripComments(t *testing.T) {
 			}
 		})
 	}
+
+	wantErr := `1:13: not a valid test operator: -m:
+> if [[ uname -m == 'x86_64']]; then
+              ^`
+
+	got, err := stripComments("if [[ uname -m == 'x86_64']]; then")
+	if err == nil {
+		t.Errorf("expected error, got %q", got)
+	} else if err.Error() != wantErr {
+		t.Errorf("want:\n%s\ngot:\n%s", wantErr, err)
+	}
 }

--- a/pkg/build/test.go
+++ b/pkg/build/test.go
@@ -343,7 +343,7 @@ func (t *Test) TestPackage(ctx context.Context) error {
 
 	log.Infof("evaluating pipelines for package requirements")
 	if err := t.Compile(ctx); err != nil {
-		return fmt.Errorf("compiling test pipelines: %w", err)
+		return fmt.Errorf("compiling %s tests: %w", t.ConfigFile, err)
 	}
 
 	if t.Runner.Name() == container.QemuName {


### PR DESCRIPTION
Before, these looked like:

```
compiling main pipelines: compiling Pipeline[0]: stripping runs comments: 14:13: not a valid test operator: -m
```

Now, these look like:

```
compiling "hwloc" test pipelines: compiling Pipeline[0]: stripping runs comments: 14:13: not a valid test operator: -m:
> if [[ uname -m == 'x86_64']]; then
              ^
```

First big change is that we include the package name in the error. Without this, it was really challenging to find which package actually had a syntax error.

Second big change is that we use the nice structured error we get back from the shell parsing library to include the line that failed with a cursor pointing at the column that failed.
