### PR TITLE
linter: update usrmerge and make it required

### DIFF
--- a/docs/md/melange_build.md
+++ b/docs/md/melange_build.md
@@ -1,7 +1,7 @@
 ---
 title: "melange build"
 slug: melange_build
-url: /open-source/melange/reference/melange_build/
+url: /docs/md/melange_build.md
 draft: false
 images: []
 type: "article"
@@ -82,5 +82,5 @@ melange build [flags]
 
 ### SEE ALSO
 
-* [melange](/open-source/melange/reference/melange/)	 - 
+* [melange](/docs/md/melange.md)	 - 
 

--- a/docs/md/melange_build.md
+++ b/docs/md/melange_build.md
@@ -1,7 +1,7 @@
 ---
 title: "melange build"
 slug: melange_build
-url: /docs/md/melange_build.md
+url: /open-source/melange/reference/melange_build/
 draft: false
 images: []
 type: "article"
@@ -53,8 +53,8 @@ melange build [flags]
   -i, --interactive                                             when enabled, attaches stdin with a tty to the pod on failure
   -k, --keyring-append strings                                  path to extra keys to include in the build environment keyring
       --license string                                          license to use for the build config file itself (default "NOASSERTION")
-      --lint-require strings                                    linters that must pass (default [dev,infodir,tempdir,varempty])
-      --lint-warn strings                                       linters that will generate warnings (default [lddcheck,object,opt,pkgconf,python/docs,python/multiple,python/test,setuidgid,srv,strip,usrlocal,usrmerge,worldwrite])
+      --lint-require strings                                    linters that must pass (default [dev,infodir,tempdir,usrmerge,varempty])
+      --lint-warn strings                                       linters that will generate warnings (default [lddcheck,object,opt,pkgconf,python/docs,python/multiple,python/test,setuidgid,srv,strip,usrlocal,worldwrite])
       --memory string                                           default memory resources to use for builds
       --namespace string                                        namespace to use in package URLs in SBOM (eg wolfi, alpine) (default "unknown")
       --out-dir string                                          directory where packages will be output (default "./packages/")
@@ -82,5 +82,5 @@ melange build [flags]
 
 ### SEE ALSO
 
-* [melange](/docs/md/melange.md)	 - 
+* [melange](/open-source/melange/reference/melange/)	 - 
 

--- a/docs/md/melange_lint.md
+++ b/docs/md/melange_lint.md
@@ -1,7 +1,7 @@
 ---
 title: "melange lint"
 slug: melange_lint
-url: /docs/md/melange_lint.md
+url: /open-source/melange/reference/melange_lint/
 draft: false
 images: []
 type: "article"
@@ -29,8 +29,8 @@ melange lint [flags]
 
 ```
   -h, --help                   help for lint
-      --lint-require strings   linters that must pass (default [dev,infodir,tempdir,varempty])
-      --lint-warn strings      linters that will generate warnings (default [lddcheck,object,opt,pkgconf,python/docs,python/multiple,python/test,setuidgid,srv,strip,usrlocal,usrmerge,worldwrite])
+      --lint-require strings   linters that must pass (default [dev,infodir,tempdir,usrmerge,varempty])
+      --lint-warn strings      linters that will generate warnings (default [object,opt,pkgconf,python/docs,python/multiple,python/test,setuidgid,srv,strip,usrlocal,worldwrite])
 ```
 
 ### Options inherited from parent commands
@@ -41,5 +41,5 @@ melange lint [flags]
 
 ### SEE ALSO
 
-* [melange](/docs/md/melange.md)	 - 
+* [melange](/open-source/melange/reference/melange/)	 - 
 

--- a/docs/md/melange_lint.md
+++ b/docs/md/melange_lint.md
@@ -30,7 +30,7 @@ melange lint [flags]
 ```
   -h, --help                   help for lint
       --lint-require strings   linters that must pass (default [dev,infodir,tempdir,usrmerge,varempty])
-      --lint-warn strings      linters that will generate warnings (default [object,opt,pkgconf,python/docs,python/multiple,python/test,setuidgid,srv,strip,usrlocal,worldwrite])
+      --lint-warn strings      linters that will generate warnings (default [lddcheck,object,opt,pkgconf,python/docs,python/multiple,python/test,setuidgid,srv,strip,usrlocal,worldwrite])
 ```
 
 ### Options inherited from parent commands

--- a/docs/md/melange_lint.md
+++ b/docs/md/melange_lint.md
@@ -41,5 +41,5 @@ melange lint [flags]
 
 ### SEE ALSO
 
-* [melange](/docs/md/melange_lint.md)	 - 
+* [melange](/docs/md/melange.md)	 - 
 

--- a/docs/md/melange_lint.md
+++ b/docs/md/melange_lint.md
@@ -1,7 +1,7 @@
 ---
 title: "melange lint"
 slug: melange_lint
-url: /open-source/melange/reference/melange_lint/
+url: /docs/md/melange_lint.md
 draft: false
 images: []
 type: "article"
@@ -41,5 +41,5 @@ melange lint [flags]
 
 ### SEE ALSO
 
-* [melange](/open-source/melange/reference/melange/)	 - 
+* [melange](/docs/md/melange_lint.md)	 - 
 

--- a/pkg/linter/linter_test.go
+++ b/pkg/linter/linter_test.go
@@ -194,6 +194,33 @@ func TestLinters(t *testing.T) {
 	}, {
 		dirFunc: mkfile(t, "sbin/test.sh"),
 		linter:  "usrmerge",
+		pass:    false,
+	}, {
+		dirFunc: mkfile(t, "sbin"),
+		linter:  "usrmerge",
+		pass:    false,
+	}, {
+		dirFunc: mkfile(t, "bin"),
+		linter:  "usrmerge",
+		pass:    false,
+	}, {
+		dirFunc: func() string {
+			d := t.TempDir()
+			assert.NoError(t, os.MkdirAll(filepath.Join(d, filepath.Dir("/sbin")), 0700))
+			_ = os.Symlink("/sbin", "/dev/null")
+			return d
+		},
+		linter: "usrmerge",
+		pass:   true,
+	}, {
+		dirFunc: func() string {
+			d := t.TempDir()
+			assert.NoError(t, os.MkdirAll(filepath.Join(d, filepath.Dir("/bin")), 0700))
+			_ = os.Symlink("/bin", "/dev/null")
+			return d
+		},
+		linter: "usrmerge",
+		pass:   true,
 	}} {
 		ctx := slogtest.Context(t)
 		t.Run(c.linter, func(t *testing.T) {


### PR DESCRIPTION
## Melange Pull Request Template

Notes:

### Linter

- [X] The new check is clean across Wolfi


I don't have a just newest copy of wolf packages locally but the failures I see are all packages we've replaced.


```
❯ melange lint packages/aarch64/wolfi-baselayout-20230201-r18.apk 
2025/03/10 14:48:58 INFO Required checks: [dev infodir tempdir usrmerge varempty]
2025/03/10 14:48:58 INFO Warning checks: [lddcheck object opt pkgconf python/docs python/multiple python/test setuidgid srv strip usrlocal worldwrite]
2025/03/10 14:48:58 INFO linting apk: wolfi-baselayout (size: 14 kB)
2025/03/10 14:48:58 WARN linter "usrlocal" failed on package "wolfi-baselayout": /usr/local path found in non-compat package: usr/local/lib64; suggest: This package should be a -compat package
```


```
❯ melange lint packages/aarch64/util-linux-misc-2.40.1-r0.apk 
2025/03/10 15:09:37 INFO Required checks: [dev infodir tempdir usrmerge varempty]
2025/03/10 15:09:37 INFO Warning checks: [lddcheck object opt pkgconf python/docs python/multiple python/test setuidgid srv strip usrlocal worldwrite]
2025/03/10 15:09:37 WARN parsing .melange.yaml: could not open .melange.yaml file: file does not exist
2025/03/10 15:09:37 INFO linting apk: util-linux-misc (size: 3.7 MB)
2025/03/10 15:09:37 WARN linter "setuidgid" failed on package "util-linux-misc": file is setgid; suggest: Unset the setuid/setgid bit on the relevant files, or remove this linter
2025/03/10 15:09:37 ERRO linter "usrmerge" failed on package "util-linux-misc": package contains non-symlink file at /sbin or /bin in violation of usrmerge; suggest: Move binary to /usr/{bin,sbin}


~/work/wolfi main ≡
❯ melange lint packages/aarch64/util-linux-misc-2.40.4-r31.apk 
2025/03/10 15:10:02 INFO Required checks: [dev infodir tempdir usrmerge varempty]
2025/03/10 15:10:02 INFO Warning checks: [lddcheck object opt pkgconf python/docs python/multiple python/test setuidgid srv strip usrlocal worldwrite]
2025/03/10 15:10:02 INFO linting apk: util-linux-misc (size: 8.8 MB)
```
