### PR TITLE
minor go cleanup and some performance improvements 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ GOLANGCI_LINT_BIN = $(GOLANGCI_LINT_DIR)/golangci-lint
 setup-golangci-lint:
 	rm -f $(GOLANGCI_LINT_BIN) || :
 	set -e ;
-	GOBIN=$(GOLANGCI_LINT_DIR) go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.59.0;
+	GOBIN=$(GOLANGCI_LINT_DIR) go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.63.4;
 
 .PHONY: fmt
 fmt: ## Format all go files

--- a/pkg/build/pipeline.go
+++ b/pkg/build/pipeline.go
@@ -23,7 +23,6 @@ import (
 	"os/signal"
 	"path"
 	"path/filepath"
-	"regexp"
 	"strconv"
 	"strings"
 
@@ -165,8 +164,13 @@ func validateWith(data map[string]string, inputs map[string]config.Input) (map[s
 }
 
 func matchValidShaChars(s string) bool {
-	match, _ := regexp.MatchString("^[a-fA-F0-9]+$", s)
-	return match
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if !(c >= '0' && c <= '9') && !(c >= 'a' && c <= 'f') && !(c >= 'A' && c <= 'F') {
+			return false
+		}
+	}
+	return true
 }
 
 // Build a script to run as part of evalRun

--- a/pkg/build/pipeline.go
+++ b/pkg/build/pipeline.go
@@ -150,7 +150,7 @@ func validateWith(data map[string]string, inputs map[string]config.Input) (map[s
 				}
 			case "expected-commit":
 				if !matchValidShaChars(data[k]) || len(data[k]) != 40 {
-					return data, fmt.Errorf("expected commit %q for pipeline contains invalid characters or invalid sha lengt", k)
+					return data, fmt.Errorf("expected commit %q for pipeline contains invalid characters or invalid sha length", k)
 				}
 			}
 		}

--- a/pkg/build/pipeline.go
+++ b/pkg/build/pipeline.go
@@ -149,7 +149,7 @@ func validateWith(data map[string]string, inputs map[string]config.Input) (map[s
 					return data, fmt.Errorf("checksum input %q for pipeline, invalid length", k)
 				}
 			case "expected-commit":
-				if !matchValidShaChars(data[k]) || len(data[k]) != 40 {
+				if !matchValidShaChars(data[k]) || len(data[k]) != expectedShaLength(k) {
 					return data, fmt.Errorf("expected commit %q for pipeline contains invalid characters or invalid sha length", k)
 				}
 			}

--- a/pkg/convert/relmon/release_monitoring.go
+++ b/pkg/convert/relmon/release_monitoring.go
@@ -41,7 +41,7 @@ type MonitorFinder struct {
 func (mf *MonitorFinder) FindMonitor(ctx context.Context, pkg string) (*Item, error) {
 	var items *Items
 	url := fmt.Sprintf(searchFmt, pkg)
-	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/http/http.go
+++ b/pkg/http/http.go
@@ -61,17 +61,12 @@ func (c *RLHTTPClient) GetArtifactSHA256(ctx context.Context, artifactURI string
 	}
 
 	defer resp.Body.Close()
-
 	if resp.StatusCode != http.StatusOK {
 		return "", fmt.Errorf("%d when getting %s", resp.StatusCode, artifactURI)
 	}
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return "", fmt.Errorf("reading body: %w", err)
-	}
-
 	h256 := sha256.New()
-	h256.Write(body)
+	if _, err := io.Copy(h256, resp.Body); err != nil {
+		return "", fmt.Errorf("hashing %s: %w", artifactURI, err)
+	}
 	return fmt.Sprintf("%x", h256.Sum(nil)), nil
 }

--- a/pkg/sbom/package_test.go
+++ b/pkg/sbom/package_test.go
@@ -1,0 +1,61 @@
+// Copyright 2024 Chainguard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package sbom
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_stringToIdentifier(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "basic_colon",
+			input:    "foo:bar",
+			expected: "foo-bar", // Colons replaced with dashes.
+		},
+		{
+			name:     "basic_slash",
+			input:    "foo/bar",
+			expected: "foo-bar", // Slashes replaced with dashes.
+		},
+		{
+			name:     "space_replacement",
+			input:    "foo bar",
+			expected: "fooC32bar", // Spaces encoded as Unicode prefix.
+		},
+		{
+			name:     "mixed_colon_and_slash",
+			input:    "foo:bar/baz",
+			expected: "foo-bar-baz", // Mixed colons and slashes replaced with dashes.
+		},
+		{
+			name:     "valid_characters_unchanged",
+			input:    "example-valid.123",
+			expected: "example-valid.123", // Valid characters remain unchanged.
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := stringToIdentifier(test.input)
+			require.Equal(t, test.expected, result, "unexpected result for input %q", test.input)
+		})
+	}
+}


### PR DESCRIPTION
Some minor improvements on sha validations 

sample benchmark code https://gist.github.com/ajayk/869fedfbcdb0a64444858c14de7c7a31

Results here 
```
goos: darwin
goarch: arm64
pkg: a.com
cpu: Apple M2 Pro
BenchmarkMatchValidShaCharsDynamic-12                  1             57416 ns/op
BenchmarkMatchValidShaCharsPrecompiled-12              1             12833 ns/op
BenchmarkMatchValidShaCharsManual-12                   1               625.0 ns/op
PASS
ok      a.com   0.233s
```