### PR TITLE
melange/update block: provide config option to indicate that automated pull requests should be merged in order rather than superseding and closing previous unmerged PRs

### DIFF
--- a/docs/UPDATE.md
+++ b/docs/UPDATE.md
@@ -25,7 +25,8 @@ package:
 update:
   enabled: true # provide a flag to easily prevent a package from receiving auto update PRs
   manual: true # indicates that this package should be manually updated, usually taking care over special version numbers which can be hard to automate
-  shared: false # indicate that an update to this package requires an epoch bump of downstream dependencies, e.g. golang, java
+  shared: false # indicate that an update to this package requires an epoch bump of downstream dependencies, e.g. golang, java 
+  require-sequential: true # Default: false - indicates that automated pull requests should be merged in order rather than superseding and closing previous unmerged PRs
   release-monitor:
     identifier: 38 # Mandatory, ID number for release monitor
     strip-prefix: v # Optional, if the version obtained from the update service contains a prefix which should be ignored
@@ -50,6 +51,7 @@ update:
   enabled: true # provide a flag to easily toggle a package from receiving auto update PRs
   manual: true # indicates that this package should be manually updated, usually taking care over special version numbers which can be hard to automate
   shared: false # indicate that an update to this package requires an epoch bump of downstream dependencies, e.g. golang, java
+  require-sequential: true # Default: false - indicates that automated pull requests should be merged in order rather than superseding and closing previous unmerged PRs
   github: # alternative today is `release_monitor:`
     identifier: sigstore/cosign # Mandatory, org/repo for github
     strip-prefix: v # Optional, if the version obtained from the update service contains a prefix which should be ignored

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -681,6 +681,8 @@ type Update struct {
 	// Indicates that this package should be manually updated, usually taking
 	// care over special version numbers
 	Manual bool `json:"manual,omitempty" yaml:"manual"`
+	// Indicates that automated pull requests should be merged in order rather than superseding and closing previous unmerged PRs
+	RequireSequential bool `json:"require-sequential,omitempty" yaml:"require-sequential"`
 	// Indicate that an update to this package requires an epoch bump of
 	// downstream dependencies, e.g. golang, java
 	Shared bool `json:"shared,omitempty" yaml:"shared,omitempty"`


### PR DESCRIPTION
Some packages such as [jenkins](https://github.com/wolfi-dev/os/blob/main/jenkins.yaml) are required to build all upstream versions.  The default behaviour of the update bot will close previous automated update bot PRs superceeded by a new version.

This new config option will allow maintainers to tell the update bot to _not_ close existing PRs if they have not yet been merged.

This will allow the bot to create issues like this...

<img width="1571" alt="Screenshot 2024-12-09 at 13 37 35" src="https://github.com/user-attachments/assets/f027b594-5ba0-4440-b5f9-da7ef3050027">

And not close old PRs.

The new config looks like

```yaml
update:
  enabled: true
  require-sequential: true
```
