### PR TITLE
sbom: update copyrightText from "/n" to "NOASSERTION"

### DIFF
--- a/pkg/build/testdata/goldenfiles/sboms/7zip-two-fetches-2301-r3.spdx.json
+++ b/pkg/build/testdata/goldenfiles/sboms/7zip-two-fetches-2301-r3.spdx.json
@@ -26,7 +26,7 @@
       "downloadLocation": "NOASSERTION",
       "originator": "Organization: Wolfi",
       "supplier": "Organization: Wolfi",
-      "copyrightText": "\n",
+      "copyrightText": "NOASSERTION",
       "externalRefs": [
         {
           "referenceCategory": "PACKAGE-MANAGER",

--- a/pkg/build/testdata/goldenfiles/sboms/crane-0.20.2-r1.spdx.json
+++ b/pkg/build/testdata/goldenfiles/sboms/crane-0.20.2-r1.spdx.json
@@ -26,7 +26,7 @@
       "downloadLocation": "NOASSERTION",
       "originator": "Organization: Wolfi",
       "supplier": "Organization: Wolfi",
-      "copyrightText": "\n",
+      "copyrightText": "NOASSERTION",
       "externalRefs": [
         {
           "referenceCategory": "PACKAGE-MANAGER",

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -345,7 +345,16 @@ func (p Package) LicensingInfos(WorkspaceDir string) (map[string]string, error) 
 func (p Package) FullCopyright() string {
 	copyright := ""
 	for _, cp := range p.Copyright {
-		copyright += cp.Attestation + "\n"
+		if cp.Attestation != "" {
+			copyright += cp.Attestation + "\n"
+		}
+	}
+	// No copyright found, instead of ommitting the field declare
+	// that no determination was attempted, which is better than a
+	// whitespace (which should also be interpreted as
+	// NOASSERTION)
+	if copyright == "" {
+		copyright = "NOASSERTION"
 	}
 	return copyright
 }


### PR DESCRIPTION
There is logic bug interating all the copyright stanzas which always
appened a single "/n" into the copyrightText field of the SBOM
package.

The SPDX spec says that empty or whistespace only value should be
treated same as "NOASSERTION" when no determination was possible to
reach, or it was not attempted, or intentionally is not being
provided. However it is better to use "NOASSERTION" value to convey
this more exactly precise meaning.

See:
- https://spdx.github.io/spdx-spec/v2.3/package-information/#717-copyright-text-field
- https://spdx.github.io/spdx-spec/v3.0.1/model/Software/Properties/copyrightText/

Fixes: https://github.com/chainguard-dev/internal-dev/issues/8822
