### PR TITLE
fix(test env): ensure build user in environment

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1358,6 +1358,16 @@ func ParseConfiguration(_ context.Context, configurationFilePath string, opts ..
 		Members:   []string{"build"},
 	}
 	cfg.Environment.Accounts.Groups = append(cfg.Environment.Accounts.Groups, grp)
+	if cfg.Test != nil {
+		cfg.Test.Environment.Accounts.Groups = append(cfg.Test.Environment.Accounts.Groups, grp)
+	}
+	for i := range cfg.Subpackages {
+		sub := &cfg.Subpackages[i]
+		if sub.Test == nil || len(sub.Test.Pipeline) == 0 {
+			continue
+		}
+		sub.Test.Environment.Accounts.Groups = append(sub.Test.Environment.Accounts.Groups, grp)
+	}
 
 	gid1000 := uint32(1000)
 	usr := apko_types.User{
@@ -1366,6 +1376,16 @@ func ParseConfiguration(_ context.Context, configurationFilePath string, opts ..
 		GID:      apko_types.GID(&gid1000),
 	}
 	cfg.Environment.Accounts.Users = append(cfg.Environment.Accounts.Users, usr)
+	if cfg.Test != nil {
+		cfg.Test.Environment.Accounts.Users = append(cfg.Test.Environment.Accounts.Users, usr)
+	}
+	for i := range cfg.Subpackages {
+		sub := &cfg.Subpackages[i]
+		if sub.Test == nil || len(sub.Test.Pipeline) == 0 {
+			continue
+		}
+		sub.Test.Environment.Accounts.Users = append(sub.Test.Environment.Accounts.Users, usr)
+	}
 
 	// Merge environment file if needed.
 	if envFile := options.envFilePath; envFile != "" {


### PR DESCRIPTION
The Test pipeline environment does not get a build user included by default; this causes test pipelines to fail when the qemu runner is used because the initial connection attempt to get the host public key always uses the build user to connect. Fix this by adding the build user to all Test environments, both the primary pipeline and any subpipelines.

Fixes: https://github.com/chainguard-dev/melange/issues/1732

## Melange Pull Request Template

<!--
*** PULL REQUEST CHECKLIST: PLEASE START HERE ***

The single most important feature of melange is that we can build Wolfi.

Many changes to melange introduce a risk of breaking the build, and sometimes
these are not flushed out until a package is changed (much) later.  This
pertains to basic execution, SCA changes, linter changes, and more.
-->

### Functional Changes

- [ ] This change can build all of Wolfi without errors (describe results in notes)

Notes:

### SCA Changes

- [ ] Examining several representative APKs show no regression / the desired effect (details in notes)

Notes:

### Linter

- [ ] The new check is clean across Wolfi
- [ ] The new check is opt-in or a warning

Notes:
