### PR TITLE
Add build user to test pipeline environments

### DIFF
--- a/pkg/build/test_test.go
+++ b/pkg/build/test_test.go
@@ -39,6 +39,25 @@ const (
 	homeBuild        = "/home/build"
 )
 
+var (
+	gid1000 = uint32(1000)
+)
+
+func defaultEnv(opts ...func(*apko_types.ImageConfiguration)) apko_types.ImageConfiguration {
+	env := apko_types.ImageConfiguration{
+		Accounts: types.ImageAccounts{
+			Groups: []types.Group{{GroupName: "build", GID: 1000, Members: []string{"build"}}},
+			Users:  []apko_types.User{{UserName: "build", UID: 1000, GID: &gid1000}},
+		},
+	}
+
+	for _, opt := range opts {
+		opt(&env)
+	}
+
+	return env
+}
+
 func TestBuildWorkspaceConfig(t *testing.T) {
 	tmpDir := t.TempDir()
 	// realpath is used to get the real path of the temp dir
@@ -151,6 +170,7 @@ func TestConfigurationLoad(t *testing.T) {
 					Resources: &config.Resources{},
 				},
 				Test: &config.Test{
+					Environment: defaultEnv(),
 					Pipeline: []config.Pipeline{
 						{
 							Name: "hello",
@@ -161,6 +181,7 @@ func TestConfigurationLoad(t *testing.T) {
 				Subpackages: []config.Subpackage{{
 					Name: "cats",
 					Test: &config.Test{
+						Environment: defaultEnv(),
 						Pipeline: []config.Pipeline{{
 							Runs: "cats are angry",
 						}},
@@ -168,6 +189,7 @@ func TestConfigurationLoad(t *testing.T) {
 				}, {
 					Name: "dogs",
 					Test: &config.Test{
+						Environment: defaultEnv(),
 						Pipeline: []config.Pipeline{{
 							Runs: "dogs are loyal",
 						}},
@@ -175,6 +197,7 @@ func TestConfigurationLoad(t *testing.T) {
 				}, {
 					Name: "turtles",
 					Test: &config.Test{
+						Environment: defaultEnv(),
 						Pipeline: []config.Pipeline{{
 							Runs: "turtles are slow",
 						}},
@@ -182,6 +205,7 @@ func TestConfigurationLoad(t *testing.T) {
 				}, {
 					Name: "donatello",
 					Test: &config.Test{
+						Environment: defaultEnv(),
 						Pipeline: []config.Pipeline{
 							{
 								Runs: "donatello's color is purple",
@@ -194,46 +218,54 @@ func TestConfigurationLoad(t *testing.T) {
 					},
 				}, {
 					Name: "leonardo",
-					Test: &config.Test{Pipeline: []config.Pipeline{
-						{
-							Runs: "leonardo's color is blue",
-						},
-						{
-							Uses: "go/build",
-							With: map[string]string{"packages": "blue"},
-						},
-					}},
+					Test: &config.Test{
+						Environment: defaultEnv(),
+						Pipeline: []config.Pipeline{
+							{
+								Runs: "leonardo's color is blue",
+							},
+							{
+								Uses: "go/build",
+								With: map[string]string{"packages": "blue"},
+							},
+						}},
 				}, {
 					Name: "michelangelo",
-					Test: &config.Test{Pipeline: []config.Pipeline{
-						{
-							Runs: "michelangelo's color is orange",
-						},
-						{
-							Uses: "go/build",
-							With: map[string]string{"packages": "orange"},
-						},
-					}},
+					Test: &config.Test{
+						Environment: defaultEnv(),
+						Pipeline: []config.Pipeline{
+							{
+								Runs: "michelangelo's color is orange",
+							},
+							{
+								Uses: "go/build",
+								With: map[string]string{"packages": "orange"},
+							},
+						}},
 				}, {
 					Name: "raphael",
-					Test: &config.Test{Pipeline: []config.Pipeline{
-						{
-							Runs: "raphael's color is red",
-						},
-						{
-							Uses: "go/build",
-							With: map[string]string{"packages": "red"},
-						},
-					}},
+					Test: &config.Test{
+						Environment: defaultEnv(),
+						Pipeline: []config.Pipeline{
+							{
+								Runs: "raphael's color is red",
+							},
+							{
+								Uses: "go/build",
+								With: map[string]string{"packages": "red"},
+							},
+						}},
 				}, {
 					Name: "simple",
-					Test: &config.Test{Pipeline: []config.Pipeline{
-						{
-							Runs: "simple-runs",
-						}, {
-							Uses: "simple-uses",
-						},
-					}},
+					Test: &config.Test{
+						Environment: defaultEnv(),
+						Pipeline: []config.Pipeline{
+							{
+								Runs: "simple-runs",
+							}, {
+								Uses: "simple-uses",
+							},
+						}},
 				}},
 			},
 		}, {
@@ -246,11 +278,9 @@ func TestConfigurationLoad(t *testing.T) {
 					Resources: &config.Resources{},
 				},
 				Test: &config.Test{
-					Environment: types.ImageConfiguration{
-						Contents: types.ImageContents{
-							Packages: []string{"busybox", "python-3"},
-						},
-					},
+					Environment: defaultEnv(func(env *apko_types.ImageConfiguration) {
+						env.Contents.Packages = []string{"busybox", "python-3"}
+					}),
 					Pipeline: []config.Pipeline{
 						{
 							Runs: "python3 ./py3-pandas-test.py\n",

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1358,6 +1358,16 @@ func ParseConfiguration(_ context.Context, configurationFilePath string, opts ..
 		Members:   []string{"build"},
 	}
 	cfg.Environment.Accounts.Groups = append(cfg.Environment.Accounts.Groups, grp)
+	if cfg.Test != nil {
+		cfg.Test.Environment.Accounts.Groups = append(cfg.Test.Environment.Accounts.Groups, grp)
+	}
+	for i := range cfg.Subpackages {
+		sub := &cfg.Subpackages[i]
+		if sub.Test == nil || len(sub.Test.Pipeline) == 0 {
+			continue
+		}
+		sub.Test.Environment.Accounts.Groups = append(sub.Test.Environment.Accounts.Groups, grp)
+	}
 
 	gid1000 := uint32(1000)
 	usr := apko_types.User{
@@ -1366,6 +1376,16 @@ func ParseConfiguration(_ context.Context, configurationFilePath string, opts ..
 		GID:      apko_types.GID(&gid1000),
 	}
 	cfg.Environment.Accounts.Users = append(cfg.Environment.Accounts.Users, usr)
+	if cfg.Test != nil {
+		cfg.Test.Environment.Accounts.Users = append(cfg.Test.Environment.Accounts.Users, usr)
+	}
+	for i := range cfg.Subpackages {
+		sub := &cfg.Subpackages[i]
+		if sub.Test == nil || len(sub.Test.Pipeline) == 0 {
+			continue
+		}
+		sub.Test.Environment.Accounts.Users = append(sub.Test.Environment.Accounts.Users, usr)
+	}
 
 	// Merge environment file if needed.
 	if envFile := options.envFilePath; envFile != "" {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1361,8 +1361,7 @@ func ParseConfiguration(_ context.Context, configurationFilePath string, opts ..
 	if cfg.Test != nil {
 		cfg.Test.Environment.Accounts.Groups = append(cfg.Test.Environment.Accounts.Groups, grp)
 	}
-	for i := range cfg.Subpackages {
-		sub := &cfg.Subpackages[i]
+	for _, sub := range cfg.Subpackages {
 		if sub.Test == nil || len(sub.Test.Pipeline) == 0 {
 			continue
 		}
@@ -1379,8 +1378,7 @@ func ParseConfiguration(_ context.Context, configurationFilePath string, opts ..
 	if cfg.Test != nil {
 		cfg.Test.Environment.Accounts.Users = append(cfg.Test.Environment.Accounts.Users, usr)
 	}
-	for i := range cfg.Subpackages {
-		sub := &cfg.Subpackages[i]
+	for _, sub := range cfg.Subpackages {
 		if sub.Test == nil || len(sub.Test.Pipeline) == 0 {
 			continue
 		}


### PR DESCRIPTION
### Functional Changes

This change adds the build user as a default to the Test pipeline environments; without this change the qemu runner does not successfully make its ssh initial connection to the qemu microvm to get the VM's host ssh public key; see https://github.com/chainguard-dev/melange/issues/1732 which this PR is intended to resolve.

It changes the emitted apko config for test pipelines to include:

```yaml
   accounts:
     runas:  
     users:
       - uid=1000(build) gid=824637199472
     groups:
       - gid=1000(build) members=[build]
```

Fixes #1732

- [ ] This change can build all of Wolfi without errors (describe results in notes)

Notes:

I have not rebuilt the world with this, but attempts to rebuild and run the test pipelines random packages (systemd, openjdk, and some others) in a variety of runners with this change have not shown breakage. 