### PR TITLE
Expand the sample yaml in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,9 @@ pipeline:
 subpackages:
   - name: "hello-doc"
     description: "Documentation for hello"
+    dependencies:
+      runtime:
+        - foo
     pipeline:
       - uses: split/manpages
     test:
@@ -108,6 +111,7 @@ test:
   environment:
     contents:
       packages:
+        - bar
   pipeline:
     - runs: |
         hello

--- a/README.md
+++ b/README.md
@@ -94,6 +94,21 @@ pipeline:
   - uses: autoconf/make
   - uses: autoconf/make-install
   - uses: strip
+
+subpackages:
+  - name: "hello-doc"
+    description: "Documentation for hello"
+    pipeline:
+      - uses: split/manpages
+
+test:
+  environment:
+    contents:
+      packages:
+  pipeline:
+    - runs: |
+        hello
+        hello --version
 ```
 
 We can build this with:

--- a/README.md
+++ b/README.md
@@ -100,6 +100,9 @@ subpackages:
     description: "Documentation for hello"
     pipeline:
       - uses: split/manpages
+    test:
+      pipeline:
+        - uses: test/docs
 
 test:
   environment:


### PR DESCRIPTION
Since I'm still learning Wolfi packaging I find myself wanting to know what keys can go in a .yaml file and trying to remember when I can use what where. Instead of grep'ing all the yaml files in Wolfi it'd be better if there was a central place to look up the answer. README.md seemed to have a lot of the possibilities so I added some more.