### PR TITLE
npm/install: provide npm binary

### DIFF
--- a/pkg/build/pipelines/npm/install.yaml
+++ b/pkg/build/pipelines/npm/install.yaml
@@ -4,6 +4,7 @@ needs:
   packages:
     - nodejs
     - busybox
+    - npm
 
 inputs:
   package:


### PR DESCRIPTION
So we can omit:
```
environment:
   contents:
     packages:
       - npm
```