### PR TITLE
bump: double-quote bumped version strings, avoid trailing newline

### DIFF
--- a/pkg/renovate/bump/bump.go
+++ b/pkg/renovate/bump/bump.go
@@ -105,8 +105,8 @@ func New(ctx context.Context, opts ...Option) renovate.Renovator {
 			epochNode.Value = fmt.Sprintf("%d", epoch+1)
 		}
 
-		versionNode.Value = bcfg.TargetVersion
-		versionNode.Style = yaml.FlowStyle
+		versionNode.Value = strings.TrimSpace(bcfg.TargetVersion)
+		versionNode.Style = yaml.DoubleQuotedStyle
 		versionNode.Tag = "!!str"
 
 		rc.Vars[config.SubstitutionPackageVersion] = bcfg.TargetVersion

--- a/pkg/renovate/bump/bump_test.go
+++ b/pkg/renovate/bump/bump_test.go
@@ -24,9 +24,9 @@ func TestBump_versions(t *testing.T) {
 		newVersion      string
 		expectedVersion string
 	}{
-		{name: "float_issue.yaml", newVersion: "7.0.1", expectedVersion: "version: 7.0.1"},
-		{name: "quoted.yaml", newVersion: "7.0.1", expectedVersion: "version: 7.0.1"},
-		{name: "major_minor_patch.yaml", newVersion: "7.0.1", expectedVersion: "version: 7.0.1"},
+		{name: "float_issue.yaml", newVersion: "7.0.1", expectedVersion: `version: "7.0.1"`},
+		{name: "quoted.yaml", newVersion: "7.0.1", expectedVersion: `version: "7.0.1"`},
+		{name: "major_minor_patch.yaml", newVersion: "7.0.1", expectedVersion: `version: "7.0.1"`},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Before this change, `melange bump foo.yaml 1.2.3` would produce:

```
package:
  name: foo
  version: 1.2.3

  epoch: 0
```

Note the blank line, which would trip up on our `yam` config.

With this change, `melange bump foo.yaml 1.2.3` produces:

```
package:
  name: foo
  version: "1.2.3"
  epoch: 0
```

Which is functionally equivalent, without the trailing empty line.

I tried other styles, but none worked but this. I'm open to hearing better alternatives.