### PR TITLE
fix(sca): Don't generate a dependnecy on ruby when found in shebang

### DIFF
--- a/pkg/sca/sca.go
+++ b/pkg/sca/sca.go
@@ -669,7 +669,7 @@ func sonameLibver(soname string) string {
 func getShbang(fp io.Reader) (string, error) {
 	// python3 and sh are symlinks and generateCmdProviders currently only considers
 	// regular files. Since nothing will fulfill such a depend, do not generate one.
-	ignores := map[string]bool{"python3": true, "python": true, "sh": true, "awk": true}
+	ignores := map[string]bool{"python3": true, "python": true, "ruby": true, "sh": true, "awk": true}
 
 	buf := make([]byte, 80)
 	blen, err := io.ReadFull(fp, buf)


### PR DESCRIPTION
Every package that depends on `cmd:ruby` today, already depends on `ruby-3.x`

As `cmd:ruby` resolves to whatever has ruby and not necessarily the correct version of ruby, get rid of this as it is not needed and broken

### SCA Changes

- [x] Examining several representative APKs show no regression / the desired effect (details in notes)

Notes: https://apk.chaindag.dev/https/packages.wolfi.dev/os/aarch64/APKINDEX.tar.gz@etag:b2b15507b98aca7d042d37e5612997e0/APKINDEX?full=false&search=&depend=cmd%3Aruby&provide=