### PR TITLE
sbom: switch SPDX namespace from SHA1 to FNV-1a

### DIFF
--- a/pkg/build/testdata/goldenfiles/sboms/7zip-two-fetches-2301-r3.spdx.json
+++ b/pkg/build/testdata/goldenfiles/sboms/7zip-two-fetches-2301-r3.spdx.json
@@ -11,7 +11,7 @@
     "licenseListVersion": "3.22"
   },
   "dataLicense": "CC0-1.0",
-  "documentNamespace": "https://spdx.org/spdxdocs/chainguard/melange/aac0a1c9478955b98366443d654718707b4c3a03",
+  "documentNamespace": "https://spdx.org/spdxdocs/chainguard/melange/35a84e53c8a7af192be547e9f8c6eac6",
   "documentDescribes": [
     "SPDXRef-Package-7zip-two-fetches-2301-r3"
   ],

--- a/pkg/build/testdata/goldenfiles/sboms/crane-0.20.2-r1.spdx.json
+++ b/pkg/build/testdata/goldenfiles/sboms/crane-0.20.2-r1.spdx.json
@@ -11,7 +11,7 @@
     "licenseListVersion": "3.22"
   },
   "dataLicense": "CC0-1.0",
-  "documentNamespace": "https://spdx.org/spdxdocs/chainguard/melange/f5eb3a5b5887866fa76fe4eb2b7b5165f07c9505",
+  "documentNamespace": "https://spdx.org/spdxdocs/chainguard/melange/be3c22f08feabeabd0f5c9cc9677dafc",
   "documentDescribes": [
     "SPDXRef-Package-crane-0.20.2-r1"
   ],

--- a/pkg/sbom/document.go
+++ b/pkg/sbom/document.go
@@ -2,9 +2,9 @@ package sbom
 
 import (
 	"context"
-	"crypto/sha1"
 	"encoding/hex"
 	"fmt"
+	"hash/fnv"
 	"time"
 
 	"chainguard.dev/apko/pkg/sbom/generator/spdx"
@@ -85,7 +85,7 @@ func (d Document) getSPDXName() string {
 }
 
 func (d Document) getSPDXNamespace() string {
-	h := sha1.New()
+	h := fnv.New128a()
 	h.Write([]byte(fmt.Sprintf("apk-%s-%s", d.Describes.Namespace, d.Describes.Version)))
 	hexHash := hex.EncodeToString(h.Sum(nil))
 


### PR DESCRIPTION
**sbom: switch SPDX namespace from SHA1 to FNV-1a**

Similar in design choice to https://github.com/golang/go/commit/092d18b31824d35a07f796c90380d5e607b61681 switch SPDX namespace calculation from a broken security hash to a non-cryptographic [FNV-1a](https://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function) hash.
  
This helps to completely remove SHA1 usage in melange.

If we want to preserve the same IDs we should consider switching from crypto/sha1 to github.com/pjbgf/sha1cd, which is not registered with the crypto framework.

The difference is that SPDX namespace URI will be different in length:
- https://spdx.org/spdxdocs/chainguard/melange/29949ae152def3411439e863d8039ac59c083862
- https://spdx.org/spdxdocs/chainguard/melange/635ba484b06e356eb6c8e67e49e70dcb
  
It is still calculated based on the same formula, which produces the same namespace for unrelated packages which happen to have identical full version number, from the same package repository.