### PR TITLE
go/build pipeline: Move `go mod tidy` after `cd` to `modroot` dir AND Validate existence of `go.mod` in `modroot`

### DIFF
--- a/pkg/build/pipelines/go/build.yaml
+++ b/pkg/build/pipelines/go/build.yaml
@@ -100,7 +100,7 @@ pipeline:
   - runs: |
       cd "${{inputs.modroot}}"
 
-      // check if modroot is set correctly by checking go.mod file exist
+      # check if modroot is set correctly by checking go.mod file exist
       if [ ! -e go.mod ]; then
         echo "go.mod not found in ${{inputs.modroot}}"
         exit 1

--- a/pkg/build/pipelines/go/build.yaml
+++ b/pkg/build/pipelines/go/build.yaml
@@ -98,16 +98,22 @@ inputs:
 
 pipeline:
   - runs: |
+      cd "${{inputs.modroot}}"
+
+      // check if modroot is set correctly by checking go.mod file exist
+      if [ ! -e go.mod ]; then
+        echo "go.mod not found in ${{inputs.modroot}}"
+        exit 1
+      fi
+
       "${{inputs.tidy}}" && go mod tidy
-      
+
       LDFLAGS="${{inputs.strip}} ${{inputs.ldflags}}"
 
       BASE_PATH="${{inputs.prefix}}/${{inputs.install-dir}}/${{inputs.output}}"
 
       # Take advantage of melange's buid cache for downloaded modules
       export GOMODCACHE=/var/cache/melange/gomodcache
-
-      cd "${{inputs.modroot}}"
 
       # Install any specified dependencies
       if [ ! "${{inputs.deps}}" == "" ]; then


### PR DESCRIPTION
- fix: Move `go mod tidy` after `cd` to `modroot` dir

  - Previously, in the `go/build` pipeline, if `modroot` was set and `tidy=true`, the `go mod tidy` command ran in the home directory instead of the `modroot` directory.
- feat: Validate existence of `go.mod` in `modroot`

  - Added a check to ensure `go.mod` exists in the `modroot` directory, ensuring `modroot` is set correctly. This will help the reliability of `go/bump` automation as it also set its modroot by looking into the `go/build` pipeline modroot.

> Notes: this will result in build failure of PR if there is any package where the modroot is set incorrectly.
