### PR TITLE
sign: drop support for creating SHA-1 signatures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,8 +128,8 @@ fmt: ## Format all go files
 checkfmt: SHELL := /usr/bin/env bash
 checkfmt: ## Check formatting of all go files
 	@ $(MAKE) --no-print-directory log-$@
- 	$(shell test -z "$(shell gofmt -l $(GOFILES) | tee /dev/stderr)")
- 	$(shell test -z "$(shell goimports -l $(GOFILES) | tee /dev/stderr)")
+	$(shell test -z "$(shell gofmt -l $(GOFILES) | tee /dev/stderr)")
+	$(shell test -z "$(shell goimports -l $(GOFILES) | tee /dev/stderr)")
 
 log-%:
 	@grep -h -E '^$*:.*?## .*$$' $(MAKEFILE_LIST) | \
@@ -148,12 +148,10 @@ lint: checkfmt setup-golangci-lint ## Run linters and checks like golangci-lint
 .PHONY: unit
 unit:
 	go test ./... -race
-	SIGNING_DIGEST=SHA1 go test ./... -race
 
 .PHONY: integration
 integration:
 	go test ./... -race -tags=integration
-	SIGNING_DIGEST=SHA1 go test ./... -race -tags=integration
 
 .PHONY: test
 test: integration

--- a/pkg/sign/apk_test.go
+++ b/pkg/sign/apk_test.go
@@ -54,22 +54,10 @@ func TestAPK(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	melangeApkDigest := crypto.SHA256
-	prefix := ".SIGN.RSA256."
-	if digest, ok := os.LookupEnv("SIGNING_DIGEST"); ok {
-		switch digest {
-		case "SHA256":
-		case "SHA1":
-			melangeApkDigest = crypto.SHA1
-			prefix = ".SIGN.RSA."
-		default:
-			t.Fatalf("unsupported SIGNING_DIGEST")
-		}
-	}
-	if sigName != prefix+testPubkey {
+	if sigName != ".SIGN.RSA256."+testPubkey {
 		t.Fatalf("unexpected signature name %s", sigName)
 	}
-	digest, err := signature.HashData(controlData, melangeApkDigest)
+	digest, err := signature.HashData(controlData, crypto.SHA256)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -77,7 +65,7 @@ func TestAPK(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := signature.RSAVerifyDigest(digest, melangeApkDigest, sig, pubKey); err != nil {
+	if err := signature.RSAVerifyDigest(digest, crypto.SHA256, sig, pubKey); err != nil {
 		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
This removes support for creating SHA-1 signatures via melange.

Similar removal is done in apko at:
- https://github.com/chainguard-dev/apko/pull/1496