### PR TITLE
feat: store --namespace as APK maintainer field

### DIFF
--- a/pkg/build/package.go
+++ b/pkg/build/package.go
@@ -154,6 +154,9 @@ origin = {{.OriginName}}
 pkgdesc = {{.Description}}
 url = {{.URL}}
 commit = {{.Commit}}
+{{- if .Build.Namespace }}
+maintainer = {{.Build.Namespace}}
+{{- end }}
 {{- if ne .Build.SourceDateEpoch.Unix 0 }}
 builddate = {{ .Build.SourceDateEpoch.Unix }}
 {{- end}}

--- a/pkg/build/package_test.go
+++ b/pkg/build/package_test.go
@@ -70,6 +70,7 @@ func Test_GenerateControlData(t *testing.T) {
 		pb: &PackageBuild{
 			Build: &Build{
 				SourceDateEpoch: time.Unix(0, 0),
+				Namespace:       "wolfi",
 			},
 			Origin:        pkg,
 			PackageName:   "glibc",
@@ -90,6 +91,7 @@ origin = bigbang
 pkgdesc = I'm a unit test
 url = https://chainguard.dev
 commit = deadbeef
+maintainer = wolfi
 datahash = baadf00d
 `,
 	}, {


### PR DESCRIPTION
Recently, we ran into an issue where `trivy` was incorrectly reporting vulnerabilities in a package/image we built via `melange`/`apko`. Upon further investigation, this issue was occurring because we were building a package with the same name and similar versioning as an existing Wolfi/Chainguard package. As a result, `trivy` was incorrectly matching the package name from Wolfi's [security.json](https://packages.wolfi.dev/os/security.json) against this internal package and subsequently reporting vulnerabilities.

We looked into "fixing" [trivy's APK package logic](https://github.com/aquasecurity/trivy/blob/011012a8b4d8add049140b3996239a8358fd4202/pkg/fanal/analyzer/pkg/apk/apk.go#L76-L77) to only extract APK packages that were installed from the Wolfi repository, however we discovered that `/lib/apk/db/installed` doesn't actually contain enough information to make this determination.

This PR attempts to improve this situation in the future by passing along the `--namespace` build parameter (which is already embedded in the generated SBOM for each package) as the `maintainer` field for each APK package as well. This information will eventually get included via the `m:` field in `/lib/apk/db/installed` when the APK package is installed via `apk-tools` or `apko`.

A future change to `trivy` or other vulnerability scanners could be made to only extract the packages that either don't have a `maintainer` field (for backwards compatibility), or have a value of `wolfi` (or `chainguard`) only. 

Arguably the `packager` field would be a more appropriate location for this value however that field does not end up in `/lib/apk/db/installed`, only a subset of fields are stored there: https://gitlab.alpinelinux.org/alpine/apk-tools/-/blob/master/src/package.c?ref_type=heads#L880