### PR TITLE
chore(docs): automatic generate pipeline docs

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -34,6 +34,7 @@ jobs:
 
       - run: |
           make docs-repo
+          make docs-pipeline
           git diff --exit-code
 
       - run: |

--- a/Makefile
+++ b/Makefile
@@ -205,6 +205,14 @@ docs-repo:
 	go run docs/main.go --baseurl /docs/md/ --suffix .md --out docs/md
 
 ##################
+# docs-pipeline - This creates documents for pipelines.
+##################
+.PHONY: docs-pipeline
+docs-pipeline:
+	@cd pkg/build/pipelines && \
+		go run ../../../docs/cmd/pipeline-reference-gen/main.go --pipeline-dir .
+
+##################
 # help
 ##################
 

--- a/pkg/build/pipelines/go/README.md
+++ b/pkg/build/pipelines/go/README.md
@@ -1,3 +1,4 @@
+
 <!-- start:pipeline-reference-gen -->
 # Pipeline Reference
 
@@ -19,7 +20,7 @@ Run a build using the go compiler
 | buildmode | false | The -buildmode flag value. See "go help buildmode" for more information.  | default |
 | deps | false | space separated list of go modules to update before building. example: github.com/foo/bar@v1.2.3  |  |
 | experiments | false | A comma-separated list of Golang experiment names (ex: loopvar) to use when building the binary.  |  |
-| extra-args | false | A space-separated list of extra arguments for go build command.  |  |
+| extra-args | false | A space-separated list of extra arguments to pass to the go build command.  |  |
 | go-package | false | The go package to install  | go |
 | install-dir | false | Directory where binaries will be installed  | bin |
 | ldflags | false | List of [pattern=]arg to append to the go compiler with -ldflags |  |


### PR DESCRIPTION
This commit adds a make target to generate documentation for pipelines. It also makes it run during the verify github workflow, alongside the generation of documentation of melange itself.
