### PR TITLE
Add support for 'finalize' pipelines.

### DIFF
--- a/docs/BUILD-FILE.md
+++ b/docs/BUILD-FILE.md
@@ -548,3 +548,6 @@ TODO(vaikas): melange config points to apko here:
 # pipeline
 Pipeline defines the ordered steps to build the package.
 
+# finalize
+Finalize defines a series of pipelines that are executed
+after the build and subpackages are processed.

--- a/e2e-tests/greeter-build-test.yaml
+++ b/e2e-tests/greeter-build-test.yaml
@@ -60,12 +60,31 @@ subpackages:
             ${{vars.tester-blob}}
             testrun ${{range.value}}
 
+finalize:
+  - name: "write /etc/finalized"
+    runs: |
+      ( cd "${{targets.outdir}}" && find . ! -type d )
+      etcd="${{targets.outdir}}/${{package.name}}/etc"
+      mkdir -p "$etcd"
+      echo "finalized-${{package.name}}" > "$etcd/finalized"
+
 test:
   pipeline:
     - name: test-greeter
       runs: |
         ${{vars.tester-blob}}
         testrun greeter howdy
+    - name: test-finalized
+      runs: |
+        set +f
+        f="/etc/finalized"
+        [ -e "$f" ] || { echo "FAIL: $f is not present"; exit 1; }
+        [ -f "$f" ] || { echo "FAIL: $f was not a file"; exit 1; }
+        exp="finalized-${{package.name}}"
+        read content < "$f" || { echo "FAIL: failed to read from $f"; exit 1; }
+        [ "$content" = "$exp" ] ||
+          { echo "$f contained '$content'. expected '$exp'"; exit 1; }
+        echo "PASS: $f existed and had expected content '$exp'"
 
 vars:
   tester-blob: |

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -701,6 +701,14 @@ func (b *Build) BuildPackage(ctx context.Context) error {
 		linterQueue = append(linterQueue, lintTarget)
 	}
 
+	// Run finalize pipelines
+	if !b.isBuildLess() && len(b.Configuration.Finalize) > 0 {
+		log.Infof("running finalize pipelines for %s", pkg.Name)
+		if err := pr.runPipelines(ctx, b.Configuration.Finalize); err != nil {
+			return fmt.Errorf("unable to run finalize pipelines for %s: %v", pkg.Name, err)
+		}
+	}
+
 	// Store metadata for use after the workspace is loaded into memory
 	xattrs, modes, owners, err := storeMetadata(b.WorkspaceDir)
 	if err != nil {

--- a/pkg/build/compile.go
+++ b/pkg/build/compile.go
@@ -137,6 +137,10 @@ func (b *Build) Compile(ctx context.Context) error {
 		return fmt.Errorf("compiling %q pipelines: %w", cfg.Package.Name, err)
 	}
 
+	if err := c.CompilePipelines(ctx, sm, cfg.Finalize); err != nil {
+		return fmt.Errorf("compiling finalize %q: %w", cfg.Package.Name, err)
+	}
+
 	for i, sp := range cfg.Subpackages {
 		sm := sm.Subpackage(&sp)
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -891,6 +891,8 @@ type Configuration struct {
 	Pipeline []Pipeline `json:"pipeline,omitempty" yaml:"pipeline,omitempty"`
 	// Optional: The list of subpackages that this package also produces.
 	Subpackages []Subpackage `json:"subpackages,omitempty" yaml:"subpackages,omitempty"`
+	// Optional: The list of finalize pipelines to execute
+	Finalize []Pipeline `json:"finalize,omitempty" yaml:"finalize,omitempty"`
 	// Optional: An arbitrary list of data that can be used via templating in the
 	// pipeline
 	Data []RangeData `json:"data,omitempty" yaml:"data,omitempty"`


### PR DESCRIPTION
  * add greeter-build e2e-test that does build and test.
    
    This also tests the finalize code.

  * Add support for 'finalize' pipelines.
    
    The idea here is that 'finalize' has access to the fully
    populated 'melange-out' directory after all subpackages
    have finished.
    
    Without this only the last subpackage has access to
    all of the melange-out/ data.  So you could utilize
    the last subpackage to do "finalize" things, but that
    seems very yucky.
    
    The initial use for this is to melange-helpers usrmerge
    to move files around in all the packages/subpackages
    at the end of the build.
    https://github.com/wolfi-dev/os/pull/42552
