### PR TITLE
Add support in e2e-tests for melange build and then test.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@
 # vendor/
 .vscode/*
 
+local-melange.rsa
+local-melange.rsa.pub
 melange
 melange.rsa
 melange.rsa.pub

--- a/e2e-tests/README.md
+++ b/e2e-tests/README.md
@@ -6,6 +6,7 @@ Melange options are based on yaml file name.
 
  * `*-build.yaml`: run 'melange build'
  * `*-test.yaml`: run 'melange test'
+ * `*-build-test`: run 'melange build && melange test'
 
     If the yaml file name matches '*-nopkg', then the flag `--test-package-append`
     will be appended for `busybox` and `python-3`.  The intent of these tests

--- a/e2e-tests/greeter-build-test.yaml
+++ b/e2e-tests/greeter-build-test.yaml
@@ -1,0 +1,95 @@
+# 'greeter' is shell based 'hello world' with different output based on arg0.
+#
+# When executed with zero arguments, greeter will emit its greeting and exit.
+# When executed with 1 or more arguments it will emit "<greeting>, <argv[1]>"
+# 'greeting' is set to basename(argv[0]), unless basename(argv[0]) is 'greeter',
+# in which case the greeting is set to 'howdy'.
+#
+# The main package installs /usr/bin/greeter.
+# subpackages install symlinks to greeter (aloha, hello).
+#
+# The 'tester-blob' melange variable provides a function
+# 'testrun' that runs test.
+package:
+  name: greeter
+  version: 1.0
+  epoch: 0
+  dependencies:
+    runtime:
+      - dash-binsh
+
+environment:
+  contents:
+    packages:
+      - busybox
+
+data:
+  - name: greetings
+    items:
+      english: hello
+      hawaiian: aloha
+      latvian: sveiki
+
+pipeline:
+  - name: install greeter
+    runs: |
+      bdir=${{targets.destdir}}/usr/bin
+      mkdir -p "$bdir"
+      cat > "$bdir/greeter" <<"EOF"
+      #!/bin/sh
+      greeting=${0##*/}
+      [ "$greeting" = "greeter" ] && greeting="howdy"
+      echo "$greeting${1:+, $1}"
+      EOF
+      chmod 755 "$bdir/greeter"
+
+subpackages:
+  - range: greetings
+    name: ${{package.name}}-${{range.key}}
+    description: Greet in ${{range.key}}
+    dependencies:
+      runtime:
+        - ${{package.name}}
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.contextdir}}/usr/bin"
+          ln -s greeter ${{targets.contextdir}}/usr/bin/${{range.value}}
+    test:
+      pipeline:
+        - runs: |
+            ${{vars.tester-blob}}
+            testrun ${{range.value}}
+
+test:
+  pipeline:
+    - name: test-greeter
+      runs: |
+        ${{vars.tester-blob}}
+        testrun greeter howdy
+
+vars:
+  tester-blob: |
+    set +x
+    testfail() { echo "FAIL:" "$tname${1:+ - $*}" 1>&2; exit 1; }
+    testpass() { echo "PASS:" "$tname"; }
+    error() { echo "FATAL:" "$@" 1>&2; exit 1; }
+    testrun() {
+      local cmd="$1" greeting="${2:-$1}" tname="" expected="" out=""
+      [ -n "$cmd" ] || error "cmd must set cmd"
+
+      tname="'$cmd' is in PATH"
+      out=$(command -v $cmd) && testpass || testfail
+
+      expected="$greeting"
+      tname="'$cmd' outputs '$expected'"
+      out=$($cmd) || testfail "'$cmd' exited $?"
+      [ "$out" = "$expected" ] &&
+        testpass || testfail "found '$out'"
+
+      expected="$greeting, bob"
+      tname="'$cmd bob' outputs '$expected'"
+      out=$($cmd bob) || testfail "'$cmd bob' exited $?"
+      [ "$out" = "$expected" ] &&
+        testpass || testfail "found '$out'"
+      return 0
+    }

--- a/e2e-tests/run-tests
+++ b/e2e-tests/run-tests
@@ -22,23 +22,34 @@ if [ $# -eq 0 ]; then
     set -- *.yaml
 fi
 
+key="local-melange.rsa"
+if [ -f "$key" -a -f "$key.pub" ]; then
+    echo "using existing $key"
+else
+    melange keygen "$key" ||
+        { echo "failed to create local-melange signing key"; exit 1; }
+fi
+
 fails=""
 for yaml in "$@"; do
   args=""
-  op=""
+  ops=""
   base=${yaml%.yaml}
   case "$base" in
+    *-build-test)
+      ops="build test"
+      ;;
     *-nopkg-test)
-      op="test"
+      ops="test"
       args="$args --test-package-append busybox"
       args="$args --test-package-append=python-3"
       ;;
     *-test)
-      op="test"
+      ops="test"
       args="${base%-test}"
       ;;
     *-build)
-      op="build"
+      ops="build"
       ;;
     *)
       echo "ERROR: Unexpected input '$yaml'."
@@ -46,14 +57,23 @@ for yaml in "$@"; do
       ;;
   esac
 
-  vrc "Testing $base from $yaml" \
-    ${MELANGE} "$op" \
-      --arch=x86_64 --source-dir=./test-fixtures \
-      $yaml \
-      ${args} \
-      "--repository-append=https://packages.wolfi.dev/os" \
-      "--keyring-append=https://packages.wolfi.dev/os/wolfi-signing.rsa.pub" ||
-      fails="${fails} $yaml"
+  for op in $ops; do
+    opargs=""
+    case "$op" in
+        build) opargs="--signing-key=$PWD/$key";;
+    esac
+
+    vrc "Testing $base from $yaml for $op" \
+      ${MELANGE} "$op" \
+        --arch=x86_64 --source-dir=./test-fixtures \
+        "$yaml" \
+        ${args} $opargs \
+        "--keyring-append=$PWD/$key.pub" \
+        "--repository-append=$PWD/packages" \
+        "--repository-append=https://packages.wolfi.dev/os" \
+        "--keyring-append=https://packages.wolfi.dev/os/wolfi-signing.rsa.pub" ||
+        fails="${fails} $yaml/$op"
+  done
 done
 
 if [ -z "$fails" ]; then


### PR DESCRIPTION
 *  Add support in e2e-tests for melange build and then test.
    
    Now a yaml file in this directory named '*-build-test.yaml'
    will have 'melange build' run and then 'melange test'.
    
    Add creation of a signing key and ignore it in git-ignore.

 *  add greeter-build e2e-test that does build and test.
