### PR TITLE
feat: build config can specify package CPE

### DIFF
--- a/pkg/build/package.go
+++ b/pkg/build/package.go
@@ -78,6 +78,7 @@ type PackageBuild struct {
 	Description   string
 	URL           string
 	Commit        string
+	CPE           string
 }
 
 func pkgFromSub(sub *config.Subpackage) *config.Package {
@@ -93,6 +94,13 @@ func pkgFromSub(sub *config.Subpackage) *config.Package {
 }
 
 func (b *Build) Emit(ctx context.Context, pkg *config.Package) error {
+	log := clog.FromContext(ctx)
+
+	renderedCPE, err := pkg.CPEString()
+	if err != nil {
+		log.Infof("unable to generate CPE string for package %s: %v", pkg.Name, err)
+	}
+
 	pc := PackageBuild{
 		Build:        b,
 		Origin:       &b.Configuration.Package,
@@ -106,6 +114,7 @@ func (b *Build) Emit(ctx context.Context, pkg *config.Package) error {
 		Description:  pkg.Description,
 		URL:          pkg.URL,
 		Commit:       pkg.Commit,
+		CPE:          renderedCPE,
 	}
 
 	if !b.StripOriginName {
@@ -181,6 +190,9 @@ replaces_priority = {{ .Dependencies.ReplacesPriority }}
 {{- if .Scriptlets}}{{ if .Scriptlets.Trigger.Paths }}
 triggers = {{ range $item := .Scriptlets.Trigger.Paths }}{{ $item }} {{ end }}
 {{- end }}{{ end }}
+{{- if .CPE }}
+# cpe = {{ .CPE }}
+{{- end }}
 datahash = {{.DataHash}}
 `
 

--- a/pkg/build/package.go
+++ b/pkg/build/package.go
@@ -78,7 +78,6 @@ type PackageBuild struct {
 	Description   string
 	URL           string
 	Commit        string
-	CPE           string
 }
 
 func pkgFromSub(sub *config.Subpackage) *config.Package {
@@ -94,13 +93,6 @@ func pkgFromSub(sub *config.Subpackage) *config.Package {
 }
 
 func (b *Build) Emit(ctx context.Context, pkg *config.Package) error {
-	log := clog.FromContext(ctx)
-
-	renderedCPE, err := pkg.CPEString()
-	if err != nil {
-		log.Infof("unable to generate CPE string for package %s: %v", pkg.Name, err)
-	}
-
 	pc := PackageBuild{
 		Build:        b,
 		Origin:       &b.Configuration.Package,
@@ -114,7 +106,6 @@ func (b *Build) Emit(ctx context.Context, pkg *config.Package) error {
 		Description:  pkg.Description,
 		URL:          pkg.URL,
 		Commit:       pkg.Commit,
-		CPE:          renderedCPE,
 	}
 
 	if !b.StripOriginName {
@@ -190,9 +181,6 @@ replaces_priority = {{ .Dependencies.ReplacesPriority }}
 {{- if .Scriptlets}}{{ if .Scriptlets.Trigger.Paths }}
 triggers = {{ range $item := .Scriptlets.Trigger.Paths }}{{ $item }} {{ end }}
 {{- end }}{{ end }}
-{{- if .CPE }}
-# cpe = {{ .CPE }}
-{{- end }}
 datahash = {{.DataHash}}
 `
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -132,11 +132,32 @@ type Package struct {
 	Resources *Resources `json:"resources,omitempty" yaml:"resources,omitempty"`
 }
 
+// CPE stores values used to produce a CPE to describe the package, suitable for
+// matching against NVD records.
+//
+// For Melange, the "part" attribute should always be interpreted as "a" (for
+// "application").
+type CPE struct {
+	Vendor  string
+	Product string
+}
+
 type Resources struct {
 	CPU      string `json:"cpu,omitempty" yaml:"cpu,omitempty"`
 	CPUModel string `json:"cpumodel,omitempty" yaml:"cpumodel,omitempty"`
 	Memory   string `json:"memory,omitempty" yaml:"memory,omitempty"`
 	Disk     string `json:"disk,omitempty" yaml:"disk,omitempty"`
+}
+
+// CPEString returns the CPE string for the package, suitable for matching
+// against NVD records.
+func (p Package) CPEString() string {
+	return fmt.Sprintf(
+		"cpe:2.3:a:%s:%s:%s:*:*:*:*:*:*:*:*",
+		p.CPE.Vendor,
+		p.CPE.Product,
+		p.Version,
+	)
 }
 
 // PackageURL returns the package URL ("purl") for the APK (origin) package.
@@ -655,21 +676,6 @@ type Configuration struct {
 
 	// Parsed AST for this configuration
 	root *yaml.Node
-}
-
-// CPE stores values used to produce a CPE to describe the package, suitable for
-// matching against NVD records.
-//
-// For Melange, the "part" attribute should always be interpreted as "a" (for
-// "application").
-type CPE struct {
-	Vendor  string
-	Product string
-}
-
-// String returns a CPE string for the package.
-func (c CPE) String() string {
-	return fmt.Sprintf("cpe:2.3:a:%s:%s:*:*:*:*:*:*:*:*", c.Vendor, c.Product)
 }
 
 // AllPackageNames returns a sequence of all package names in the configuration,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -122,6 +122,9 @@ type Package struct {
 	Scriptlets *Scriptlets `json:"scriptlets,omitempty" yaml:"scriptlets,omitempty"`
 	// Optional: enabling, disabling, and configuration of build checks
 	Checks Checks `json:"checks,omitempty" yaml:"checks,omitempty"`
+	// The CPE field values to be used for matching against NVD vulnerability
+	// records, if known.
+	CPE CPE `json:"cpe,omitempty" yaml:"cpe,omitempty"`
 
 	// Optional: The amount of time to allow this build to take before timing out.
 	Timeout time.Duration `json:"timeout,omitempty" yaml:"timeout,omitempty"`
@@ -654,6 +657,21 @@ type Configuration struct {
 	root *yaml.Node
 }
 
+// CPE stores values used to produce a CPE to describe the package, suitable for
+// matching against NVD records.
+//
+// For Melange, the "part" attribute should always be interpreted as "a" (for
+// "application").
+type CPE struct {
+	Vendor  string
+	Product string
+}
+
+// String returns a CPE string for the package.
+func (c CPE) String() string {
+	return fmt.Sprintf("cpe:2.3:a:%s:%s:*:*:*:*:*:*:*:*", c.Vendor, c.Product)
+}
+
 // AllPackageNames returns a sequence of all package names in the configuration,
 // i.e. the origin package name and the names of all subpackages.
 func (cfg Configuration) AllPackageNames() iter.Seq[string] {
@@ -1177,6 +1195,7 @@ func replacePackage(r *strings.Replacer, commit string, in Package) Package {
 		Options:            in.Options,
 		Scriptlets:         replaceScriptlets(r, in.Scriptlets),
 		Checks:             in.Checks,
+		CPE:                in.CPE,
 		Timeout:            in.Timeout,
 		Resources:          in.Resources,
 	}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -9,6 +9,59 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func Test_validateCPE(t *testing.T) {
+	cases := []struct {
+		name    string
+		cpe     CPE
+		wantErr bool
+	}{
+		{
+			name:    "minimally valid",
+			cpe:     CPE{Vendor: "b", Product: "c"},
+			wantErr: false,
+		},
+		{
+			name:    "product without vendor",
+			cpe:     CPE{Product: "c"},
+			wantErr: true,
+		},
+		{
+			name:    "vendor without product",
+			cpe:     CPE{Vendor: "b"},
+			wantErr: true,
+		},
+		{
+			name:    "valid with additional fields set",
+			cpe:     CPE{Part: "a", Vendor: "b", Product: "c", TargetSW: "d", TargetHW: "e"},
+			wantErr: false,
+		},
+		{
+			name:    "invalid part",
+			cpe:     CPE{Part: "h", Vendor: "b", Product: "c"},
+			wantErr: true,
+		},
+		{
+			name:    "invalid characters",
+			cpe:     CPE{Vendor: "b", Product: "c:5"},
+			wantErr: true,
+		},
+		{
+			name:    "more invalid characters",
+			cpe:     CPE{Vendor: "B!", Product: "c"},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateCPE(tt.cpe)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
 func Test_applySubstitution(t *testing.T) {
 	ctx := slogtest.Context(t)
 


### PR DESCRIPTION
This draft PR is trying out an idea where a package's build config could specify its own CPE values. Today our scanning system maintains its own list of known CPEs for packages with certain names. But perhaps it's better if each package is capable of defining the correct CPE on its own (if it has a CPE), which would remove the need for us to keep a central list up to date.

Improving CPE identification for packages will help us find CVEs for packages better (specifically, by improving recall) because it's not always possible to derive the correct CPE just from the package's other metadata.

Example of how this might look for cosign, for example:

```yaml
package:
  name: cosign
  version: 2.4.1
  epoch: 5
  description: Container Signing
  cpe:
    vendor: sigstore
    product: cosign
  copyright:
    - license: Apache-2.0
  dependencies:
    runtime:
      - ca-certificates-bundle
# ...
```

We could add other CPE fields over time as we find the need.

Should we use this CPE information in the package's SBOM as well? Probably. Although there's an argument to be made that finding this data in the built package's `.melange.yaml` is easier (and perhaps less likely to change shapes in the future) than finding it in the `/var/lib/db/sbom/...` location.