### PR TITLE
Fix numpy-test to work across python 3.12 to 3.13 transition.

### DIFF
--- a/e2e-tests/numpy-test.yaml
+++ b/e2e-tests/numpy-test.yaml
@@ -8,16 +8,7 @@ pipeline:
 
 # Test python/import, and python/test pipelines
 test:
-  environment:
-    # TODO(pnasrat): fix to use multiple python
-    contents:
-      packages:
-        - python-3.13
   pipeline:
-    # Test import with command (python -c "import numpy")
-    - uses: python/test
-      with:
-        command: python3.13 -c "import numpy"
     # Test import directly (python -c "import numpy")
     - uses: python/import
       with:


### PR DESCRIPTION
The test was failing because 'numpy' is now installing a python3.13 version.  Instead of making an assumption on what it installs, let the pipeline do the rigth thing.

The python/import pipeline will search for exactly one python installed and use it to test the import.
