### PR TITLE
Consolidate build user/group strings

### DIFF
--- a/pkg/build/build_test.go
+++ b/pkg/build/build_test.go
@@ -37,7 +37,6 @@ var requireErrInvalidConfiguration require.ErrorAssertionFunc = func(t require.T
 // TestConfiguration_Load is the main set of tests for loading a configuration
 // file. When in doubt, add your test here.
 func TestConfiguration_Load(t *testing.T) {
-	gid1000 := uint32(1000)
 	tests := []struct {
 		name                string
 		skipConfigCleanStep bool
@@ -209,8 +208,8 @@ func TestConfiguration_Load(t *testing.T) {
 						"GOPATH":     "/var/cache/melange/go",
 					},
 					Accounts: apko_types.ImageAccounts{
-						Users:  []apko_types.User{{UserName: "build", UID: 1000, GID: apko_types.GID(&gid1000)}},
-						Groups: []apko_types.Group{{GroupName: "build", GID: 1000, Members: []string{"build"}}},
+						Users:  []apko_types.User{{UserName: buildUser, UID: 1000, GID: apko_types.GID(&gid1000)}},
+						Groups: []apko_types.Group{{GroupName: buildUser, GID: 1000, Members: []string{buildUser}}},
 					},
 				},
 				Subpackages: []config.Subpackage{},
@@ -285,14 +284,14 @@ package:
 	}
 	gid1000 := uint32(1000)
 	expected.Environment.Accounts.Users = []apko_types.User{{
-		UserName: "build",
+		UserName: buildUser,
 		UID:      1000,
 		GID:      apko_types.GID(&gid1000),
 	}}
 	expected.Environment.Accounts.Groups = []apko_types.Group{{
-		GroupName: "build",
+		GroupName: buildUser,
 		GID:       1000,
-		Members:   []string{"build"},
+		Members:   []string{buildUser},
 	}}
 	expected.Environment.Environment = map[string]string{
 		"HOME":       "/home/build",

--- a/pkg/build/test_test.go
+++ b/pkg/build/test_test.go
@@ -32,14 +32,13 @@ import (
 )
 
 const (
+	buildUser        = "build"
+	etcResolveConf   = "/etc/resolv.conf"
+	homeBuild        = "/home/build"
 	testImgRef       = "testImageRef"
 	testPkgName      = "testPkgName"
 	testWorkspaceDir = "/workspace"
-	etcResolveConf   = "/etc/resolv.conf"
-	homeBuild        = "/home/build"
 )
-
-const buildUser = "build"
 
 var gid1000 = uint32(1000)
 

--- a/pkg/build/test_test.go
+++ b/pkg/build/test_test.go
@@ -39,14 +39,14 @@ const (
 	homeBuild        = "/home/build"
 )
 
-var (
-	gid1000 = uint32(1000)
-)
+const buildUser = "build"
+
+var gid1000 = uint32(1000)
 
 func defaultEnv(opts ...func(*apko_types.ImageConfiguration)) apko_types.ImageConfiguration {
 	env := apko_types.ImageConfiguration{
 		Accounts: types.ImageAccounts{
-			Groups: []types.Group{{GroupName: "build", GID: 1000, Members: []string{"build"}}},
+			Groups: []types.Group{{GroupName: "build", GID: 1000, Members: []string{buildUser}}},
 			Users:  []apko_types.User{{UserName: "build", UID: 1000, GID: apko_types.GID(&gid1000)}},
 		},
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -42,7 +42,10 @@ import (
 	"chainguard.dev/melange/pkg/util"
 )
 
-const purlTypeAPK = "apk"
+const (
+	buildUser   = "build"
+	purlTypeAPK = "apk"
+)
 
 type Trigger struct {
 	// Optional: The script to run
@@ -1360,12 +1363,19 @@ func ParseConfiguration(_ context.Context, configurationFilePath string, opts ..
 	cfg.Data = nil // TODO: zero this out or not?
 
 	// TODO: validate that subpackage ranges have been consumed and applied
-
+	grpName := buildUser
 	grp := apko_types.Group{
-		GroupName: "build",
+		GroupName: grpName,
 		GID:       1000,
-		Members:   []string{"build"},
+		Members:   []string{buildUser},
 	}
+
+	usr := apko_types.User{
+		UserName: buildUser,
+		UID:      1000,
+		GID:      apko_types.GID(&grp.GID),
+	}
+
 	cfg.Environment.Accounts.Groups = append(cfg.Environment.Accounts.Groups, grp)
 	if cfg.Test != nil {
 		cfg.Test.Environment.Accounts.Groups = append(cfg.Test.Environment.Accounts.Groups, grp)
@@ -1377,12 +1387,6 @@ func ParseConfiguration(_ context.Context, configurationFilePath string, opts ..
 		sub.Test.Environment.Accounts.Groups = append(sub.Test.Environment.Accounts.Groups, grp)
 	}
 
-	gid1000 := uint32(1000)
-	usr := apko_types.User{
-		UserName: "build",
-		UID:      1000,
-		GID:      apko_types.GID(&gid1000),
-	}
 	cfg.Environment.Accounts.Users = append(cfg.Environment.Accounts.Users, usr)
 	if cfg.Test != nil {
 		cfg.Test.Environment.Accounts.Users = append(cfg.Test.Environment.Accounts.Users, usr)


### PR DESCRIPTION
This PR controls the build user/group string from only two places rather than hard-coding the value in several places.