### PR TITLE
docker: add remote option

### DIFF
--- a/pkg/cli/test.go
+++ b/pkg/cli/test.go
@@ -49,6 +49,7 @@ func test() *cobra.Command {
 	var runner string
 	var extraTestPackages []string
 	var remove bool
+	var dockerRemote string
 
 	cmd := &cobra.Command{
 		Use:     "test",
@@ -58,7 +59,10 @@ func test() *cobra.Command {
 		Args:    cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
-			r, err := getRunner(ctx, runner, remove)
+			r, err := getRunner(ctx, runner, RunnerOptions{
+				BubblewrapRemove: remove,
+				DockerRemote:     dockerRemote,
+			})
 			if err != nil {
 				return err
 			}
@@ -132,6 +136,7 @@ func test() *cobra.Command {
 	cmd.Flags().StringSliceVarP(&extraRepos, "repository-append", "r", []string{}, "path to extra repositories to include in the build environment")
 	cmd.Flags().StringSliceVar(&extraTestPackages, "test-package-append", []string{}, "extra packages to install for each of the test environments")
 	cmd.Flags().BoolVar(&remove, "rm", true, "clean up intermediate artifacts (e.g. container images, temp dirs)")
+	cmd.Flags().StringVar(&dockerRemote, "docker-remote", "", "remote to use for docker images, if empty images are loaded to local docker socket")
 
 	return cmd
 }


### PR DESCRIPTION
## Melange Pull Request Template

<!--
*** PULL REQUEST CHECKLIST: PLEASE START HERE ***

The single most important feature of melange is that we can build Wolfi.

Many changes to melange introduce a risk of breaking the build, and sometimes
these are not flushed out until a package is changed (much) later.  This
pertains to basic execution, SCA changes, linter changes, and more.
-->

Adds an option to push apko bundle images to a remote registry. The intent here is to allow these images to be referenced by non-docker daemon OCI-compliant implementations (e.g. kubernetes pods).

### Functional Changes

- [x] This change can build all of Wolfi without errors (describe results in notes)

Notes:

### SCA Changes

- [ ] Examining several representative APKs show no regression / the desired effect (details in notes)

Notes:

### Linter

- [x] The new check is clean across Wolfi
- [ ] The new check is opt-in or a warning

Notes:
