### PR TITLE
fix(sca): Revert recent SCA changes for Ruby

### DIFF
--- a/pkg/sca/sca.go
+++ b/pkg/sca/sca.go
@@ -548,7 +548,7 @@ func generatePythonDeps(ctx context.Context, hdl SCAHandle, generated *config.De
 	return nil
 }
 
-// generateRubyDeps generates a ruby-X.Y-base dependency for packages which ship
+// generateRubyDeps generates a ruby-X.Y dependency for packages which ship
 // Ruby gems.
 func generateRubyDeps(ctx context.Context, hdl SCAHandle, generated *config.Dependencies) error {
 	log := clog.FromContext(ctx)
@@ -590,8 +590,8 @@ func generateRubyDeps(ctx context.Context, hdl SCAHandle, generated *config.Depe
 		}
 	}
 
-	log.Infof("  found ruby gem, generating ruby-%s-base dependency", rubyGemVer)
-	generated.Runtime = append(generated.Runtime, fmt.Sprintf("ruby-%s-base", rubyGemVer))
+	log.Infof("  found ruby gem, generating ruby-%s dependency", rubyGemVer)
+	generated.Runtime = append(generated.Runtime, fmt.Sprintf("ruby-%s", rubyGemVer))
 
 	return nil
 }
@@ -669,7 +669,7 @@ func sonameLibver(soname string) string {
 func getShbang(fp io.Reader) (string, error) {
 	// python3 and sh are symlinks and generateCmdProviders currently only considers
 	// regular files. Since nothing will fulfill such a depend, do not generate one.
-	ignores := map[string]bool{"python3": true, "python": true, "ruby": true, "sh": true, "awk": true}
+	ignores := map[string]bool{"python3": true, "python": true, "sh": true, "awk": true}
 
 	buf := make([]byte, 80)
 	blen, err := io.ReadFull(fp, buf)

--- a/pkg/sca/sca_test.go
+++ b/pkg/sca/sca_test.go
@@ -212,7 +212,7 @@ func TestRubySca(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	want := config.Dependencies{Runtime: []string{"ruby-3.2-base"}}
+	want := config.Dependencies{Runtime: []string{"ruby-3.2"}}
 
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("Analyze(): (-want, +got):\n%s", diff)


### PR DESCRIPTION
Everything that depends on cmd:ruby fails to resolve, this was poorly timed and would require a Ruby world rebuild