### PR TITLE
rebuild: add e2e test

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -131,6 +131,11 @@ jobs:
     permissions:
       contents: read
 
+    container:
+      image: alpine:latest
+      options: |
+        --cap-add NET_ADMIN --cap-add SYS_ADMIN --security-opt seccomp=unconfined --security-opt apparmor:unconfined
+
     steps:
       - uses: step-security/harden-runner@cb605e52c26070c328afc4562f0b4ada7618a84e # v2.10.4
         with:

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -168,7 +168,7 @@ jobs:
           # This is a hack so that we can build `minimal.yaml` again, remove this when we get the path from the SBOM.
           mv packages/x86_64/minimal-0.0.1-r0.apk ../original.apk
           ../melange rebuild ../original.apk
-          mv packages/x86_64/minimal-0.0.1-r0.apk ../rebuilt.apk
+          mv x86_64/minimal-0.0.1-r0.apk ../rebuilt.apk
 
       - name: Diff filesystem
         run: |

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -161,7 +161,9 @@ jobs:
         run: |
           make melange
           ./melange keygen
-          ./melange build examples/minimal.yaml --arch=x86_64 --empty-workspace
+
+          cd examples/
+          ./melange build minimal.yaml --arch=x86_64 --empty-workspace --namespace=wolfi
 
           mv packages/x86_64/minimal-0.0.1-r0.apk orig.apk
           ./melange rebuild orig.apk

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -167,7 +167,7 @@ jobs:
 
           # This is a hack so that we can build `minimal.yaml` again, remove this when we get the path from the SBOM.
           mv packages/x86_64/minimal-0.0.1-r0.apk ../original.apk
-          ../melange rebuild ../original.apk
+          ../melange rebuild ../original.apk --arch=x86_64
           mv packages/x86_64/minimal-0.0.1-r0.apk ../rebuilt.apk
 
       - name: Diff filesystem

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -124,3 +124,40 @@ jobs:
           sha256sum stage2/x86_64/*.apk | sed -e 's:stage2/:stage3/:g' | sha256sum -c
       - name: Verify operation of stage3 melange
         run: melange version
+
+  rebuild:
+    name: test rebuild
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: step-security/harden-runner@cb605e52c26070c328afc4562f0b4ada7618a84e # v2.10.4
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
+        with:
+          go-version-file: "go.mod"
+
+      - run: |
+          go install
+          melange build examples/vars.yaml
+          mv packages/x86_64/vars-2.12.4-r0.apk orig.apk
+          melange rebuild orig.apk
+
+          # Diff filesystem
+          diff \
+            <(tar -tvf orig.apk | sort) \
+            <(tar -tvf x86_64/vars-2.12.4-r0.apk | sort)
+
+          # Diff SBOM
+          diff \
+            <(tar -Oxf orig.apk var/lib/db/sbom/vars-2.12-4-r0.spdx.json | jq) \
+            <(tar -tvf x86_64/vars-2.12.4-r0.apk var/lib/db/sbom/vars-2.12-4-r0.spdx.json | jq)
+
+          # Diff .melange.yaml
+          diff \
+            <(tar -Oxf orig.apk .melange.yaml) \
+            <(tar -Oxf x86_64/vars-2.12.4-r0.apk .melange.yaml)

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -184,11 +184,11 @@ jobs:
           tar -Oxf orig.apk var/lib/db/sbom/minimal-0.0.1-r0.spdx.json | jq
           echo ::endgroup::
           echo ::group::rebuilt
-          tar -tvf x86_64/minimal-0.0.1-r0.apk var/lib/db/sbom/minimal-0.0.1-r0.spdx.json # TODO: jq it
+          tar -Oxf x86_64/minimal-0.0.1-r0.apk var/lib/db/sbom/minimal-0.0.1-r0.spdx.json | jq
           echo ::endgroup::
           diff \
             <(tar -Oxf orig.apk var/lib/db/sbom/minimal-0.0.1-r0.spdx.json | jq) \
-            <(tar -tvf x86_64/minimal-0.0.1-r0.apk var/lib/db/sbom/minimal-0.0.1-r0.spdx.json | jq) || true
+            <(tar -Oxf x86_64/minimal-0.0.1-r0.apk var/lib/db/sbom/minimal-0.0.1-r0.spdx.json | jq) || true
 
       - name: Diff .melange.yaml
         run: |

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -166,9 +166,9 @@ jobs:
           ../melange build minimal.yaml --arch=x86_64 --empty-workspace --namespace=wolfi
 
           # This is a hack so that we can build `minimal.yaml` again, remove this when we get the path from the SBOM.
-          mv packages/x86_64/minimal-0.0.1-r0.apk ../original.apk
+          mv x86_64/minimal-0.0.1-r0.apk ../original.apk
           ../melange rebuild ../original.apk
-          mv packages/x86_64/minimal-0.0.1-r0.apk ../rebuilt.apk
+          mv x86_64/minimal-0.0.1-r0.apk ../rebuilt.apk
 
       - name: Diff filesystem
         run: |

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -142,22 +142,32 @@ jobs:
           go-version-file: "go.mod"
 
       - run: |
-          go install
-          melange build examples/vars.yaml
+          sudo apt-get update -y
+          sudo apt-get install -y bubblewrap
+
+          make melange
+          ./melange keygen
+          ./melange build examples/vars.yaml --arch=x86_64 --empty-workspace
+
           mv packages/x86_64/vars-2.12.4-r0.apk orig.apk
-          melange rebuild orig.apk
+          ./melange rebuild orig.apk
 
           # Diff filesystem
           diff \
             <(tar -tvf orig.apk | sort) \
-            <(tar -tvf x86_64/vars-2.12.4-r0.apk | sort)
+            <(tar -tvf x86_64/vars-2.12.4-r0.apk | sort) || true
 
           # Diff SBOM
           diff \
             <(tar -Oxf orig.apk var/lib/db/sbom/vars-2.12-4-r0.spdx.json | jq) \
-            <(tar -tvf x86_64/vars-2.12.4-r0.apk var/lib/db/sbom/vars-2.12-4-r0.spdx.json | jq)
+            <(tar -tvf x86_64/vars-2.12.4-r0.apk var/lib/db/sbom/vars-2.12-4-r0.spdx.json | jq) || true
 
           # Diff .melange.yaml
           diff \
             <(tar -Oxf orig.apk .melange.yaml) \
-            <(tar -Oxf x86_64/vars-2.12.4-r0.apk .melange.yaml)
+            <(tar -Oxf x86_64/vars-2.12.4-r0.apk .melange.yaml) || true
+
+          # Diff .PKGINFO
+          diff \
+            <(tar -Oxf orig.apk .PKGINFO) \
+            <(tar -Oxf x86_64/vars-2.12.4-r0.apk .PKGINFO) || true

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -165,6 +165,7 @@ jobs:
 
           mv packages/x86_64/minimal-0.0.1-r0.apk orig.apk
           ./melange rebuild orig.apk
+
       - name: Diff filesystem
         run: |
           echo ::group::original
@@ -183,7 +184,7 @@ jobs:
           tar -Oxf orig.apk var/lib/db/sbom/minimal-0.0.1-r0.spdx.json | jq
           echo ::endgroup::
           echo ::group::rebuilt
-          tar -tvf x86_64/minimal-0.0.1-r0.apk var/lib/db/sbom/minimal-0.0.1-r0.spdx.json | jq
+          tar -tvf x86_64/minimal-0.0.1-r0.apk var/lib/db/sbom/minimal-0.0.1-r0.spdx.json # TODO: jq it
           echo ::endgroup::
           diff \
             <(tar -Oxf orig.apk var/lib/db/sbom/minimal-0.0.1-r0.spdx.json | jq) \

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -155,7 +155,7 @@ jobs:
           _EOF_
 
           apk upgrade -Ua
-          apk add go build-base git bubblewrap
+          apk add go build-base git bubblewrap jq
 
       - run: |
           make melange
@@ -164,31 +164,26 @@ jobs:
 
           mv packages/x86_64/minimal-0.0.1-r0.apk orig.apk
           ./melange rebuild orig.apk
-
-          # Diff filesystem
-          echo ::group::filesystem diff
+      - name: Diff filesystem
+        run: |
           diff \
             <(tar -tvf orig.apk | sort) \
             <(tar -tvf x86_64/minimal-0.0.1-r0.apk | sort) || true
-          echo ::endgroup::
 
-          # Diff SBOM
-          echo ::group::sbom diff
+      - name: Diff SBOM
+        run: |
           diff \
             <(tar -Oxf orig.apk var/lib/db/sbom/minimal-0.0.1-r0.spdx.json | jq) \
             <(tar -tvf x86_64/minimal-0.0.1-r0.apk var/lib/db/sbom/minimal-0.0.1-r0.spdx.json | jq) || true
-          echo ::endgroup::
 
-          # Diff .melange.yaml
-          echo ::group::.melange.yaml diff
+      - name: Diff .melange.yaml
+        run: |
           diff \
             <(tar -Oxf orig.apk .melange.yaml) \
             <(tar -Oxf x86_64/minimal-0.0.1-r0.apk .melange.yaml) || true
-          echo ::endgroup::
 
-          # Diff .PKGINFO
-          echo ::group::.PKGINFO diff
+      - name: Diff .PKGINFO
+        run: |
           diff \
             <(tar -Oxf orig.apk .PKGINFO) \
             <(tar -Oxf x86_64/minimal-0.0.1-r0.apk .PKGINFO) || true
-          echo ::endgroup::

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -157,7 +157,8 @@ jobs:
           apk upgrade -Ua
           apk add go build-base git bubblewrap jq
 
-      - run: |
+      - name: Build and rebuild
+        run: |
           make melange
           ./melange keygen
           ./melange build examples/minimal.yaml --arch=x86_64 --empty-workspace
@@ -166,24 +167,48 @@ jobs:
           ./melange rebuild orig.apk
       - name: Diff filesystem
         run: |
+          echo ::group::original
+          tar -tvf orig.apk | sort
+          echo ::endgroup::
+          echo ::group::rebuilt
+          tar -tvf x86_64/minimal-0.0.1-r0.apk | sort
+          echo ::endgroup::
           diff \
             <(tar -tvf orig.apk | sort) \
             <(tar -tvf x86_64/minimal-0.0.1-r0.apk | sort) || true
 
       - name: Diff SBOM
         run: |
+          echo ::group::original
+          tar -Oxf orig.apk var/lib/db/sbom/minimal-0.0.1-r0.spdx.json | jq
+          echo ::endgroup::
+          echo ::group::rebuilt
+          tar -tvf x86_64/minimal-0.0.1-r0.apk var/lib/db/sbom/minimal-0.0.1-r0.spdx.json | jq
+          echo ::endgroup::
           diff \
             <(tar -Oxf orig.apk var/lib/db/sbom/minimal-0.0.1-r0.spdx.json | jq) \
             <(tar -tvf x86_64/minimal-0.0.1-r0.apk var/lib/db/sbom/minimal-0.0.1-r0.spdx.json | jq) || true
 
       - name: Diff .melange.yaml
         run: |
+          echo ::group::original
+          tar -Oxf orig.apk .melange.yaml
+          echo ::endgroup::
+          echo ::group::rebuilt
+          tar -Oxf x86_64/minimal-0.0.1-r0.apk .melange.yaml
+          echo ::endgroup::
           diff \
             <(tar -Oxf orig.apk .melange.yaml) \
             <(tar -Oxf x86_64/minimal-0.0.1-r0.apk .melange.yaml) || true
 
       - name: Diff .PKGINFO
         run: |
+          echo ::group::original
+          tar -Oxf orig.apk .PKGINFO
+          echo ::endgroup::
+          echo ::group::rebuilt
+          tar -Oxf x86_64/minimal-0.0.1-r0.apk .PKGINFO
+          echo ::endgroup::
           diff \
             <(tar -Oxf orig.apk .PKGINFO) \
             <(tar -Oxf x86_64/minimal-0.0.1-r0.apk .PKGINFO) || true

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -180,7 +180,7 @@ jobs:
           echo ::endgroup::
           diff \
             <(tar -tvf original.apk | sort) \
-            <(tar -tvf rebuilt.apk | sort) || true
+            <(tar -tvf rebuilt.apk | sort) && echo "No diff!"
 
       - name: Diff SBOM
         run: |
@@ -192,7 +192,7 @@ jobs:
           echo ::endgroup::
           diff \
             <(tar -Oxf original.apk var/lib/db/sbom/minimal-0.0.1-r0.spdx.json | jq) \
-            <(tar -Oxf rebuilt.apk var/lib/db/sbom/minimal-0.0.1-r0.spdx.json | jq) || true
+            <(tar -Oxf rebuilt.apk var/lib/db/sbom/minimal-0.0.1-r0.spdx.json | jq) && echo "No diff!"
 
       - name: Diff .melange.yaml
         run: |
@@ -204,7 +204,7 @@ jobs:
           echo ::endgroup::
           diff \
             <(tar -Oxf original.apk .melange.yaml) \
-            <(tar -Oxf rebuilt.apk .melange.yaml) || true
+            <(tar -Oxf rebuilt.apk .melange.yaml) && echo "No diff!"
 
       - name: Diff .PKGINFO
         run: |
@@ -216,4 +216,4 @@ jobs:
           echo ::endgroup::
           diff \
             <(tar -Oxf original.apk .PKGINFO) \
-            <(tar -Oxf rebuilt.apk .PKGINFO) || true
+            <(tar -Oxf rebuilt.apk .PKGINFO) && echo "No diff!"

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -162,25 +162,25 @@ jobs:
           ./melange keygen
           ./melange build examples/vars.yaml --arch=x86_64 --empty-workspace
 
-          mv packages/x86_64/vars-2.12.4-r0.apk orig.apk
+          mv packages/x86_64/hello-2.12.4-r0.apk orig.apk
           ./melange rebuild orig.apk
 
           # Diff filesystem
           diff \
             <(tar -tvf orig.apk | sort) \
-            <(tar -tvf x86_64/vars-2.12.4-r0.apk | sort) || true
+            <(tar -tvf x86_64/hello-2.12.4-r0.apk | sort) || true
 
           # Diff SBOM
           diff \
-            <(tar -Oxf orig.apk var/lib/db/sbom/vars-2.12-4-r0.spdx.json | jq) \
-            <(tar -tvf x86_64/vars-2.12.4-r0.apk var/lib/db/sbom/vars-2.12-4-r0.spdx.json | jq) || true
+            <(tar -Oxf orig.apk var/lib/db/sbom/hello-2.12-4-r0.spdx.json | jq) \
+            <(tar -tvf x86_64/hello-2.12.4-r0.apk var/lib/db/sbom/hello-2.12-4-r0.spdx.json | jq) || true
 
           # Diff .melange.yaml
           diff \
             <(tar -Oxf orig.apk .melange.yaml) \
-            <(tar -Oxf x86_64/vars-2.12.4-r0.apk .melange.yaml) || true
+            <(tar -Oxf x86_64/hello-2.12.4-r0.apk .melange.yaml) || true
 
           # Diff .PKGINFO
           diff \
             <(tar -Oxf orig.apk .PKGINFO) \
-            <(tar -Oxf x86_64/vars-2.12.4-r0.apk .PKGINFO) || true
+            <(tar -Oxf x86_64/hello-2.12.4-r0.apk .PKGINFO) || true

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -166,21 +166,29 @@ jobs:
           ./melange rebuild orig.apk
 
           # Diff filesystem
+          echo ::group::filesystem diff
           diff \
             <(tar -tvf orig.apk | sort) \
             <(tar -tvf x86_64/hello-2.12.4-r0.apk | sort) || true
+          echo ::endgroup::
 
           # Diff SBOM
+          echo ::group::sbom diff
           diff \
             <(tar -Oxf orig.apk var/lib/db/sbom/hello-2.12-4-r0.spdx.json | jq) \
             <(tar -tvf x86_64/hello-2.12.4-r0.apk var/lib/db/sbom/hello-2.12-4-r0.spdx.json | jq) || true
+          echo ::endgroup::
 
           # Diff .melange.yaml
+          echo ::group::.melange.yaml diff
           diff \
             <(tar -Oxf orig.apk .melange.yaml) \
             <(tar -Oxf x86_64/hello-2.12.4-r0.apk .melange.yaml) || true
+          echo ::endgroup::
 
           # Diff .PKGINFO
+          echo ::group::.PKGINFO diff
           diff \
             <(tar -Oxf orig.apk .PKGINFO) \
             <(tar -Oxf x86_64/hello-2.12.4-r0.apk .PKGINFO) || true
+          echo ::endgroup::

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -168,7 +168,7 @@ jobs:
           # This is a hack so that we can build `minimal.yaml` again, remove this when we get the path from the SBOM.
           mv packages/x86_64/minimal-0.0.1-r0.apk ../original.apk
           ../melange rebuild ../original.apk
-          mv x86_64/minimal-0.0.1-r0.apk ../rebuilt.apk
+          mv packages/x86_64/minimal-0.0.1-r0.apk ../rebuilt.apk
 
       - name: Diff filesystem
         run: |

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -165,8 +165,9 @@ jobs:
           cd examples/
           ../melange build minimal.yaml --arch=x86_64 --empty-workspace --namespace=wolfi
 
+          # This is a hack so that we can build `minimal.yaml` again, remove this when we get the path from the SBOM.
           mv packages/x86_64/minimal-0.0.1-r0.apk ../orig.apk
-          ../melange rebuild orig.apk
+          ../melange rebuild ../orig.apk
 
       - name: Diff filesystem
         run: |

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -171,6 +171,7 @@ jobs:
           mv packages/x86_64/minimal-0.0.1-r0.apk ../rebuilt.apk
 
       - name: Diff filesystem
+        if: always()
         run: |
           echo ::group::original
           tar -tvf original.apk | sort
@@ -183,6 +184,7 @@ jobs:
             <(tar -tvf rebuilt.apk | sort) && echo "No diff!"
 
       - name: Diff SBOM
+        if: always()
         run: |
           echo ::group::original
           tar -Oxf original.apk var/lib/db/sbom/minimal-0.0.1-r0.spdx.json | jq
@@ -195,6 +197,7 @@ jobs:
             <(tar -Oxf rebuilt.apk var/lib/db/sbom/minimal-0.0.1-r0.spdx.json | jq) && echo "No diff!"
 
       - name: Diff .melange.yaml
+        if: always()
         run: |
           echo ::group::original
           tar -Oxf original.apk .melange.yaml
@@ -207,6 +210,7 @@ jobs:
             <(tar -Oxf rebuilt.apk .melange.yaml) && echo "No diff!"
 
       - name: Diff .PKGINFO
+        if: always()
         run: |
           echo ::group::original
           tar -Oxf original.apk .PKGINFO
@@ -217,3 +221,10 @@ jobs:
           diff \
             <(tar -Oxf original.apk .PKGINFO) \
             <(tar -Oxf rebuilt.apk .PKGINFO) && echo "No diff!"
+
+      - name: Diff digest
+        if: always()
+        run: |
+          diff \
+            <(sha256sum original.apk | cut -d' ' -f1) \
+            <(sha256sum rebuilt.apk | cut -d' ' -f1) && echo "No diff!"

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -166,9 +166,9 @@ jobs:
           ../melange build minimal.yaml --arch=x86_64 --empty-workspace --namespace=wolfi
 
           # This is a hack so that we can build `minimal.yaml` again, remove this when we get the path from the SBOM.
-          mv x86_64/minimal-0.0.1-r0.apk ../original.apk
+          mv packages/x86_64/minimal-0.0.1-r0.apk ../original.apk
           ../melange rebuild ../original.apk
-          mv x86_64/minimal-0.0.1-r0.apk ../rebuilt.apk
+          mv packages/x86_64/minimal-0.0.1-r0.apk ../rebuilt.apk
 
       - name: Diff filesystem
         run: |

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -146,10 +146,18 @@ jobs:
         with:
           go-version-file: "go.mod"
 
-      - run: |
-          sudo apt-get update -y
-          sudo apt-get install -y bubblewrap
+      - name: Fetch dependencies
+        run: |
+          cat >/etc/apk/repositories <<_EOF_
+          https://dl-cdn.alpinelinux.org/alpine/edge/main
+          https://dl-cdn.alpinelinux.org/alpine/edge/community
+          https://dl-cdn.alpinelinux.org/alpine/edge/testing
+          _EOF_
 
+          apk upgrade -Ua
+          apk add go build-base git bubblewrap
+
+      - run: |
           make melange
           ./melange keygen
           ./melange build examples/vars.yaml --arch=x86_64 --empty-workspace

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -165,7 +165,7 @@ jobs:
           cd examples/
           ../melange build minimal.yaml --arch=x86_64 --empty-workspace --namespace=wolfi
 
-          mv packages/x86_64/minimal-0.0.1-r0.apk orig.apk
+          mv packages/x86_64/minimal-0.0.1-r0.apk ../orig.apk
           ../melange rebuild orig.apk
 
       - name: Diff filesystem

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -175,11 +175,11 @@ jobs:
           tar -tvf orig.apk | sort
           echo ::endgroup::
           echo ::group::rebuilt
-          tar -tvf x86_64/minimal-0.0.1-r0.apk | sort
+          tar -tvf packages/x86_64/minimal-0.0.1-r0.apk | sort
           echo ::endgroup::
           diff \
             <(tar -tvf orig.apk | sort) \
-            <(tar -tvf x86_64/minimal-0.0.1-r0.apk | sort) || true
+            <(tar -tvf packages/x86_64/minimal-0.0.1-r0.apk | sort) || true
 
       - name: Diff SBOM
         run: |
@@ -187,11 +187,11 @@ jobs:
           tar -Oxf orig.apk var/lib/db/sbom/minimal-0.0.1-r0.spdx.json | jq
           echo ::endgroup::
           echo ::group::rebuilt
-          tar -Oxf x86_64/minimal-0.0.1-r0.apk var/lib/db/sbom/minimal-0.0.1-r0.spdx.json | jq
+          tar -Oxf packages/x86_64/minimal-0.0.1-r0.apk var/lib/db/sbom/minimal-0.0.1-r0.spdx.json | jq
           echo ::endgroup::
           diff \
             <(tar -Oxf orig.apk var/lib/db/sbom/minimal-0.0.1-r0.spdx.json | jq) \
-            <(tar -Oxf x86_64/minimal-0.0.1-r0.apk var/lib/db/sbom/minimal-0.0.1-r0.spdx.json | jq) || true
+            <(tar -Oxf packages/x86_64/minimal-0.0.1-r0.apk var/lib/db/sbom/minimal-0.0.1-r0.spdx.json | jq) || true
 
       - name: Diff .melange.yaml
         run: |
@@ -199,11 +199,11 @@ jobs:
           tar -Oxf orig.apk .melange.yaml
           echo ::endgroup::
           echo ::group::rebuilt
-          tar -Oxf x86_64/minimal-0.0.1-r0.apk .melange.yaml
+          tar -Oxf packages/x86_64/minimal-0.0.1-r0.apk .melange.yaml
           echo ::endgroup::
           diff \
             <(tar -Oxf orig.apk .melange.yaml) \
-            <(tar -Oxf x86_64/minimal-0.0.1-r0.apk .melange.yaml) || true
+            <(tar -Oxf packages/x86_64/minimal-0.0.1-r0.apk .melange.yaml) || true
 
       - name: Diff .PKGINFO
         run: |
@@ -211,8 +211,8 @@ jobs:
           tar -Oxf orig.apk .PKGINFO
           echo ::endgroup::
           echo ::group::rebuilt
-          tar -Oxf x86_64/minimal-0.0.1-r0.apk .PKGINFO
+          tar -Oxf packages/x86_64/minimal-0.0.1-r0.apk .PKGINFO
           echo ::endgroup::
           diff \
             <(tar -Oxf orig.apk .PKGINFO) \
-            <(tar -Oxf x86_64/minimal-0.0.1-r0.apk .PKGINFO) || true
+            <(tar -Oxf packages/x86_64/minimal-0.0.1-r0.apk .PKGINFO) || true

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -160,35 +160,35 @@ jobs:
       - run: |
           make melange
           ./melange keygen
-          ./melange build examples/vars.yaml --arch=x86_64 --empty-workspace
+          ./melange build examples/minimal.yaml --arch=x86_64 --empty-workspace
 
-          mv packages/x86_64/hello-2.12.4-r0.apk orig.apk
+          mv packages/x86_64/minimal-0.0.1-r0.apk orig.apk
           ./melange rebuild orig.apk
 
           # Diff filesystem
           echo ::group::filesystem diff
           diff \
             <(tar -tvf orig.apk | sort) \
-            <(tar -tvf x86_64/hello-2.12.4-r0.apk | sort) || true
+            <(tar -tvf x86_64/minimal-0.0.1-r0.apk | sort) || true
           echo ::endgroup::
 
           # Diff SBOM
           echo ::group::sbom diff
           diff \
-            <(tar -Oxf orig.apk var/lib/db/sbom/hello-2.12-4-r0.spdx.json | jq) \
-            <(tar -tvf x86_64/hello-2.12.4-r0.apk var/lib/db/sbom/hello-2.12-4-r0.spdx.json | jq) || true
+            <(tar -Oxf orig.apk var/lib/db/sbom/minimal-0.0.1-r0.spdx.json | jq) \
+            <(tar -tvf x86_64/minimal-0.0.1-r0.apk var/lib/db/sbom/minimal-0.0.1-r0.spdx.json | jq) || true
           echo ::endgroup::
 
           # Diff .melange.yaml
           echo ::group::.melange.yaml diff
           diff \
             <(tar -Oxf orig.apk .melange.yaml) \
-            <(tar -Oxf x86_64/hello-2.12.4-r0.apk .melange.yaml) || true
+            <(tar -Oxf x86_64/minimal-0.0.1-r0.apk .melange.yaml) || true
           echo ::endgroup::
 
           # Diff .PKGINFO
           echo ::group::.PKGINFO diff
           diff \
             <(tar -Oxf orig.apk .PKGINFO) \
-            <(tar -Oxf x86_64/hello-2.12.4-r0.apk .PKGINFO) || true
+            <(tar -Oxf x86_64/minimal-0.0.1-r0.apk .PKGINFO) || true
           echo ::endgroup::

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -163,10 +163,10 @@ jobs:
           ./melange keygen
 
           cd examples/
-          ./melange build minimal.yaml --arch=x86_64 --empty-workspace --namespace=wolfi
+          ../melange build minimal.yaml --arch=x86_64 --empty-workspace --namespace=wolfi
 
           mv packages/x86_64/minimal-0.0.1-r0.apk orig.apk
-          ./melange rebuild orig.apk
+          ../melange rebuild orig.apk
 
       - name: Diff filesystem
         run: |

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -166,53 +166,54 @@ jobs:
           ../melange build minimal.yaml --arch=x86_64 --empty-workspace --namespace=wolfi
 
           # This is a hack so that we can build `minimal.yaml` again, remove this when we get the path from the SBOM.
-          mv packages/x86_64/minimal-0.0.1-r0.apk ../orig.apk
-          ../melange rebuild ../orig.apk
+          mv packages/x86_64/minimal-0.0.1-r0.apk ../original.apk
+          ../melange rebuild ../original.apk
+          mv packages/x86_64/minimal-0.0.1-r0.apk ../rebuilt.apk
 
       - name: Diff filesystem
         run: |
           echo ::group::original
-          tar -tvf orig.apk | sort
+          tar -tvf original.apk | sort
           echo ::endgroup::
           echo ::group::rebuilt
-          tar -tvf packages/x86_64/minimal-0.0.1-r0.apk | sort
+          tar -tvf rebuilt.apk | sort
           echo ::endgroup::
           diff \
-            <(tar -tvf orig.apk | sort) \
-            <(tar -tvf packages/x86_64/minimal-0.0.1-r0.apk | sort) || true
+            <(tar -tvf original.apk | sort) \
+            <(tar -tvf rebuilt.apk | sort) || true
 
       - name: Diff SBOM
         run: |
           echo ::group::original
-          tar -Oxf orig.apk var/lib/db/sbom/minimal-0.0.1-r0.spdx.json | jq
+          tar -Oxf original.apk var/lib/db/sbom/minimal-0.0.1-r0.spdx.json | jq
           echo ::endgroup::
           echo ::group::rebuilt
-          tar -Oxf packages/x86_64/minimal-0.0.1-r0.apk var/lib/db/sbom/minimal-0.0.1-r0.spdx.json | jq
+          tar -Oxf rebuilt.apk var/lib/db/sbom/minimal-0.0.1-r0.spdx.json | jq
           echo ::endgroup::
           diff \
-            <(tar -Oxf orig.apk var/lib/db/sbom/minimal-0.0.1-r0.spdx.json | jq) \
-            <(tar -Oxf packages/x86_64/minimal-0.0.1-r0.apk var/lib/db/sbom/minimal-0.0.1-r0.spdx.json | jq) || true
+            <(tar -Oxf original.apk var/lib/db/sbom/minimal-0.0.1-r0.spdx.json | jq) \
+            <(tar -Oxf rebuilt.apk var/lib/db/sbom/minimal-0.0.1-r0.spdx.json | jq) || true
 
       - name: Diff .melange.yaml
         run: |
           echo ::group::original
-          tar -Oxf orig.apk .melange.yaml
+          tar -Oxf original.apk .melange.yaml
           echo ::endgroup::
           echo ::group::rebuilt
-          tar -Oxf packages/x86_64/minimal-0.0.1-r0.apk .melange.yaml
+          tar -Oxf rebuilt.apk .melange.yaml
           echo ::endgroup::
           diff \
-            <(tar -Oxf orig.apk .melange.yaml) \
-            <(tar -Oxf packages/x86_64/minimal-0.0.1-r0.apk .melange.yaml) || true
+            <(tar -Oxf original.apk .melange.yaml) \
+            <(tar -Oxf rebuilt.apk .melange.yaml) || true
 
       - name: Diff .PKGINFO
         run: |
           echo ::group::original
-          tar -Oxf orig.apk .PKGINFO
+          tar -Oxf original.apk .PKGINFO
           echo ::endgroup::
           echo ::group::rebuilt
-          tar -Oxf packages/x86_64/minimal-0.0.1-r0.apk .PKGINFO
+          tar -Oxf rebuilt.apk .PKGINFO
           echo ::endgroup::
           diff \
-            <(tar -Oxf orig.apk .PKGINFO) \
-            <(tar -Oxf packages/x86_64/minimal-0.0.1-r0.apk .PKGINFO) || true
+            <(tar -Oxf original.apk .PKGINFO) \
+            <(tar -Oxf rebuilt.apk .PKGINFO) || true

--- a/examples/minimal.yaml
+++ b/examples/minimal.yaml
@@ -1,6 +1,7 @@
 package:
   name: minimal
   version: 0.0.1
+  epoch: 0
   description: a very basic melange example
 
 environment:

--- a/pkg/cli/rebuild.go
+++ b/pkg/cli/rebuild.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"os"
 	"path/filepath"
 	"strings"

--- a/pkg/cli/rebuild.go
+++ b/pkg/cli/rebuild.go
@@ -69,6 +69,7 @@ func rebuild() *cobra.Command {
 					build.WithConfigFileLicense(cfgpkg.LicenseDeclared),
 					build.WithBuildDate(time.Unix(pkginfo.BuildDate, 0).UTC().Format(time.RFC3339)),
 					build.WithRunner(r),
+					build.WithOutDir("./packages/"), // TODO configurable?
 					build.WithConfig(f.Name())); err != nil {
 					return fmt.Errorf("failed to rebuild %q: %v", a, err)
 				}

--- a/pkg/cli/rebuild.go
+++ b/pkg/cli/rebuild.go
@@ -49,10 +49,6 @@ func rebuild() *cobra.Command {
 					return fmt.Errorf("failed to get config for %s: %v", a, err)
 				}
 
-				// TODO: This should not be necessary.
-				cfg.Environment.Contents.RuntimeRepositories = append(cfg.Environment.Contents.RuntimeRepositories, "https://packages.wolfi.dev/os")
-				cfg.Environment.Contents.Keyring = append(cfg.Environment.Contents.Keyring, "https://packages.wolfi.dev/os/wolfi-signing.rsa.pub")
-
 				// The name of this file gets included in the SBOM, so it must match the original file name.
 				f, err := os.Create(fmt.Sprintf("%s.yaml", cfg.Package.Name))
 				if err != nil {

--- a/pkg/cli/rebuild.go
+++ b/pkg/cli/rebuild.go
@@ -7,7 +7,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -16,6 +18,7 @@ import (
 	"chainguard.dev/apko/pkg/sbom/generator/spdx"
 	"chainguard.dev/melange/pkg/build"
 	"chainguard.dev/melange/pkg/config"
+	purl "github.com/package-url/packageurl-go"
 	"github.com/spf13/cobra"
 	"gopkg.in/ini.v1"
 	"gopkg.in/yaml.v3"
@@ -27,6 +30,7 @@ import (
 
 func rebuild() *cobra.Command {
 	var runner string
+	var archstrs []string
 	cmd := &cobra.Command{
 		Use:               "rebuild",
 		DisableAutoGenTag: true,
@@ -49,9 +53,17 @@ func rebuild() *cobra.Command {
 					return fmt.Errorf("failed to get config for %s: %v", a, err)
 				}
 
+				cfgpurl, err := purl.FromString(cfgpkg.ExternalRefs[0].Locator)
+				if err != nil {
+					return fmt.Errorf("failed to parse package URL %q: %v", cfgpkg.ExternalRefs[0].Locator, err)
+				}
+
 				// The name of this file gets included in the SBOM, so it must match the original file name.
 				// TODO: Get this path from the SBOM.
-				f, err := os.Create(fmt.Sprintf("%s.yaml", cfg.Package.Name))
+				if err := os.MkdirAll(filepath.Dir(cfgpurl.Subpath), 0755); err != nil {
+					return fmt.Errorf("failed to create directory for temporary file: %v", err)
+				}
+				f, err := os.Create(cfgpurl.Subpath)
 				if err != nil {
 					return fmt.Errorf("failed to create temporary file: %v", err)
 				}
@@ -59,12 +71,12 @@ func rebuild() *cobra.Command {
 					return fmt.Errorf("failed to encode stripped config: %v", err)
 				}
 				defer f.Close()
-				defer os.Remove(f.Name())
+				defer os.Remove(f.Name()) // TODO: THIS IS DESTRUCTIVE!! We need to make a copy and not have that mess up the path we embed into the SBOM's Purls.
 
 				if err := BuildCmd(ctx,
-					[]apko_types.Architecture{apko_types.Architecture("amd64")},          // TODO configurable, or detect
-					build.WithConfigFileRepositoryURL("https://github.com/wolfi-dev/os"), // TODO get this from the package SBOM
-					build.WithNamespace("wolfi"),                                         // TODO get this from the package SBOM
+					apko_types.ParseArchitectures(archstrs),
+					build.WithConfigFileRepositoryURL(fmt.Sprintf("https://github.com/%s/%s", cfgpurl.Namespace, cfgpurl.Name)),
+					build.WithNamespace(strings.ToLower(strings.TrimPrefix(cfgpkg.Originator, "Organization: "))),
 					build.WithConfigFileRepositoryCommit(cfgpkg.Version),
 					build.WithConfigFileLicense(cfgpkg.LicenseDeclared),
 					build.WithBuildDate(time.Unix(pkginfo.BuildDate, 0).UTC().Format(time.RFC3339)),
@@ -79,6 +91,7 @@ func rebuild() *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&runner, "runner", "", fmt.Sprintf("which runner to use to enable running commands, default is based on your platform. Options are %q", build.GetAllRunners()))
+	cmd.Flags().StringSliceVar(&archstrs, "arch", nil, "architectures to build for (e.g., x86_64,ppc64le,arm64) -- default is all, unless specified in config")
 	return cmd
 }
 
@@ -143,11 +156,10 @@ func getConfig(fn string) (*config.Configuration, *goapk.PackageInfo, *spdx.Pack
 			for _, p := range doc.Packages {
 				if strings.HasSuffix(p.Name, ".yaml") {
 					cfgpkg = &p
-					break
 				}
 			}
 			if cfgpkg == nil {
-				return nil, nil, nil, fmt.Errorf("failed to find config package info in SBOM: %v", err)
+				return nil, nil, nil, errors.New("failed to find config package info in SBOM")
 			}
 
 		default:

--- a/pkg/cli/rebuild.go
+++ b/pkg/cli/rebuild.go
@@ -50,6 +50,7 @@ func rebuild() *cobra.Command {
 				}
 
 				// The name of this file gets included in the SBOM, so it must match the original file name.
+				// TODO: Get this path from the SBOM.
 				f, err := os.Create(fmt.Sprintf("%s.yaml", cfg.Package.Name))
 				if err != nil {
 					return fmt.Errorf("failed to create temporary file: %v", err)

--- a/pkg/cli/rebuild.go
+++ b/pkg/cli/rebuild.go
@@ -29,7 +29,7 @@ import (
 
 func rebuild() *cobra.Command {
 	var runner string
-	var archstrs []string
+	var archstrs []string // TODO: Detect this from the APK somehow?
 	cmd := &cobra.Command{
 		Use:               "rebuild",
 		DisableAutoGenTag: true,

--- a/pkg/cli/rebuild.go
+++ b/pkg/cli/rebuild.go
@@ -53,6 +53,7 @@ func rebuild() *cobra.Command {
 				cfg.Environment.Contents.RuntimeRepositories = append(cfg.Environment.Contents.RuntimeRepositories, "https://packages.wolfi.dev/os")
 				cfg.Environment.Contents.Keyring = append(cfg.Environment.Contents.Keyring, "https://packages.wolfi.dev/os/wolfi-signing.rsa.pub")
 
+				// The name of this file gets included in the SBOM, so it must match the original file name.
 				f, err := os.Create(fmt.Sprintf("%s.yaml", cfg.Package.Name))
 				if err != nil {
 					return fmt.Errorf("failed to create temporary file: %v", err)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1379,34 +1379,36 @@ func ParseConfiguration(ctx context.Context, configurationFilePath string, opts 
 		GID:      apko_types.GID(&grp.GID),
 	}
 
-	if !slices.ContainsFunc(cfg.Environment.Accounts.Groups, func(g apko_types.Group) bool {
-		return g.GroupName == grpName
-	}) {
+	sameGroup := func(g apko_types.Group) bool { return g.GroupName == grpName }
+	if !slices.ContainsFunc(cfg.Environment.Accounts.Groups, sameGroup) {
 		cfg.Environment.Accounts.Groups = append(cfg.Environment.Accounts.Groups, grp)
 	}
-	if cfg.Test != nil && !slices.ContainsFunc(cfg.Test.Environment.Accounts.Groups, func(g apko_types.Group) bool {
-		return g.GroupName == grpName
-	}) {
+	if cfg.Test != nil && !slices.ContainsFunc(cfg.Test.Environment.Accounts.Groups, sameGroup) {
 		cfg.Test.Environment.Accounts.Groups = append(cfg.Test.Environment.Accounts.Groups, grp)
 	}
 	for _, sub := range cfg.Subpackages {
 		if sub.Test == nil || len(sub.Test.Pipeline) == 0 {
 			continue
 		}
-		sub.Test.Environment.Accounts.Groups = append(sub.Test.Environment.Accounts.Groups, grp)
+		if !slices.ContainsFunc(sub.Test.Environment.Accounts.Groups, sameGroup) {
+			sub.Test.Environment.Accounts.Groups = append(sub.Test.Environment.Accounts.Groups, grp)
+		}
 	}
 
-	if !slices.Contains(cfg.Environment.Accounts.Users, usr) {
+	sameUser := func(u apko_types.User) bool { return u.UserName == buildUser }
+	if !slices.ContainsFunc(cfg.Environment.Accounts.Users, sameUser) {
 		cfg.Environment.Accounts.Users = append(cfg.Environment.Accounts.Users, usr)
 	}
-	if cfg.Test != nil && !slices.Contains(cfg.Test.Environment.Accounts.Users, usr) {
+	if cfg.Test != nil && !slices.ContainsFunc(cfg.Test.Environment.Accounts.Users, sameUser) {
 		cfg.Test.Environment.Accounts.Users = append(cfg.Test.Environment.Accounts.Users, usr)
 	}
 	for _, sub := range cfg.Subpackages {
 		if sub.Test == nil || len(sub.Test.Pipeline) == 0 {
 			continue
 		}
-		sub.Test.Environment.Accounts.Users = append(sub.Test.Environment.Accounts.Users, usr)
+		if !slices.ContainsFunc(sub.Test.Environment.Accounts.Users, sameUser) {
+			sub.Test.Environment.Accounts.Users = append(sub.Test.Environment.Accounts.Users, usr)
+		}
 	}
 
 	// Merge environment file if needed.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -26,6 +26,7 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -1378,8 +1379,14 @@ func ParseConfiguration(ctx context.Context, configurationFilePath string, opts 
 		GID:      apko_types.GID(&grp.GID),
 	}
 
-	cfg.Environment.Accounts.Groups = append(cfg.Environment.Accounts.Groups, grp)
-	if cfg.Test != nil {
+	if !slices.ContainsFunc(cfg.Environment.Accounts.Groups, func(g apko_types.Group) bool {
+		return g.GroupName == grpName
+	}) {
+		cfg.Environment.Accounts.Groups = append(cfg.Environment.Accounts.Groups, grp)
+	}
+	if cfg.Test != nil && !slices.ContainsFunc(cfg.Test.Environment.Accounts.Groups, func(g apko_types.Group) bool {
+		return g.GroupName == grpName
+	}) {
 		cfg.Test.Environment.Accounts.Groups = append(cfg.Test.Environment.Accounts.Groups, grp)
 	}
 	for _, sub := range cfg.Subpackages {
@@ -1389,8 +1396,10 @@ func ParseConfiguration(ctx context.Context, configurationFilePath string, opts 
 		sub.Test.Environment.Accounts.Groups = append(sub.Test.Environment.Accounts.Groups, grp)
 	}
 
-	cfg.Environment.Accounts.Users = append(cfg.Environment.Accounts.Users, usr)
-	if cfg.Test != nil {
+	if !slices.Contains(cfg.Environment.Accounts.Users, usr) {
+		cfg.Environment.Accounts.Users = append(cfg.Environment.Accounts.Users, usr)
+	}
+	if cfg.Test != nil && !slices.Contains(cfg.Test.Environment.Accounts.Users, usr) {
 		cfg.Test.Environment.Accounts.Users = append(cfg.Test.Environment.Accounts.Users, usr)
 	}
 	for _, sub := range cfg.Subpackages {


### PR DESCRIPTION
This demonstrates that minimal no-op builds produce reproducible packages, with no diffs to metadata, filesystem, or melange config.

The only functional change to existing code is that adding the build user won't add it again if it's already specified.

Having this stake in the ground, we can detect future changes that inadvertently break reproducibility. We can also expand the set of configs that are checked for reproducibility and hopefully fix breaking issues in built in build pipelines, like `go/build`.