### PR TITLE
Suggest adding the pkgconf test pipeline

### DIFF
--- a/pkg/sca/sca.go
+++ b/pkg/sca/sca.go
@@ -448,6 +448,10 @@ func generatePkgConfigDeps(ctx context.Context, hdl SCAHandle, generated *config
 		pcName := filepath.Base(path)
 		pcName, _ = strings.CutSuffix(pcName, ".pc")
 
+		if isInDir(path, []string{"usr/lib/pkgconfig/", "usr/lib64/pkgconfig/", "usr/share/pkgconfig/"}) {
+			log.Warnf("%s provides .pc files and could use a pkgconf test pipeline", hdl.PackageName())
+                }
+
 		if isInDir(path, []string{"usr/local/lib/pkgconfig/", "usr/local/share/pkgconfig/", "usr/lib/pkgconfig/", "usr/lib64/pkgconfig/", "usr/share/pkgconfig/"}) {
 			log.Infof("  found pkg-config %s for %s", pcName, path)
 			generated.Provides = append(generated.Provides, fmt.Sprintf("pc:%s=%s", pcName, hdl.Version()))


### PR DESCRIPTION
This adds a warning when building a package to let developers know that the package would benefit from a pkgconf test pipeline, however it isn't smart enough to know if the test already exists.  Here's an example run of it though:

```
2025/01/09 13:55:14 INFO scanning for pkg-config data...
2025/01/09 13:55:14 WARN yajl-dev provides .pc files and could use a pkgconf test pipeline
2025/01/09 13:55:14 INFO   found pkg-config yajl for usr/share/pkgconfig/yajl.pc
2025/01/09 13:55:14 INFO scanning for python modules...
```