### PR TITLE
stop generation homebrew update as melange in in homebrew core

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -72,18 +72,9 @@ jobs:
           version: latest
           install-only: true
 
-      # Federate to create a token to authenticate with the homebrew-tap repository.
-      - uses: octo-sts/action@6177b4481c00308b3839969c3eca88c96a91775f # v1.0.0
-        if: steps.check.outputs.need_release == 'yes'
-        id: octo-sts
-        with:
-          scope: chainguard-dev/homebrew-tap
-          identity: melange
-
       - name: Release
         if: steps.check.outputs.need_release == 'yes'
         run: make release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HOMEBREW_TAP_GITHUB_TOKEN: ${{ steps.octo-sts.outputs.token }}
           TAG: ${{ steps.check.outputs.existing_tag || steps.create_tag.outputs.new_tag }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -44,25 +44,6 @@ archives:
       - LICENSE
     wrap_in_directory: true
 
-brews:
-  - name: melange
-    repository:
-      owner: chainguard-dev
-      name: homebrew-tap
-      branch: main
-      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
-    url_template: "https://github.com/chainguard-dev/melange/releases/download/v{{ .Version }}/{{ .ArtifactName }}"
-    directory: Formula
-    commit_author:
-      name: guardian
-      email: guardian@chainguard.dev
-    homepage: "https://github.com/chainguard-dev/melange"
-    description: "Build apk packages using declarative pipelines"
-    install: |
-      bin.install "{{ .Binary }}" => "{{ .ProjectName }}"
-    test: |
-      system "#{bin}/{{ .ProjectName }}", "version"
-
 checksum:
   name_template: 'checksums.txt'
 


### PR DESCRIPTION
melange homebrew is in homebrew core now, so we dont need to generate the update script to our hosted tap

https://github.com/Homebrew/homebrew-core/blob/master/Formula/m/melange.rb


this cleans up our side a bit.
will remove the sts policy as soon this PR is approved and merged