### PR TITLE
patch: add --verbose flag to patch pipeline

### DIFF
--- a/pkg/build/pipelines/patch.yaml
+++ b/pkg/build/pipelines/patch.yaml
@@ -33,5 +33,5 @@ pipeline:
       fi
 
       grep -v -E '^(#|$)' $series | (while read patchfile; do
-        patch '-p${{inputs.strip-components}}' < $patchfile
+        patch '-p${{inputs.strip-components}}' --verbose < $patchfile
       done)


### PR DESCRIPTION
## Melange Pull Request Template



### Functional Changes

- This PR adds the flag `--verbose` to the patch command. Nowadays it is a bit hard to debug any issues whenever a patch pipeline fails, e.g. `Hunk #1 FAILED at 14`.  Those errors are cryptic and sometimes even misleading to what is the root cause. As a consequence I decided to propose to use the `--verbose` flag by default so anyone could get additional information whenever a patch fails on our packages.

Notes:

This is the output of a `--verbose` flag set for and a successful execution:
```
2025/01/27 15:47:21 INFO | uses=patch
2025/01/27 15:47:21 INFO |diff --git a/frontend/server/package.json b/frontend/server/package.json uses=patch
2025/01/27 15:47:21 INFO |index 8395b2c49..8b21a4eb1 100644 uses=patch
2025/01/27 15:47:21 INFO |--- a/frontend/server/package.json uses=patch
2025/01/27 15:47:21 INFO |+++ b/frontend/server/package.json uses=patch
2025/01/27 15:47:21 INFO -------------------------- uses=patch
2025/01/27 15:47:21 INFO patching file frontend/server/package.json uses=patch
```

and a successful output without `--verbose` flag:
```
2025/01/24 14:08:28 INFO running step "patch"
2025/01/24 14:08:28 INFO patching file frontend/server/package.json
```
