### PR TITLE
sign: switch to SHA2-256 signature by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -148,10 +148,12 @@ lint: checkfmt setup-golangci-lint ## Run linters and checks like golangci-lint
 .PHONY: unit
 unit:
 	go test ./... -race
+	SIGNING_DIGEST=SHA1 go test ./... -race
 
 .PHONY: integration
 integration:
 	go test ./... -race -tags=integration
+	SIGNING_DIGEST=SHA1 go test ./... -race -tags=integration
 
 .PHONY: test
 test: integration

--- a/e2e-tests/numpy-test.yaml
+++ b/e2e-tests/numpy-test.yaml
@@ -12,12 +12,12 @@ test:
     # TODO(pnasrat): fix to use multiple python
     contents:
       packages:
-        - python-3.12
+        - python-3.13
   pipeline:
     # Test import with command (python -c "import numpy")
     - uses: python/test
       with:
-        command: python3.12 -c "import numpy"
+        command: python3.13 -c "import numpy"
     # Test import directly (python -c "import numpy")
     - uses: python/import
       with:

--- a/pkg/sign/apk_test.go
+++ b/pkg/sign/apk_test.go
@@ -54,10 +54,18 @@ func TestAPK(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	melangeApkDigest := crypto.SHA1
-	prefix := ".SIGN.RSA."
-	// melangeApkDigest := crypto.SHA256
-	// prefix := ".SIGN.RSA256."
+	melangeApkDigest := crypto.SHA256
+	prefix := ".SIGN.RSA256."
+	if digest, ok := os.LookupEnv("SIGNING_DIGEST"); ok {
+		switch digest {
+		case "SHA256":
+		case "SHA1":
+			melangeApkDigest = crypto.SHA1
+			prefix = ".SIGN.RSA."
+		default:
+			t.Fatalf("unsupported SIGNING_DIGEST")
+		}
+	}
 	if sigName != prefix+testPubkey {
 		t.Fatalf("unexpected signature name %s", sigName)
 	}


### PR DESCRIPTION
Switch to SHA2-256 signature by default for the `melange sign`
command.

Use the same runtime opt-out back to SHA1 signatures as apko.

With apko from:
- https://github.com/chainguard-dev/apko/pull/1440

This will use RSA256 signature type for both .apk & APKINDEX.tar.gz
signing.
