### PR TITLE
Add ${{context.name}} string substitution

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -121,7 +121,25 @@ jobs:
           mv packages stage3
       - name: Ensure melange package is reproducible
         run: |
-          sha256sum stage2/x86_64/*.apk | sed -e 's:stage2/:stage3/:g' | sha256sum -c
+          # echo compare stage2 and stage3
+          set -- stage2/x86_64/*.apk
+          if sha256sum "$@" | sed -e 's:stage2/:stage3/:g' | sha256sum -c; then
+            echo "PASS: stage2 == stage3 for $*"
+            exit 0
+          fi
+          set +x
+          echo "FATAL: stage2 and stage3 differed for $*."
+          for s2apk in $* ; do
+             s3apk=stage3/${s2apk#stage2/}
+             echo "== $s2apk -> $s3apk =="
+             tar -Oxf $s2apk .PKGINFO > stage2.info
+             tar -Oxf $s3apk .PKGINFO > stage3.info
+             diff -u stage2.info stage3.info || :
+             tar -tf $s2apk > stage2.flist
+             tar -tf $s3apk > stage3.flist
+             diff -u stage2.flist stage3.flist || :
+          done
+          exit 1
       - name: Verify operation of stage3 melange
         run: melange version
 

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -125,6 +125,8 @@ jobs:
           set -- stage2/x86_64/*.apk
           if sha256sum "$@" | sed -e 's:stage2/:stage3/:g' | sha256sum -c; then
             echo "PASS: stage2 == stage3 for $*"
+            sha256sum stage2/x86_64/*.apk
+            sha256sum stage3/x86_64/*.apk
             exit 0
           fi
           set +x

--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ Melange provides the following default substitutions which can be referenced in 
 | `${{package.description}}`  | Package description                                                      |
 | `${{package.srcdir}}`       | Package source directory (`--source-dir`)                                |
 | `${{subpkg.name}}`          | Subpackage name                                                          |
+| `${{context.name}}`         | main package or subpackage name
 | `${{targets.outdir}}`       | Directory where targets will be stored                                   |
 | `${{targets.contextdir}}`   | Directory where targets will be stored for main packages and subpackages |
 | `${{targets.destdir}}`      | Directory where targets will be stored for main                          |

--- a/pkg/build/pipeline.go
+++ b/pkg/build/pipeline.go
@@ -68,6 +68,7 @@ type SubstitutionMap struct {
 func (sm *SubstitutionMap) Subpackage(subpkg *config.Subpackage) *SubstitutionMap {
 	nw := maps.Clone(sm.Substitutions)
 	nw[config.SubstitutionSubPkgName] = subpkg.Name
+	nw[config.SubstitutionContextName] = subpkg.Name
 	nw[config.SubstitutionSubPkgDir] = fmt.Sprintf("/home/build/melange-out/%s", subpkg.Name)
 	nw[config.SubstitutionTargetsContextdir] = nw[config.SubstitutionSubPkgDir]
 
@@ -86,6 +87,7 @@ func NewSubstitutionMap(cfg *config.Configuration, arch apkoTypes.Architecture, 
 		config.SubstitutionTargetsOutdir:      "/home/build/melange-out",
 		config.SubstitutionTargetsDestdir:     fmt.Sprintf("/home/build/melange-out/%s", pkg.Name),
 		config.SubstitutionTargetsContextdir:  fmt.Sprintf("/home/build/melange-out/%s", pkg.Name),
+		config.SubstitutionContextName:        pkg.Name,
 	}
 
 	nw[config.SubstitutionHostTripletGnu] = arch.ToTriplet(flavor)

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -62,6 +62,7 @@ subpackages:
     test:
       pipeline:
         - runs: echo "${{subpkg.name}} test case"
+        - runs: echo "context.name=${{context.name}}"
 
 test:
   environment:
@@ -71,6 +72,8 @@ test:
         - replacement-provides-${{vars.short-package-version}}
     environment:
       LD_LIBRARY_PATH: "/usr/local/${{vars.foo}}"
+  pipeline:
+    - runs: "echo context.name=${{context.name}}"
 `), 0644); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/config/vars.go
+++ b/pkg/config/vars.go
@@ -33,6 +33,7 @@ const (
 	SubstitutionTargetsContextdir     = "${{targets.contextdir}}"
 	SubstitutionSubPkgName            = "${{subpkg.name}}"
 	SubstitutionSubPkgDir             = "${{targets.subpkgdir}}"
+	SubstitutionContextName           = "${{context.name}}"
 	SubstitutionHostTripletGnu        = "${{host.triplet.gnu}}"
 	SubstitutionHostTripletRust       = "${{host.triplet.rust}}"
 	SubstitutionCrossTripletGnuGlibc  = "${{cross.triplet.gnu.glibc}}"


### PR DESCRIPTION
Many of the places where subpkg.name is used now would be even nicer with a context-specific name.

Ie, we have this stanza in wolfi lots of times:

    uses: test/ldd-check
    with:
      packages: ${{subpkg.name}}

But if we changed the default in test/ldd-check to be 'context.name' then we could replace those with:

    uses: test/ldd-check
