### PR TITLE
goreleaser: remove homebrew tap update

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -44,25 +44,6 @@ archives:
       - LICENSE
     wrap_in_directory: true
 
-brews:
-  - name: melange
-    repository:
-      owner: chainguard-dev
-      name: homebrew-tap
-      branch: main
-      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
-    url_template: "https://github.com/chainguard-dev/melange/releases/download/v{{ .Version }}/{{ .ArtifactName }}"
-    directory: Formula
-    commit_author:
-      name: guardian
-      email: guardian@chainguard.dev
-    homepage: "https://github.com/chainguard-dev/melange"
-    description: "Build apk packages using declarative pipelines"
-    install: |
-      bin.install "{{ .Binary }}" => "{{ .ProjectName }}"
-    test: |
-      system "#{bin}/{{ .ProjectName }}", "version"
-
 checksum:
   name_template: 'checksums.txt'
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ the form of OCI container images with [apko][apko].
 
 ## Installation
 
-You can install Melange from Homebrew:
+You can install [Melange](https://formulae.brew.sh/formula/melange) from [Homebrew](https://brew.sh/):
 
 ```shell
 brew install melange


### PR DESCRIPTION
remove the tap update as in readme it already specified to install from core tap

https://github.com/chainguard-dev/melange/blob/53a5317c401306df33ff23f353d5ee88bfae7e6b/README.md?plain=1#L31-L35

relates to https://github.com/chainguard-dev/homebrew-tap/pull/75