### PR TITLE
fix: change git-checkout pipeline from convert apkbuild.

### DIFF
--- a/pkg/convert/apkbuild/apkbuild.go
+++ b/pkg/convert/apkbuild/apkbuild.go
@@ -351,7 +351,7 @@ func (c *Context) buildFetchStep(ctx context.Context, converter ApkConvertor) er
 
 			// Create a basic git-checkout pipeline
 			pipeline := config.Pipeline{
-				Uses: "melange/git-checkout",
+				Uses: "git-checkout",
 				With: map[string]string{
 					"repository":      apkBuild.Url,
 					"tag":             "${{package.version}}", // The version as the tag or branch reference


### PR DESCRIPTION
This generate a better UX to `melange convert` command.
Now, if we detect a git clone in the APKBUILD file, we define the pipe `melange/git-checkout` and it does not exist.

```terminal
./melange version
  __  __   _____   _          _      _   _    ____   _____
 |  \/  | | ____| | |        / \    | \ | |  / ___| | ____|
 | |\/| | |  _|   | |       / _ \   |  \| | | |  _  |  _|
 | |  | | | |___  | |___   / ___ \  | |\  | | |_| | | |___
 |_|  |_| |_____| |_____| /_/   \_\ |_| \_|  \____| |_____|
melange

GitVersion:    v0.12.0-411-g1b930c2
GitCommit:     1b930c2c0820cef286db65dacbac57470a84adce
GitTreeState:  clean
BuildDate:     '2025-02-03T14:27:36Z'
GoVersion:     go1.23.3
Compiler:      gc
Platform:      darwin/arm64

./melange convert apkbuild --base-uri-format https://git.alpinelinux.org/aports/plain/community/%s/APKBUILD libfreeaptx
2025/02/03 22:00:00 INFO generating convert config files for APKBUILD https://git.alpinelinux.org/aports/plain/community/libfreeaptx/APKBUILD
2025/02/03 22:00:01 INFO Using git-checkout pipeline for package libfreeaptx with repository https://github.com/iamthehorker/libfreeaptx and expected commit 9d26ae7d07d803a64a36a78c4afe1d470d6b175e
2025/02/03 22:00:01 INFO Generated melange config with update block: 00-libfreeaptx.yaml

./melange build 00-libfreeaptx.yaml --arch host --keyring-append=https://packages.wolfi.dev/os/wolfi-signing.rsa.pub --repository-append=https://packages.wolfi.dev/os
2025/02/03 22:00:15 INFO git commit for build config not provided, attempting to detect automatically
2025/02/03 22:00:15 WARN git repository URL for build config not provided
2025/02/03 22:00:15 INFO melange v0.12.0-411-g1b930c2 is building:
2025/02/03 22:00:15 INFO   configuration file: 00-libfreeaptx.yaml
2025/02/03 22:00:15 INFO   workspace dir: /var/folders/mt/99hkwd656vn7tlbfrdxy7358l9562b/T/melange-workspace-2262829258
2025/02/03 22:00:15 ERRO failed to build package: compiling 00-libfreeaptx.yaml: compiling "libfreeaptx" pipelines: compiling Pipeline[0]: unable to load pipeline: open pipelines/melange/git-checkout.yaml: file does not exist
```