### PR TITLE
Add annotations field map[string]string

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -102,6 +102,8 @@ type Package struct {
 	Epoch uint64 `json:"epoch" yaml:"epoch"`
 	// A human-readable description of the package
 	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+	// Annotations for this package
+	Annotations map[string]string `json:"annotations,omitempty" yaml:"annotations,omitempty"`
 	// The URL to the package's homepage
 	URL string `json:"url,omitempty" yaml:"url,omitempty"`
 	// Optional: The git commit of the package build configuration
@@ -1165,6 +1167,7 @@ func replacePackage(r *strings.Replacer, commit string, in Package) Package {
 		Version:            r.Replace(in.Version),
 		Epoch:              in.Epoch,
 		Description:        r.Replace(in.Description),
+		Annotations:        replaceMap(r, in.Annotations),
 		URL:                r.Replace(in.URL),
 		Commit:             replaceCommit(commit, in.Commit),
 		TargetArchitecture: replaceAll(r, in.TargetArchitecture),

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -346,6 +346,28 @@ pipeline:
 	require.Equal(t, "https://example.com/foo-0.0.1.zip", cfg.Pipeline[1].Pipeline[0].Pipeline[2].With["uri"])
 }
 
+func Test_packageAnnotations(t *testing.T) {
+	ctx := slogtest.Context(t)
+	fp := filepath.Join(os.TempDir(), "melange-test-packageAnnotations")
+	if err := os.WriteFile(fp, []byte(`
+package:
+  name: annotations-workdir
+  version: 0.0.1
+  epoch: 1
+  annotations:
+    cgr.dev/ecosystem: python
+
+`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := ParseConfiguration(ctx, fp)
+	if err != nil {
+		t.Fatalf("failed to parse configuration: %s", err)
+	}
+
+	require.Equal(t, "python", cfg.Package.Annotations["cgr.dev/ecosystem"])
+}
+
 func TestDuplicateSubpackage(t *testing.T) {
 	ctx := slogtest.Context(t)
 


### PR DESCRIPTION
Adding an annotation field to Package so that arbitrary groupings can be made. In my case I want to use something like:

```
package:
  name: python-magic
  version: 0.0.1
  epoch: 1
  annotations:
    cgr.dev/ecosystem: python
```

I'd like to know this is a package for the python ecosystem, instead of grepping a bunch of files which makes me sad.