### PR TITLE
remove --create-build-log flag

### DIFF
--- a/docs/md/melange_build.md
+++ b/docs/md/melange_build.md
@@ -37,7 +37,6 @@ melange build [flags]
       --cleanup                                                 when enabled, the temp dir used for the guest will be cleaned up after completion (default true)
       --cpu string                                              default CPU resources to use for builds
       --cpumodel string                                         default memory resources to use for builds
-      --create-build-log                                        creates a package.log file containing a list of packages that were built by the command
       --debug                                                   enables debug logging of build pipelines
       --debug-runner                                            when enabled, the builder pod will persist after the build succeeds or fails
       --dependency-log string                                   log dependencies to a specified file

--- a/docs/md/melange_compile.md
+++ b/docs/md/melange_compile.md
@@ -35,7 +35,6 @@ melange compile [flags]
       --cache-dir string            directory used for cached inputs (default "./melange-cache/")
       --cache-source string         directory or bucket used for preloading the cache
       --cpu string                  default CPU resources to use for builds
-      --create-build-log            creates a package.log file containing a list of packages that were built by the command
       --debug                       enables debug logging of build pipelines
       --debug-runner                when enabled, the builder pod will persist after the build succeeds or fails
       --dependency-log string       log dependencies to a specified file

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -119,7 +119,6 @@ type Build struct {
 	ExtraPackages         []string
 	DependencyLog         string
 	BinShOverlay          string
-	CreateBuildLog        bool
 	CacheDir              string
 	ApkCacheDir           string
 	CacheSource           string

--- a/pkg/build/options.go
+++ b/pkg/build/options.go
@@ -285,16 +285,6 @@ func WithEnabledBuildOptions(enabledBuildOptions []string) Option {
 	}
 }
 
-// WithCreateBuildLog indicates whether to generate a package.log file containing the
-// list of packages that were built.  Some packages may have been skipped
-// during the build if , so it can be hard to know exactly which packages were built
-func WithCreateBuildLog(createBuildLog bool) Option {
-	return func(b *Build) error {
-		b.CreateBuildLog = createBuildLog
-		return nil
-	}
-}
-
 // WithDebug indicates whether debug logging of pipelines should be enabled.
 func WithDebug(debug bool) Option {
 	return func(b *Build) error {

--- a/pkg/build/package.go
+++ b/pkg/build/package.go
@@ -115,24 +115,6 @@ func (b *Build) Emit(ctx context.Context, pkg *config.Package) error {
 	return pc.EmitPackage(ctx)
 }
 
-// AppendBuildLog will create or append a list of packages that were built by melange build
-func (pc *PackageBuild) AppendBuildLog(dir string) error {
-	if !pc.Build.CreateBuildLog {
-		return nil
-	}
-
-	f, err := os.OpenFile(filepath.Join(dir, "packages.log"),
-		os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-
-	// separate with pipe so it is easy to parse
-	_, err = f.WriteString(fmt.Sprintf("%s|%s|%s|%s-r%d\n", pc.Arch, pc.OriginName, pc.PackageName, pc.Origin.Version, pc.Origin.Epoch))
-	return err
-}
-
 func (pc *PackageBuild) Identity() string {
 	return fmt.Sprintf("%s-%s-r%d", pc.PackageName, pc.Origin.Version, pc.Origin.Epoch)
 }
@@ -539,11 +521,6 @@ func (pc *PackageBuild) EmitPackage(ctx context.Context) error {
 	}
 
 	log.Infof("wrote %s", outFile.Name())
-
-	// add the package to the build log if requested
-	if err := pc.AppendBuildLog(""); err != nil {
-		log.Warnf("unable to append package log: %s", err)
-	}
 
 	return nil
 }

--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -65,7 +65,6 @@ func buildCmd() *cobra.Command {
 	var varsFile string
 	var purlNamespace string
 	var buildOption []string
-	var createBuildLog bool
 	var debug bool
 	var debugRunner bool
 	var interactive bool
@@ -173,7 +172,6 @@ func buildCmd() *cobra.Command {
 				build.WithVarsFile(varsFile),
 				build.WithNamespace(purlNamespace),
 				build.WithEnabledBuildOptions(buildOption),
-				build.WithCreateBuildLog(createBuildLog),
 				build.WithDebug(debug),
 				build.WithDebugRunner(debugRunner),
 				build.WithInteractive(interactive),
@@ -245,7 +243,6 @@ func buildCmd() *cobra.Command {
 	cmd.Flags().StringSliceVarP(&extraKeys, "keyring-append", "k", []string{}, "path to extra keys to include in the build environment keyring")
 	cmd.Flags().StringSliceVarP(&extraRepos, "repository-append", "r", []string{}, "path to extra repositories to include in the build environment")
 	cmd.Flags().StringSliceVar(&extraPackages, "package-append", []string{}, "extra packages to install for each of the build environments")
-	cmd.Flags().BoolVar(&createBuildLog, "create-build-log", false, "creates a package.log file containing a list of packages that were built by the command")
 	cmd.Flags().BoolVar(&debug, "debug", false, "enables debug logging of build pipelines")
 	cmd.Flags().BoolVar(&debugRunner, "debug-runner", false, "when enabled, the builder pod will persist after the build succeeds or fails")
 	cmd.Flags().BoolVarP(&interactive, "interactive", "i", false, "when enabled, attaches stdin with a tty to the pod on failure")

--- a/pkg/cli/compile.go
+++ b/pkg/cli/compile.go
@@ -54,7 +54,6 @@ func compile() *cobra.Command {
 	var purlNamespace string
 	var buildOption []string
 	var logPolicy []string
-	var createBuildLog bool
 	var debug bool
 	var debugRunner bool
 	var interactive bool
@@ -129,7 +128,6 @@ func compile() *cobra.Command {
 				build.WithVarsFile(varsFile),
 				build.WithNamespace(purlNamespace),
 				build.WithEnabledBuildOptions(buildOption),
-				build.WithCreateBuildLog(createBuildLog),
 				build.WithDebug(debug),
 				build.WithDebugRunner(debugRunner),
 				build.WithInteractive(interactive),
@@ -198,7 +196,6 @@ func compile() *cobra.Command {
 	cmd.Flags().StringSliceVarP(&extraKeys, "keyring-append", "k", []string{}, "path to extra keys to include in the build environment keyring")
 	cmd.Flags().StringSliceVarP(&extraRepos, "repository-append", "r", []string{}, "path to extra repositories to include in the build environment")
 	cmd.Flags().StringSliceVar(&extraPackages, "package-append", []string{}, "extra packages to install for each of the build environments")
-	cmd.Flags().BoolVar(&createBuildLog, "create-build-log", false, "creates a package.log file containing a list of packages that were built by the command")
 	cmd.Flags().BoolVar(&debug, "debug", false, "enables debug logging of build pipelines")
 	cmd.Flags().BoolVar(&debugRunner, "debug-runner", false, "when enabled, the builder pod will persist after the build succeeds or fails")
 	cmd.Flags().BoolVarP(&interactive, "interactive", "i", false, "when enabled, attaches stdin with a tty to the pod on failure")


### PR DESCRIPTION
This was seemingly broken a while ago while removing legacy build logging, and nobody noticed. Just removing the flag and all downstream code for it.