### PR TITLE
build: Write a GCC specs file into workspace

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -694,7 +694,9 @@ func (b *Build) populateWorkspace(ctx context.Context, src fs.FS) error {
 	if err := template.Must(specTemplate.Parse(gccLinkTemplate)).Execute(specFile, b); err != nil {
 		return err
 	}
-
+	if err := specFile.Close(); err != nil {
+		return err
+	}
 	return fs.WalkDir(src, ".", func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -691,8 +691,7 @@ func (b *Build) populateWorkspace(ctx context.Context, src fs.FS) error {
 		return err
 	}
 	specTemplate := template.New("gccSpecFile")
-	err = template.Must(specTemplate.Parse(gccLinkTemplate)).Execute(specFile, b)
-	if err != nil {
+	if err := template.Must(specTemplate.Parse(gccLinkTemplate)).Execute(specFile, b); err != nil {
 		return err
 	}
 

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -30,6 +30,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"text/template"
 	"time"
 
 	"chainguard.dev/apko/pkg/apk/apk"
@@ -74,6 +75,10 @@ echo "cleaning Workspace by removing $# file/directories in $d"
 rm -Rf "$@"`,
 	"shellEmptyDir",
 }
+
+var gccLinkTemplate = `*link:
++ --package-metadata={"type":"apk","os":"{{.Namespace}}","name":"{{.Configuration.Package.Name}}","version":"{{.Configuration.Package.FullVersion}}","architecture":"{{.Arch.ToAPK}}"}
+`
 
 var ErrSkipThisArch = errors.New("error: skip this arch")
 
@@ -674,6 +679,19 @@ func (b *Build) populateWorkspace(ctx context.Context, src fs.FS) error {
 	defer span.End()
 
 	ignorePatterns, err := b.loadIgnoreRules(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Write out build settings into workspacedir
+	// For now, just the gcc spec file and just link settings.
+	// In the future can control debug symbol generation, march/mtune, etc.
+	specFile, err := os.Create(filepath.Join(b.WorkspaceDir, ".melange.gcc.spec"))
+	if err != nil {
+		return err
+	}
+	specTemplate := template.New("gccSpecFile")
+	err = template.Must(specTemplate.Parse(gccLinkTemplate)).Execute(specFile, b)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Write out a GCC specs file into the workspace, that toolchain can
import to adjust build settings on per-package basis. For now, this
only adds Package Metadata ELF note settings.

In the future, this can be extended with other settings, for example
controlling generation of debug symbols, march/mtune/optimisations,
etc.

Potentially workspace is not a good location for this file. Maybe
worth considering to move this from /home/build/.melange.gcc.spec to
/etc/melange/gcc.spec.

By itself this PR is innert, until our default spec files start including the newly generated snippets when present. See:
- https://github.com/wolfi-dev/os/pull/39152

For the proposed usage of this change, which initially makes it opt-in for 3 packages to shake out any e2e integration.