### PR TITLE
feat(build/pipelines): add llvm/covreport

### DIFF
--- a/pkg/build/pipelines/llvm/README.md
+++ b/pkg/build/pipelines/llvm/README.md
@@ -1,0 +1,20 @@
+<!-- start:pipeline-reference-gen -->
+# Pipeline Reference
+
+
+- [llvm/covreport](#llvmcovreport)
+
+## llvm/covreport
+
+Get coverage percentage with llvm-cov report
+
+### Inputs
+
+| Name | Required | Description | Default |
+| ---- | -------- | ----------- | ------- |
+| ignore-filename-regex | false | Exclude source code files from the report with file paths that match the given regular expression |  |
+| object | false | The path to the coverage executable or object file |  |
+| package | false | The llvm package to install | llvm-19 |
+
+
+<!-- end:pipeline-reference-gen -->

--- a/pkg/build/pipelines/llvm/covreport.yaml
+++ b/pkg/build/pipelines/llvm/covreport.yaml
@@ -1,0 +1,40 @@
+name: Get coverage percentage with llvm-cov report
+
+needs:
+  packages:
+    - ${{inputs.package}}
+
+inputs:
+  package:
+    description: The llvm package to install
+    default: llvm-19
+  object:
+    description: The path to the coverage executable or object file
+    default: ""
+  ignore-filename-regex:
+    description: Exclude source code files from the report with file paths that match the given regular expression
+    default: ""
+
+pipeline:
+  - runs: |
+      llvm-profdata merge \
+        --sparse default_*.profraw \
+        --output default.profdata
+      obj="${{inputs.object}}"
+      # Fallback to rough autodetection.
+      if [ -z "${obj}" ]; then
+        obj="/$(apk info -L ${{package.name}} 2>/dev/null | grep 'bin\/')"
+      elif ![ -f "${obj}" ]; then
+        obj=$(command -v ${obj})
+      fi
+      if [ -z "${obj}" ]; then
+        echo "Object not found. Required for llvm-cov report --object argument."
+        exit 1
+      fi
+      echo -n "Statements coverage: "
+      llvm-cov report \
+         --ignore-filename-regex="${{inputs.ignore-filename-regex}}" \
+         --instr-profile=default.profdata \
+         --object "${obj}" \
+         --summary-only 2>/dev/null \
+         | tail -1 | awk '{print $7}'


### PR DESCRIPTION
It produces a statements by functions based-coverage percentage report via llvm-profdata merge and llvm-cov report as summary. It requires the produced binary to be instrumented for coverage using the ‘llvm.instrprof.increment’ Intrinsic [1].


For instance:

```diff
diff --git a/helix.yaml b/helix.yaml
index e6e94fa50..9922e4737 100644
--- a/helix.yaml
+++ b/helix.yaml
@@ -25,6 +25,7 @@ pipeline:
   - name: Build
     uses: cargo/build
     with:
+      rustflags: "-C instrument-coverage"
       opts: --locked --profile opt
       output-dir: target/opt
       output: hx
@@ -51,3 +52,7 @@ test:
     - uses: test/ldd-check
       with:
         packages: ${{package.name}}
+    - uses: llvm/covreport
+      with:
+        # Exclude the sources for dependencies from the coverage results.
+        ignore-filename-regex: /.cargo/registry
```

> In example the _-C instrument-coverage_ `rustc` flag makes LLVM backend to instrument the resulting binary for coverage [2]

```shell
$ make test/helix
...
2025/02/27 20:48:14 INFO Statements coverage: 0.32%
```

1. https://llvm.org/docs/LangRef.html#llvm-instrprof-increment-intrinsic
2. https://doc.rust-lang.org/rustc/instrument-coverage.html#how-it-works