### PR TITLE
sca: ignore symlinks when generating so deps

### DIFF
--- a/pkg/sca/sca.go
+++ b/pkg/sca/sca.go
@@ -264,7 +264,7 @@ func generateSharedObjectNameDeps(ctx context.Context, hdl SCAHandle, generated 
 		}
 
 		// If it is not a regular file, we are finished processing it.
-		if !mode.IsRegular() && !isLink {
+		if !mode.IsRegular() {
 			return nil
 		}
 


### PR DESCRIPTION
When processing a package that contains a symlink from, say, `/usr/bin/ps` to `/bin/ps`, we shouldn't chase that symlink to scan it for SO deps.

We should still chase `.so` symlinks that point to other `.so`s, just not file paths that we scan for ELF dependency metadata.

I'm not confident this is a correct change, so I'd love a really thorough review and ideas about how we should test this.