### PR TITLE
set GOFIPS140=latest  (build setting) sets GODEBUG=fips140 to on by d…

### DIFF
--- a/pkg/build/pipelines/go/build.yaml
+++ b/pkg/build/pipelines/go/build.yaml
@@ -134,4 +134,9 @@ pipeline:
       [ -e /home/build/go.mod.local ] && cp /home/build/go.mod.local go.mod
       [ -e /home/build/go.sum.local ] && cp /home/build/go.sum.local go.sum
 
+      # Check if go-package is go-fips and set GOFIPS140 environment variable
+      if [ "${{inputs.go-package}}" == "go-fips" ]; then
+        export GOFIPS140=latest
+      fi
+
       GOAMD64="${{inputs.amd64}}" GOARM64="${{inputs.arm64}}" GOEXPERIMENT="${{inputs.experiments}}" go build -o "${{targets.contextdir}}"/${BASE_PATH} -tags "${{inputs.toolchaintags}},${{inputs.tags}}" -ldflags "${LDFLAGS}" -trimpath -buildmode ${{inputs.buildmode}} ${{inputs.extra-args}} ${{inputs.packages}}


### PR DESCRIPTION
https://tip.golang.org/doc/go1.24#fips140

GOFIPS140=latest (build setting) sets GODEBUG=fips140 to on by default. Replaces -tags=requirefips.