### PR TITLE
pipelines/strip: slightly improve strip pipeline

### DIFF
--- a/pkg/build/pipelines/strip.yaml
+++ b/pkg/build/pipelines/strip.yaml
@@ -14,10 +14,22 @@ inputs:
 pipeline:
   - working-directory: ${{targets.contextdir}}
     runs: |
-      scanelf --recursive --nobanner --osabi --etype "ET_DYN,ET_EXEC" . \
-        | while read type osabi filename; do
+      check() { "$@" || { echo "[strip] FATAL: '$*' failed $?"; exit 1; }; }
 
+      scanout=$(mktemp)
+      check scanelf --recursive --nobanner --etype "ET_DYN,ET_EXEC" --format "%I %a" -o "$scanout" .
+
+      count=0
+      while read osabi arch filename; do
+        # Skip foreign binaries
+        case "${{build.arch}}" in
+          x86_64) [ "$arch" = "EM_X86_64" ] || continue;;
+          aarch64) [ "$arch" = "EM_AARCH64" ] || continue;;
+        esac
         [ "$osabi" != "STANDALONE" ] || continue
-        # scanelf may have picked up a temp file so verify that file still exists
-        strip ${{inputs.opts}} "${filename}" || [ ! -e "$filename" ]
-      done
+        check strip ${{inputs.opts}} "$filename"
+        count=$((count+1))
+      done < "$scanout"
+
+      echo "[strip] stripped $count ${{build.arch}} binaries in $PWD"
+      rm -f "$scanout"


### PR DESCRIPTION
Currently wolfi builds non-multiarch capable strip, which fails on
foreign binaries. Often foreign arch binaries are shipped by toolchain
test suites.

Make strip pipeline attempt to strip only binaries of the native arch.
