### PR TITLE
new command: rebuild

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,7 @@ tags
 ctags
 
 .DS_Store
+
+
+x86_64/**
+aarch64/**

--- a/docs/md/melange.md
+++ b/docs/md/melange.md
@@ -30,6 +30,7 @@ toc: true
 * [melange lint](/docs/md/melange_lint.md)	 - EXPERIMENTAL COMMAND - Lints an APK, checking for problems and errors
 * [melange package-version](/docs/md/melange_package-version.md)	 - Report the target package for a YAML configuration file
 * [melange query](/docs/md/melange_query.md)	 - Query a Melange YAML file for information
+* [melange rebuild](/docs/md/melange_rebuild.md)	 - Rebuild a melange package.
 * [melange scan](/docs/md/melange_scan.md)	 - Scan an existing APK to regenerate .PKGINFO
 * [melange sign](/docs/md/melange_sign.md)	 - Sign an APK package
 * [melange sign-index](/docs/md/melange_sign-index.md)	 - Sign an APK index

--- a/docs/md/melange_rebuild.md
+++ b/docs/md/melange_rebuild.md
@@ -1,0 +1,33 @@
+---
+title: "melange rebuild"
+slug: melange_rebuild
+url: /docs/md/melange_rebuild.md
+draft: false
+images: []
+type: "article"
+toc: true
+---
+## melange rebuild
+
+Rebuild a melange package.
+
+```
+melange rebuild [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for rebuild
+```
+
+### Options inherited from parent commands
+
+```
+      --log-level string   log level (e.g. debug, info, warn, error) (default "INFO")
+```
+
+### SEE ALSO
+
+* [melange](/docs/md/melange.md)	 - 
+

--- a/pkg/build/pipelines/README.md
+++ b/pkg/build/pipelines/README.md
@@ -56,6 +56,7 @@ Apply patches
 
 | Name | Required | Description | Default |
 | ---- | -------- | ----------- | ------- |
+| fuzz | false | Sets the maximum fuzz factor. This option only applies to context diffs, and causes patch to ignore up to that many lines in looking for places to install a hunk.  | 2 |
 | patches | false | A list of patches to apply, as a whitespace delimited string.  |  |
 | series | false | A quilt-style patch series file to apply.  |  |
 | strip-components | false | The number of path components to strip while extracting.  | 1 |

--- a/pkg/build/pipelines/cargo/README.md
+++ b/pkg/build/pipelines/cargo/README.md
@@ -16,7 +16,9 @@ Compile an auditable rust binary with Cargo
 | modroot | false | Top directory of the rust package, this is where the target package lives. Before building, the cargo pipeline wil cd into this directory. Defaults to current working directory  | . |
 | opts | false | Options to pass to cargo build. Defaults to release  | --release |
 | output | false | Filename to use when writing the binary. The final install location inside the apk will be in prefix / install-dir / output  |  |
+| output-dir | false | Directory where the binaris will be placed after building. Defaults to target/release  | target/release |
 | prefix | false | Installation prefix. Defaults to usr  | usr |
+| rustflags | false | Rustc flags to be passed to pass to all compiler invocations that Cargo performs. In contrast with cargo rustc, this is useful for passing a flag to all compiler instances. This string is split by whitespace.  |  |
 
 
 <!-- end:pipeline-reference-gen -->

--- a/pkg/cli/commands.go
+++ b/pkg/cli/commands.go
@@ -67,6 +67,7 @@ func New() *cobra.Command {
 	cmd.AddCommand(test())
 	cmd.AddCommand(updateCache())
 	cmd.AddCommand(version.Version())
+	cmd.AddCommand(rebuild())
 	return cmd
 }
 

--- a/pkg/cli/rebuild.go
+++ b/pkg/cli/rebuild.go
@@ -1,0 +1,134 @@
+package cli
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"time"
+
+	goapk "chainguard.dev/apko/pkg/apk/apk"
+	apko_types "chainguard.dev/apko/pkg/build/types"
+	"chainguard.dev/melange/pkg/build"
+	"chainguard.dev/melange/pkg/config"
+	"chainguard.dev/melange/pkg/container/docker"
+	"github.com/spf13/cobra"
+	"gopkg.in/ini.v1"
+	"gopkg.in/yaml.v3"
+)
+
+// TODO: Detect when the package is a subpackage (origin is different) and compare against the subpackage after building all packages.
+// TODO: Avoid rebuilding twice when rebuilding two subpackages of the same origin.
+// TODO: Add `--diff` flag to show the differences between the original and rebuilt packages, or document how to do it with shell commands.
+
+func rebuild() *cobra.Command {
+	return &cobra.Command{
+		Use:               "rebuild",
+		DisableAutoGenTag: true,
+		SilenceUsage:      true,
+		SilenceErrors:     true,
+		Short:             "Rebuild a melange package.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			r, err := docker.NewRunner(ctx)
+			if err != nil {
+				return fmt.Errorf("failed to create docker runner: %v", err)
+			}
+
+			for _, a := range args {
+				cfg, pkginfo, err := getConfig(a)
+				if err != nil {
+					return fmt.Errorf("failed to get config for %s: %v", a, err)
+				}
+
+				// TODO: This should not be necessary.
+				cfg.Environment.Contents.RuntimeRepositories = append(cfg.Environment.Contents.RuntimeRepositories, "https://packages.wolfi.dev/os")
+				cfg.Environment.Contents.Keyring = append(cfg.Environment.Contents.Keyring, "https://packages.wolfi.dev/os/wolfi-signing.rsa.pub")
+
+				f, err := os.CreateTemp("", "melange-rebuild-*.")
+				if err != nil {
+					return fmt.Errorf("failed to create temporary file: %v", err)
+				}
+				if err := yaml.NewEncoder(f).Encode(cfg); err != nil {
+					return fmt.Errorf("failed to encode stripped config: %v", err)
+				}
+				log.Println("wrote stripped config to", f.Name())
+
+				if err := BuildCmd(ctx,
+					[]apko_types.Architecture{apko_types.Architecture("amd64")},          // TODO configurable, or detect
+					build.WithConfigFileRepositoryURL("https://github.com/wolfi-dev/os"), // TODO get this from the package SBOM
+					build.WithConfigFileRepositoryCommit("TODO"),                         // TODO get this from the package SBOM
+					build.WithConfigFileLicense("Apache-2.0"),                            // TODO get this from the package SBOM
+					build.WithBuildDate(time.Unix(pkginfo.BuildDate, 0).Format(time.RFC3339)),
+					build.WithRunner(r), // TODO configurable
+					build.WithConfig(f.Name())); err != nil {
+					return fmt.Errorf("failed to rebuild %q: %v", a, err)
+				}
+			}
+
+			return nil
+		},
+	}
+}
+
+func getConfig(fn string) (*config.Configuration, *goapk.PackageInfo, error) {
+	f, err := os.Open(fn)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to open file %s: %v", fn, err)
+	}
+	defer f.Close()
+
+	var cfg *config.Configuration
+	var pkginfo *goapk.PackageInfo
+
+	gz, err := gzip.NewReader(f)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create gzip reader: %v", err)
+	}
+	defer gz.Close()
+	tr := tar.NewReader(gz)
+	for {
+		hdr, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			if cfg == nil {
+				return nil, nil, fmt.Errorf("failed to find .melange.yaml in %s", fn)
+			}
+			if pkginfo == nil {
+				return nil, nil, fmt.Errorf("failed to find .PKGINFO in %s", fn)
+			}
+			return nil, nil, fmt.Errorf("failed to find necessary rebuild information in %s", fn)
+		} else if err != nil {
+			return nil, nil, fmt.Errorf("failed to read tar header: %v", err)
+		}
+
+		switch hdr.Name {
+		case ".melange.yaml":
+			cfg = new(config.Configuration)
+			if err := yaml.NewDecoder(io.LimitReader(tr, hdr.Size)).Decode(cfg); err != nil {
+				return nil, nil, fmt.Errorf("failed to decode .melange.yaml: %v", err)
+			}
+
+		case ".PKGINFO":
+			i, err := ini.ShadowLoad(tr)
+			if err != nil {
+				return nil, nil, fmt.Errorf("failed to load .PKGINFO: %v", err)
+			}
+			pkginfo = new(goapk.PackageInfo)
+			if err = i.MapTo(pkginfo); err != nil {
+				return nil, nil, fmt.Errorf("failed to map .PKGINFO: %v", err)
+			}
+
+		default:
+			// TODO: Get the SBOM, since we need some info from it too.
+			continue
+		}
+
+		if cfg != nil && pkginfo != nil {
+			return cfg, pkginfo, nil
+		}
+	}
+	// unreachable
+}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -416,7 +416,7 @@ func TestValidatePipelines(t *testing.T) {
 			p: []Pipeline{
 				{Uses: "deploy", Pipeline: []Pipeline{{Runs: "somescript.sh"}}},
 			},
-			wantErr: true,
+			wantErr: false, // only a warning.
 		},
 	}
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -422,7 +422,8 @@ func TestValidatePipelines(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := validatePipelines(tt.p)
+			ctx := slogtest.Context(t)
+			err := validatePipelines(ctx, tt.p)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("validatePipelines() error = %v, wantErr %v", err, tt.wantErr)
 			}

--- a/pkg/config/schema.json
+++ b/pkg/config/schema.json
@@ -35,6 +35,27 @@
       ],
       "description": "BuildOption describes an optional deviation to a package build."
     },
+    "Capabilities": {
+      "properties": {
+        "add": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Linux process capabilities to add to the pipeline container."
+        },
+        "drop": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Linux process capabilities to drop from the pipeline container."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "Capabilities is the configuration for Linux capabilities for the runner."
+    },
     "Checks": {
       "properties": {
         "disabled": {
@@ -57,6 +78,10 @@
         "environment": {
           "$ref": "#/$defs/ImageConfiguration",
           "description": "The specification for the packages build environment"
+        },
+        "capabilities": {
+          "$ref": "#/$defs/Capabilities",
+          "description": "Optional: Linux capabilities configuration to apply to the melange runner."
         },
         "pipeline": {
           "items": {
@@ -115,7 +140,7 @@
         "package",
         "environment"
       ],
-      "description": "The root melange configuration"
+      "description": "Configuration is the root melange configuration."
     },
     "ContentsOption": {
       "properties": {
@@ -430,7 +455,7 @@
       "properties": {
         "description": {
           "type": "string",
-          "description": "Optional: The human readable description of the input"
+          "description": "Optional: The human-readable description of the input"
         },
         "default": {
           "type": "string",
@@ -499,7 +524,7 @@
         },
         "description": {
           "type": "string",
-          "description": "A human readable description of the package"
+          "description": "A human-readable description of the package"
         },
         "url": {
           "type": "string",
@@ -608,6 +633,10 @@
     },
     "Pipeline": {
       "properties": {
+        "if": {
+          "type": "string",
+          "description": "Optional: A condition to evaluate before running the pipeline"
+        },
         "name": {
           "type": "string",
           "description": "Optional: A user defined name for the pipeline"
@@ -632,7 +661,7 @@
             "$ref": "#/$defs/Pipeline"
           },
           "type": "array",
-          "description": "Optional: The list of pipelines to run.\n\nEach pipeline runs in it's own context that is not shared between other\npipelines. To share context between pipelines, nest a pipeline within an\nexisting pipeline. This can be useful when you wish to share common\nconfiguration, such as an alternative `working-directory`."
+          "description": "Optional: The list of pipelines to run.\n\nEach pipeline runs in its own context that is not shared between other\npipelines. To share context between pipelines, nest a pipeline within an\nexisting pipeline. This can be useful when you wish to share common\nconfiguration, such as an alternative `working-directory`."
         },
         "inputs": {
           "additionalProperties": {
@@ -648,10 +677,6 @@
         "label": {
           "type": "string",
           "description": "Optional: Labels to apply to the pipeline"
-        },
-        "if": {
-          "type": "string",
-          "description": "Optional: A condition to evaluate before running the pipeline"
         },
         "assertions": {
           "$ref": "#/$defs/PipelineAssertions",
@@ -731,6 +756,9 @@
     "Resources": {
       "properties": {
         "cpu": {
+          "type": "string"
+        },
+        "cpumodel": {
           "type": "string"
         },
         "memory": {
@@ -897,6 +925,10 @@
         "manual": {
           "type": "boolean",
           "description": "Indicates that this package should be manually updated, usually taking\ncare over special version numbers"
+        },
+        "require-sequential": {
+          "type": "boolean",
+          "description": "Indicates that automated pull requests should be merged in order rather than superseding and closing previous unmerged PRs"
         },
         "shared": {
           "type": "boolean",


### PR DESCRIPTION
This adds a new top-level command, `melange rebuild`, which takes an existing APK (or multiple), and extracts the `.melange.yaml` and `.PKGINFO` embedded in the control section, and uses it to build the package again from locked inputs.

The intention is that we would be able to tell _whether_ package builds are reproducible when built with all the same config and versions of the tools that were originally used, and if they're not reproducible, _how_.

Initial tests are promising!

To rebuild our `crane` package:

```
$ go run ./ rebuild <(curl -sL https://apk.cgr.dev/chainguard/x86_64/crane-0.20.3-r2.apk)
```

Its `crane` binary has the same digest as the original package:

```
$ tar -Oxf x86_64/crane-0.20.3-r2.apk usr/bin/crane | sha256sum -                        
eaa2d9818a1889daf9fb8fba44e5dba3082a9d22e204e1ff34369fa5491416a4  -
$ curl -sL https://apk.cgr.dev/chainguard/x86_64/crane-0.20.3-r2.apk | tar -Ox usr/bin/crane | sha256sum -
eaa2d9818a1889daf9fb8fba44e5dba3082a9d22e204e1ff34369fa5491416a4  -
```

🎉 

There are however some differences in the surrounding package metadata, which is either a TODO for `rebuild` or for how we embed stuff into `.melange.yaml`

```
$ diff \
  <(tar -Oxf x86_64/crane-0.20.3-r2.apk .melange.yaml) \
  <(curl -sL https://apk.cgr.dev/chainguard/x86_64/crane-0.20.3-r2.apk | tar -Ox .melange.yaml)
```

- `accounts` block is moved around inexplicably
- `crane` is added twice to the `test` package dependencies

File contents are also slightly different:

```
$ diff \
  <(tar -tvf x86_64/crane-0.20.3-r2.apk | sort) \
  <(curl -sL https://apk.cgr.dev/chainguard/x86_64/crane-0.20.3-r2.apk | tar -tv | sort)              
1d0
< -rw-r--r--  0 jason  dialout     3054 Feb  8 15:03 var/lib/db/sbom/crane-0.20.3-r2.spdx.json
3,10c2,10
< -rw-r--r--  0 root   root    12409 Feb  8 15:03 .melange.yaml
< -rwxr-xr-x  0 jason  dialout 11870488 Feb  8 15:03 usr/bin/crane
---
> -rw-r--r--  0 root   root     2936 Feb  8 15:03 var/lib/db/sbom/crane-0.20.3-r2.spdx.json
> -rw-r--r--  0 root   root    11827 Feb  8 15:03 .melange.yaml
> -rwxr-xr-x  0 root   root 11870488 Feb  8 15:03 usr/bin/crane
```

- owner `dialout` probably because of docker runner vs bwrap
- SBOM is different, probably due to missing metadata

To enable this, it's only a warning to include `uses` and `with` with a `pipeline`, since that's how we resolve the `.melange.yaml`.