### PR TITLE
fix(sca): Generate dependency for ruby-*-base instead of ruby-*

### DIFF
--- a/pkg/sca/sca.go
+++ b/pkg/sca/sca.go
@@ -548,7 +548,7 @@ func generatePythonDeps(ctx context.Context, hdl SCAHandle, generated *config.De
 	return nil
 }
 
-// generateRubyDeps generates a ruby-X.Y dependency for packages which ship
+// generateRubyDeps generates a ruby-X.Y-base dependency for packages which ship
 // Ruby gems.
 func generateRubyDeps(ctx context.Context, hdl SCAHandle, generated *config.Dependencies) error {
 	log := clog.FromContext(ctx)
@@ -590,8 +590,8 @@ func generateRubyDeps(ctx context.Context, hdl SCAHandle, generated *config.Depe
 		}
 	}
 
-	log.Infof("  found ruby gem, generating ruby-%s dependency", rubyGemVer)
-	generated.Runtime = append(generated.Runtime, fmt.Sprintf("ruby-%s", rubyGemVer))
+	log.Infof("  found ruby gem, generating ruby-%s-base dependency", rubyGemVer)
+	generated.Runtime = append(generated.Runtime, fmt.Sprintf("ruby-%s-base", rubyGemVer))
 
 	return nil
 }

--- a/pkg/sca/sca.go
+++ b/pkg/sca/sca.go
@@ -669,7 +669,7 @@ func sonameLibver(soname string) string {
 func getShbang(fp io.Reader) (string, error) {
 	// python3 and sh are symlinks and generateCmdProviders currently only considers
 	// regular files. Since nothing will fulfill such a depend, do not generate one.
-	ignores := map[string]bool{"python3": true, "python": true, "sh": true, "awk": true}
+	ignores := map[string]bool{"python3": true, "python": true, "ruby": true, "sh": true, "awk": true}
 
 	buf := make([]byte, 80)
 	blen, err := io.ReadFull(fp, buf)

--- a/pkg/sca/sca_test.go
+++ b/pkg/sca/sca_test.go
@@ -212,7 +212,7 @@ func TestRubySca(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	want := config.Dependencies{Runtime: []string{"ruby-3.2"}}
+	want := config.Dependencies{Runtime: []string{"ruby-3.2-base"}}
 
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("Analyze(): (-want, +got):\n%s", diff)


### PR DESCRIPTION
Ruby is being modified to be coinstallable across versions. To avoid different versions of Ruby from clashing, we need to generate a dependency on ruby-\*-base instead of ruby-\*

## Melange Pull Request Template

<!--
*** PULL REQUEST CHECKLIST: PLEASE START HERE ***

The single most important feature of melange is that we can build Wolfi.

Many changes to melange introduce a risk of breaking the build, and sometimes
these are not flushed out until a package is changed (much) later.  This
pertains to basic execution, SCA changes, linter changes, and more.
-->

### Functional Changes

- [ ] This change can build all of Wolfi without errors (describe results in notes)

Notes:

### SCA Changes

- [x] Examining several representative APKs show no regression / the desired effect (details in notes)

Notes:

### Linter

- [ ] The new check is clean across Wolfi
- [ ] The new check is opt-in or a warning

Notes:
