### PR TITLE
feat(volume mounts): add support for mounting volumes into the melange build context

### DIFF
--- a/docs/md/melange_build.md
+++ b/docs/md/melange_build.md
@@ -71,6 +71,7 @@ melange build [flags]
       --timeout duration                                        default timeout for builds
       --trace string                                            where to write trace output
       --vars-file string                                        file to use for preloaded build configuration variables
+  -v, --volume strings                                          bind mount a volume(s) into the container (e.g., /host:/container)
       --workspace-dir string                                    directory used for the workspace at /home/build
 ```
 

--- a/docs/md/melange_test.md
+++ b/docs/md/melange_test.md
@@ -47,6 +47,7 @@ melange test [flags]
       --source-dir string             directory used for included sources
       --test-option strings           build options to enable
       --test-package-append strings   extra packages to install for each of the test environments
+  -v, --volume strings                bind mount a volume(s) into the container (e.g., /host:/container)
       --workspace-dir string          directory used for the workspace at /home/build
 ```
 

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -135,6 +135,7 @@ type Build struct {
 	DefaultTimeout        time.Duration
 	Auth                  map[string]options.Auth
 	IgnoreSignatures      bool
+	VolumeMounts          []container.BindMount
 
 	EnabledBuildOptions []string
 
@@ -1144,6 +1145,10 @@ func (b *Build) buildWorkspaceConfig(ctx context.Context) *container.Config {
 		} else {
 			log.Infof("--cache-dir %s not a dir; skipping", b.CacheDir)
 		}
+	}
+
+	for _, vm := range b.VolumeMounts {
+		mounts = append(mounts, container.BindMount{Source: vm.Source, Destination: vm.Destination})
 	}
 
 	// TODO(kaniini): Disable networking capability according to the pipeline requirements.

--- a/pkg/build/options.go
+++ b/pkg/build/options.go
@@ -412,3 +412,11 @@ func WithIgnoreSignatures(ignore bool) Option {
 		return nil
 	}
 }
+
+// WithVolumeMounts adds a volume mount to the build environment.
+func WithVolumeMounts(src, dest string) Option {
+	return func(b *Build) error {
+		b.VolumeMounts = append(b.VolumeMounts, container.BindMount{Source: src, Destination: dest})
+		return nil
+	}
+}

--- a/pkg/build/test.go
+++ b/pkg/build/test.go
@@ -69,6 +69,7 @@ type Test struct {
 	Interactive       bool
 	Auth              map[string]options.Auth
 	IgnoreSignatures  bool
+	VolumeMounts      []container.BindMount
 }
 
 func NewTest(ctx context.Context, opts ...TestOption) (*Test, error) {
@@ -559,6 +560,10 @@ func (t *Test) buildWorkspaceConfig(ctx context.Context, imgRef, pkgName string,
 		} else {
 			return nil, fmt.Errorf("--cache-dir %s not a dir", t.CacheDir)
 		}
+	}
+
+	for _, vm := range t.VolumeMounts {
+		mounts = append(mounts, container.BindMount{Source: vm.Source, Destination: vm.Destination})
 	}
 
 	// TODO(kaniini): Disable networking capability according to the pipeline requirements.

--- a/pkg/build/test_options.go
+++ b/pkg/build/test_options.go
@@ -204,3 +204,10 @@ func WithTestRemove(c bool) TestOption {
 		return nil
 	}
 }
+
+func WithTestVolumeMount(src, dest string) TestOption {
+	return func(t *Test) error {
+		t.VolumeMounts = append(t.VolumeMounts, container.BindMount{Source: src, Destination: dest})
+		return nil
+	}
+}

--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -81,6 +81,7 @@ func buildCmd() *cobra.Command {
 	var configFileGitCommit string
 	var configFileGitRepoURL string
 	var configFileLicense string
+	var volume []string
 
 	var traceFile string
 
@@ -205,6 +206,14 @@ func buildCmd() *cobra.Command {
 				options = append(options, build.WithSourceDir(sourceDir))
 			}
 
+			for _, volumeMount := range volume {
+				parts := strings.SplitN(volumeMount, ":", 2)
+				if len(parts) != 2 {
+					return fmt.Errorf("volume mounts must be in the form 'src:dest' (got %q)", volumeMount)
+				}
+				options = append(options, build.WithVolumeMounts(parts[0], parts[1]))
+			}
+
 			if auth, ok := os.LookupEnv("HTTP_AUTH"); !ok {
 				// Fine, no auth.
 			} else if parts := strings.SplitN(auth, ":", 4); len(parts) != 4 {
@@ -263,6 +272,7 @@ func buildCmd() *cobra.Command {
 	cmd.Flags().StringVar(&configFileGitCommit, "git-commit", "", "commit hash of the git repository containing the build config file (defaults to detecting HEAD)")
 	cmd.Flags().StringVar(&configFileGitRepoURL, "git-repo-url", "", "URL of the git repository containing the build config file (defaults to detecting from configured git remotes)")
 	cmd.Flags().StringVar(&configFileLicense, "license", "NOASSERTION", "license to use for the build config file itself")
+	cmd.Flags().StringSliceVarP(&volume, "volume", "v", []string{}, "bind mount a volume(s) into the container (e.g., /host:/container)")
 
 	_ = cmd.Flags().Bool("fail-on-lint-warning", false, "DEPRECATED: DO NOT USE")
 	_ = cmd.Flags().MarkDeprecated("fail-on-lint-warning", "use --lint-require and --lint-warn instead")

--- a/pkg/cli/test.go
+++ b/pkg/cli/test.go
@@ -49,6 +49,7 @@ func test() *cobra.Command {
 	var runner string
 	var extraTestPackages []string
 	var remove bool
+	var volume []string
 
 	cmd := &cobra.Command{
 		Use:     "test",
@@ -93,6 +94,14 @@ func test() *cobra.Command {
 				options = append(options, build.WithTestSourceDir(sourceDir))
 			}
 
+			for _, volumeMount := range volume {
+				parts := strings.SplitN(volumeMount, ":", 2)
+				if len(parts) != 2 {
+					return fmt.Errorf("volume mounts must be in the form 'src:dest' (got %q)", volumeMount)
+				}
+				options = append(options, build.WithTestVolumeMount(parts[0], parts[1]))
+			}
+
 			for i := range pipelineDirs {
 				options = append(options, build.WithTestPipelineDir(pipelineDirs[i]))
 			}
@@ -132,6 +141,7 @@ func test() *cobra.Command {
 	cmd.Flags().StringSliceVarP(&extraRepos, "repository-append", "r", []string{}, "path to extra repositories to include in the build environment")
 	cmd.Flags().StringSliceVar(&extraTestPackages, "test-package-append", []string{}, "extra packages to install for each of the test environments")
 	cmd.Flags().BoolVar(&remove, "rm", true, "clean up intermediate artifacts (e.g. container images, temp dirs)")
+	cmd.Flags().StringSliceVarP(&volume, "volume", "v", []string{}, "bind mount a volume(s) into the container (e.g., /host:/container)")
 
 	return cmd
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -120,6 +120,11 @@ type Package struct {
 	Timeout time.Duration `json:"timeout,omitempty" yaml:"timeout,omitempty"`
 	// Optional: Resources to allocate to the build.
 	Resources *Resources `json:"resources,omitempty" yaml:"resources,omitempty"`
+
+	// Optional: The ecosystem this package is built with
+	Ecosystem string `json:"ecosystem,omitempty" yaml:"ecosystem,omitempty"`
+	// Optional: The group this package belongs to
+	Group string `json:"group,omitempty" yaml:"group,omitempty"`
 }
 
 type Resources struct {


### PR DESCRIPTION
This change allows the specification of volume mounts in the format src:dest,src2:dest2 into the context of the melange build container.

## Melange Pull Request Template

<!--
*** PULL REQUEST CHECKLIST: PLEASE START HERE ***

The single most important feature of melange is that we can build Wolfi.

Many changes to melange introduce a risk of breaking the build, and sometimes
these are not flushed out until a package is changed (much) later.  This
pertains to basic execution, SCA changes, linter changes, and more.
-->

### Functional Changes

- [ ] This change can build all of Wolfi without errors (describe results in notes)

Notes:

### SCA Changes

- [ ] Examining several representative APKs show no regression / the desired effect (details in notes)

Notes:

### Linter

- [ ] The new check is clean across Wolfi
- [x] The new check is opt-in or a warning

Notes:

This has general utility for Melange but the first use case will be for mounting google cloud credentials into the context of melange so that a pipeline could retrieve an artifact from GAR for rebuilt artifacts.

Fixes https://github.com/chainguard-dev/internal-dev/issues/7385
