### PR TITLE
rebuild: populate Config directly without file

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,4 +1,4 @@
-name: e2e melange bootstrap + build
+name: e2e tests
 
 on:
   push:
@@ -57,99 +57,18 @@ jobs:
             docker run --rm -v $(pwd)/sbom.json:/sbom.json --entrypoint "sh" cgr.dev/chainguard/wolfi-base -c "apk add spdx-tools-java && tools-java Verify /sbom.json"
           done
 
-  bootstrap:
-    name: bootstrap package
-    runs-on: ubuntu-latest
-
-    permissions:
-      contents: read
-
-    container:
-      image: alpine:latest
-      options: |
-        --cap-add NET_ADMIN --cap-add SYS_ADMIN --security-opt seccomp=unconfined --security-opt apparmor:unconfined
-
-    steps:
-      - name: Fetch dependencies
-        run: |
-          cat >/etc/apk/repositories <<_EOF_
-          https://dl-cdn.alpinelinux.org/alpine/edge/main
-          https://dl-cdn.alpinelinux.org/alpine/edge/community
-          https://dl-cdn.alpinelinux.org/alpine/edge/testing
-          _EOF_
-
-          apk upgrade -Ua
-          apk add go cosign build-base git bubblewrap
-
-      - uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481 # v2.11.0
-        with:
-          egress-policy: audit
-
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
-        with:
-          go-version-file: "go.mod"
-      - name: Mark workspace as a safe repository
-        run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
-      - name: Build bootstrap melange tool (stage1)
-        run: make melange
-      - name: Generate a package signing keypair
-        run: |
-          ./melange keygen
-          mv melange.rsa.pub /etc/apk/keys
-      - name: Prepare build workspace for stage2
-        run: |
-          git clone . workspace-stage2/x86_64
-      - name: Build stage2 melange package with bootstrap melange
-        run: ./melange build --pipeline-dir=pipelines/ --signing-key=melange.rsa --arch x86_64 --workspace-dir ${{github.workspace}}/workspace-stage2/
-      - name: Install stage2 melange package
-        run: apk add ./packages/x86_64/melange-*.apk
-      - name: Move stage2 artifacts to stage2 directory
-        run: |
-          mv packages stage2
-      - name: Verify operation of stage2 melange
-        run: melange version
-      - name: Prepare build workspace for stage3
-        run: |
-          git clone . workspace-stage3/x86_64
-      - name: Build stage3 melange package with stage2 melange
-        run: melange build --signing-key=melange.rsa --arch x86_64 --workspace-dir ${{github.workspace}}/workspace-stage3/
-      - name: Install stage3 melange package
-        run: apk add ./packages/x86_64/melange-*.apk
-      - name: Move stage3 artifacts to stage3 directory
-        run: |
-          mv packages stage3
-      - name: Ensure melange package is reproducible
-        run: |
-          # echo compare stage2 and stage3
-          set -- stage2/x86_64/*.apk
-          if sha256sum "$@" | sed -e 's:stage2/:stage3/:g' | sha256sum -c; then
-            echo "PASS: stage2 == stage3 for $*"
-            sha256sum stage2/x86_64/*.apk
-            sha256sum stage3/x86_64/*.apk
-            exit 0
-          fi
-          set +x
-          echo "FATAL: stage2 and stage3 differed for $*."
-          for s2apk in $* ; do
-             s3apk=stage3/${s2apk#stage2/}
-             echo "== $s2apk -> $s3apk =="
-             tar -Oxf $s2apk .PKGINFO > stage2.info
-             tar -Oxf $s3apk .PKGINFO > stage3.info
-             diff -u stage2.info stage3.info || :
-             tar -tf $s2apk > stage2.flist
-             tar -tf $s3apk > stage3.flist
-             diff -u stage2.flist stage3.flist || :
-          done
-          exit 1
-      - name: Verify operation of stage3 melange
-        run: melange version
-
   rebuild:
-    name: test rebuild
+    name: rebuild
     runs-on: ubuntu-latest
     permissions:
       contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        cfg:
+          - examples/minimal.yaml
+          - melange.yaml
 
     container:
       image: alpine:latest
@@ -168,12 +87,6 @@ jobs:
 
       - name: Fetch dependencies
         run: |
-          cat >/etc/apk/repositories <<_EOF_
-          https://dl-cdn.alpinelinux.org/alpine/edge/main
-          https://dl-cdn.alpinelinux.org/alpine/edge/community
-          https://dl-cdn.alpinelinux.org/alpine/edge/testing
-          _EOF_
-
           apk upgrade -Ua
           apk add go build-base git bubblewrap jq
 
@@ -182,13 +95,11 @@ jobs:
           make melange
           ./melange keygen
 
-          cd examples/
-          ../melange build minimal.yaml --arch=x86_64 --empty-workspace --namespace=wolfi
+          ./melange build ${{matrix.cfg}} --arch=x86_64 --namespace=wolfi
+          mv packages/x86_64/*.apk original.apk
 
-          # This is a hack so that we can build `minimal.yaml` again, remove this when we get the path from the SBOM.
-          mv packages/x86_64/minimal-0.0.1-r0.apk ../original.apk
-          ../melange rebuild ../original.apk --arch=x86_64
-          mv packages/x86_64/minimal-0.0.1-r0.apk ../rebuilt.apk
+          ./melange rebuild original.apk --arch=x86_64
+          mv packages/x86_64/*.apk rebuilt.apk
 
       - name: Diff filesystem
         if: always()
@@ -207,14 +118,14 @@ jobs:
         if: always()
         run: |
           echo ::group::original
-          tar -Oxf original.apk var/lib/db/sbom/minimal-0.0.1-r0.spdx.json | jq
+          tar -Oxf original.apk var/lib/db/sbom/ | jq
           echo ::endgroup::
           echo ::group::rebuilt
-          tar -Oxf rebuilt.apk var/lib/db/sbom/minimal-0.0.1-r0.spdx.json | jq
+          tar -Oxf rebuilt.apk var/lib/db/sbom/ | jq
           echo ::endgroup::
           diff \
-            <(tar -Oxf original.apk var/lib/db/sbom/minimal-0.0.1-r0.spdx.json | jq) \
-            <(tar -Oxf rebuilt.apk var/lib/db/sbom/minimal-0.0.1-r0.spdx.json | jq) && echo "No diff!"
+            <(tar -Oxf original.apk var/lib/db/sbom/ | jq) \
+            <(tar -Oxf rebuilt.apk var/lib/db/sbom/ | jq) && echo "No diff!"
 
       - name: Diff .melange.yaml
         if: always()

--- a/pkg/build/compile.go
+++ b/pkg/build/compile.go
@@ -116,7 +116,7 @@ func (t *Test) Compile(ctx context.Context) error {
 // Compile compiles all configuration, including tests, by loading any pipelines and substituting all variables.
 func (b *Build) Compile(ctx context.Context) error {
 	cfg := b.Configuration
-	sm, err := NewSubstitutionMap(&cfg, b.Arch, b.buildFlavor(), b.EnabledBuildOptions)
+	sm, err := NewSubstitutionMap(cfg, b.Arch, b.buildFlavor(), b.EnabledBuildOptions)
 	if err != nil {
 		return err
 	}

--- a/pkg/build/compile_test.go
+++ b/pkg/build/compile_test.go
@@ -35,7 +35,7 @@ func TestCompileEmpty(t *testing.T) {
 	}
 
 	build := &Build{
-		Configuration: config.Configuration{
+		Configuration: &config.Configuration{
 			Subpackages: []config.Subpackage{{}},
 		},
 	}
@@ -47,7 +47,7 @@ func TestCompileEmpty(t *testing.T) {
 
 func TestInheritWorkdir(t *testing.T) {
 	build := &Build{
-		Configuration: config.Configuration{
+		Configuration: &config.Configuration{
 			Pipeline: []config.Pipeline{{
 				WorkDir: "/work",
 				Pipeline: []config.Pipeline{{}, {

--- a/pkg/build/options.go
+++ b/pkg/build/options.go
@@ -21,6 +21,7 @@ import (
 
 	apko_types "chainguard.dev/apko/pkg/build/types"
 	"chainguard.dev/apko/pkg/options"
+	"chainguard.dev/melange/pkg/config"
 	"chainguard.dev/melange/pkg/container"
 )
 
@@ -30,6 +31,15 @@ type Option func(*Build) error
 func WithConfig(configFile string) Option {
 	return func(b *Build) error {
 		b.ConfigFile = configFile
+		return nil
+	}
+}
+
+// WithConfiguration sets the configuration used for the package build context, and the filename that should be reported for that.
+func WithConfiguration(config *config.Configuration, filename string) Option {
+	return func(b *Build) error {
+		b.ConfigFile = filename
+		b.Configuration = config
 		return nil
 	}
 }

--- a/pkg/cli/scan.go
+++ b/pkg/cli/scan.go
@@ -149,7 +149,7 @@ func scanCmd(ctx context.Context, file string, sc *scanConfig) error {
 		bb := &build.Build{
 			WorkspaceDir:    dir,
 			SourceDateEpoch: time.Unix(0, 0),
-			Configuration:   *cfg,
+			Configuration:   cfg,
 		}
 
 		pb := build.PackageBuild{


### PR DESCRIPTION
Prior to this change `build.New`'s options only accepted a config file path, which it would parse and use. The filename of the config is passed to the SBOM.

This complicated `rebuild` which doesn't have a real file path to rebuild, but it wanted to populate the same file path to be able to rebuild reproducibly.

With this change, `build.WithConfiguration(cfg, filename)` populates the pre-parsed config struct, and populates the filename to report in the SBOM, which is a little disingenuous, but 🤷.

I suspect there are lots of places where we call `build.New` with a temp file just to be able to pass it to `build.WithConfig(tmpfile)`, which we no longer need to do. If we find them, we can clean them up and maybe hopefully deprecate `WithConfig`.

I'm not married to the name `build.WithConfiguration`, if you have a better suggestion I'm open to it.

edit: while working on this PR, it seems the bootstrap test is broken now, potentially by a change in Go 1.24 that embeds the build commit and git tree state:

```
--rw-r--r-- root/root      2100 2022-11-29 01:05:10 var/lib/db/sbom/melange-0.0.1-r0.spdx.json
+-rw-r--r-- root/root      2133 2022-11-29 01:05:10 var/lib/db/sbom/melange-0.0.1-r0.spdx.json
```

```
-      "Tool: melange (0b48159)",
+      "Tool: melange (v0.0.0-20250226183030-0b48159d0fea+dirty)",
```

I've dropped the bootstrap test in this PR, and added coverage for melange itself in the rebuild matrix, which proves its reproducible given a fresh environment, instead of relying on local git state (which breaks reproducibility now)