### PR TITLE
support install-if

### DIFF
--- a/pkg/build/package.go
+++ b/pkg/build/package.go
@@ -160,6 +160,9 @@ builddate = {{ .Build.SourceDateEpoch.Unix }}
 {{- range $copyright := .Origin.Copyright }}
 license = {{ $copyright.License }}
 {{- end }}
+{{- if ne .Dependencies.InstallIf "" }}
+install_if = {{.Dependencies.InstallIf}}
+{{- end }}
 {{- range $dep := .Dependencies.Runtime }}
 depend = {{ $dep }}
 {{- end }}
@@ -351,6 +354,8 @@ func (pc *PackageBuild) GenerateDependencies(ctx context.Context, hdl sca.SCAHan
 
 	// Sets .PKGINFO `# vendored = ...` comments; does not affect resolution.
 	pc.Dependencies.Vendored = slices.Compact(slices.Sorted(slices.Values(generated.Vendored)))
+
+	pc.Dependencies.InstallIf = generated.InstallIf
 
 	pc.Dependencies.Summarize(ctx)
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -29,6 +29,7 @@ package:
       - replacement-provides-foo=${{vars.foo}}
       - replacement-provides-bar=${{vars.bar}}
       - replacement-provides=${{package.full-version}}
+    install-if: docs something=${{package.full-version}}
 
 environment:
   contents:
@@ -75,6 +76,8 @@ test:
 	if err != nil {
 		t.Fatalf("failed to parse configuration: %s", err)
 	}
+	require.Equal(t, "docs something=0.0.1-r7", cfg.Package.Dependencies.InstallIf)
+
 	require.Equal(t, []string{
 		"replacement-provides-version=0.0.1",
 		"replacement-provides-foo=FOO",


### PR DESCRIPTION
APK has a facility for expressing "if X and Y (and Z=1.2.3-r4 and W>=4) are installed, install me too", which we don't take advantage of in melange or apko.

This is the melange part. Setting to draft while I figure out what we have to do with apko.