### PR TITLE
Add ${{subpkg.name}} string substitution

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ Melange provides the following default substitutions which can be referenced in 
 | `${{package.full-version}}` | `${{package.version}}-r${{package.epoch}}`                               |
 | `${{package.description}}`  | Package description                                                      |
 | `${{package.srcdir}}`       | Package source directory (`--source-dir`)                                |
+| `${{subpkg.name}}`          | Subpackage name                                                          |
 | `${{targets.outdir}}`       | Directory where targets will be stored                                   |
 | `${{targets.contextdir}}`   | Directory where targets will be stored for main packages and subpackages |
 | `${{targets.destdir}}`      | Directory where targets will be stored for main                          |

--- a/pkg/build/pipeline.go
+++ b/pkg/build/pipeline.go
@@ -67,6 +67,7 @@ type SubstitutionMap struct {
 
 func (sm *SubstitutionMap) Subpackage(subpkg *config.Subpackage) *SubstitutionMap {
 	nw := maps.Clone(sm.Substitutions)
+	nw[config.SubstitutionSubPkgName] = subpkg.Name
 	nw[config.SubstitutionSubPkgDir] = fmt.Sprintf("/home/build/melange-out/%s", subpkg.Name)
 	nw[config.SubstitutionTargetsContextdir] = nw[config.SubstitutionSubPkgDir]
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -59,6 +59,9 @@ subpackages:
         - subpackage-bar=${{vars.bar}}
       replaces:
         - james=${{package.name}}
+    test:
+      pipeline:
+        - runs: echo "${{subpkg.name}} test case"
 
 test:
   environment:

--- a/pkg/config/vars.go
+++ b/pkg/config/vars.go
@@ -31,6 +31,7 @@ const (
 	SubstitutionTargetsOutdir         = "${{targets.outdir}}"
 	SubstitutionTargetsDestdir        = "${{targets.destdir}}"
 	SubstitutionTargetsContextdir     = "${{targets.contextdir}}"
+	SubstitutionSubPkgName            = "${{subpkg.name}}"
 	SubstitutionSubPkgDir             = "${{targets.subpkgdir}}"
 	SubstitutionHostTripletGnu        = "${{host.triplet.gnu}}"
 	SubstitutionHostTripletRust       = "${{host.triplet.rust}}"


### PR DESCRIPTION
I've noticed a growing pattern of using `$(basename ${{targets.contextdir}})` in our YAML to calculate the subpackage name. This only works when the string is processed by a shell, and is really just a hack anyway. Let's introduce a formal substitution.
