### PR TITLE
fix(pkg/build/pipelines/go/covdata.yaml): add jq dep

### DIFF
--- a/pkg/build/pipelines/go/covdata.yaml
+++ b/pkg/build/pipelines/go/covdata.yaml
@@ -5,6 +5,7 @@ needs:
   packages:
     - ${{inputs.package}}
     - busybox
+    - jq
 
 inputs:
   package:


### PR DESCRIPTION
This PR adds the missing `jq` runtime dependency for the pipeline to work, in order to parse the statements by function coverage profile generated by the go tool covdata.