### PR TITLE
add ca-certificates-bundle to cargo/build pipeline

### DIFF
--- a/pkg/build/pipelines/cargo/build.yaml
+++ b/pkg/build/pipelines/cargo/build.yaml
@@ -3,6 +3,7 @@ name: Compile an auditable rust binary with Cargo
 needs:
   packages:
     - build-base
+    - ca-certificates-bundle
     - busybox
     - cargo-auditable
     - rust


### PR DESCRIPTION
    add ca-certificates-bundle to cargo/build pipeline
    
    similar to our go/build pipeline, this commit adds
    ca-certificates-bundle to cargo/build pipeline.
    
    this is required because sometimes cargo cannot connect to github.com
    directly. In cases where cargo cannot connect to github.com, we get the
    following error message:
    
    Stderr: fatal: unable to access
    'https://github.com/the-mikedavis/tree-sitter-git-commit/': Failed to
    connect to github.com port 443 after 131793 ms: Could not connect to
    server
    
    this is happening because we don't have ca-certificates-bundle at
    build-time. Adding ca-certificates-bundle fixes the same.
    
    Signed-off-by: kranurag7 <81210977+kranurag7@users.noreply.github.com>

## Melange Pull Request Template

<!--
*** PULL REQUEST CHECKLIST: PLEASE START HERE ***

The single most important feature of melange is that we can build Wolfi.

Many changes to melange introduce a risk of breaking the build, and sometimes
these are not flushed out until a package is changed (much) later.  This
pertains to basic execution, SCA changes, linter changes, and more.
-->

### Functional Changes

- [x] This change can build all of Wolfi without errors (describe results in notes)

Notes:

### SCA Changes

- [ ] Examining several representative APKs show no regression / the desired effect (details in notes)

Notes:

### Linter

- [ ] The new check is clean across Wolfi
- [ ] The new check is opt-in or a warning

Notes:
