### PR TITLE
patch pipeline: expose fuzz flag so we can set a different value

### DIFF
--- a/pkg/build/pipelines/patch.yaml
+++ b/pkg/build/pipelines/patch.yaml
@@ -10,6 +10,11 @@ inputs:
       The number of path components to strip while extracting.
     default: 1
 
+  fuzz:
+    description: |
+      Sets the maximum fuzz factor. This option only applies to context diffs, and causes patch to ignore up to that many lines in looking for places to install a hunk.
+    default: 2
+
   patches:
     description: |
       A list of patches to apply, as a whitespace delimited string.
@@ -33,5 +38,5 @@ pipeline:
       fi
 
       grep -v -E '^(#|$)' $series | (while read patchfile; do
-        patch '-p${{inputs.strip-components}}' --verbose < $patchfile
+        patch '-p${{inputs.strip-components}}' --fuzz=${{inputs.fuzz}} --verbose < $patchfile
       done)


### PR DESCRIPTION
## Melange Pull Request Template



### Functional Changes

- This change exposes the flag `--fuzz` from the patch pipeline so anyone could set its value to `0` or any other value. Otherwise it defaults to its original value `2`.

```
      Sets the maximum fuzz factor. This option only applies to context diffs, and causes patch to ignore up to that many lines in looking for places to install a hunk. The default fuzz factor is 2.
```


