### PR TITLE
DRAFT: bug(qemu runner): use gnutar for xattr+acl support

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -310,6 +310,7 @@ func (b *Build) buildGuest(ctx context.Context, imgConfig apko_types.ImageConfig
 	if b.Runner.Name() == container.QemuName {
 		b.ExtraPackages = append(b.ExtraPackages, []string{
 			"melange-microvm-init",
+			"gnutar", // needed for xattrs/acls when extracting built files in vm
 		}...)
 	}
 

--- a/pkg/container/qemu_runner.go
+++ b/pkg/container/qemu_runner.go
@@ -234,7 +234,7 @@ func (bw *qemu) WorkspaceTar(ctx context.Context, cfg *Config) (io.ReadCloser, e
 		nil,
 		outFile,
 		false,
-		[]string{"sh", "-c", "cd /home/build && tar cvzf - melange-out"},
+		[]string{"sh", "-c", "cd /home/build && tar cvpzf - --xattrs --acls melange-out"},
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Unlike the other runners which use a shared directory between the runner and the host OS, the qemu runner tars up the built artifacts in the vm and then untars them (through go's tar implementation) in the host environment, using busybox's tar.

There were two problems with this:

- --preserve-permissions (aka -p) was not being passed, so non-default permissions like setgid/setuid were not being captured in the tarball
- busybox tar reads PAX format tarfiles but does not generate them, so has no mechanism for including them in generated tarballs.

To fix this, convert to using gnutar by always including it in the environment when using the qemu runner, and secondly, pass the -p, --xattrs, and --acls arguments to tar so they are captured in the generated tarball.

This only partially addresses the issue, for two reasons:

1. melange is not setting xattrs when extracting from the tarball
2. in order for setuid root permissions and security xattrs (for fscaps) to be created in the host environment's file system, root (or more correctly, CAP_DAC_OVERRIDE, CAP_FOWNER, and CAP_SYSADMIN for setuid, acls, and fscap xatrrs respectively).

Fixes-partially: https://github.com/chainguard-dev/melange/issues/1731

## Melange Pull Request Template

<!--
*** PULL REQUEST CHECKLIST: PLEASE START HERE ***

The single most important feature of melange is that we can build Wolfi.

Many changes to melange introduce a risk of breaking the build, and sometimes
these are not flushed out until a package is changed (much) later.  This
pertains to basic execution, SCA changes, linter changes, and more.
-->

### Functional Changes

- [ ] This change can build all of Wolfi without errors (describe results in notes)

Notes:

### SCA Changes

- [ ] Examining several representative APKs show no regression / the desired effect (details in notes)

Notes:

### Linter

- [ ] The new check is clean across Wolfi
- [ ] The new check is opt-in or a warning

Notes:
