### PR TITLE
fix(sca): Don't generate dependency on luajit

### DIFF
--- a/pkg/sca/sca.go
+++ b/pkg/sca/sca.go
@@ -668,7 +668,11 @@ func sonameLibver(soname string) string {
 func getShbang(fp io.Reader) (string, error) {
 	// python3 and sh are symlinks and generateCmdProviders currently only considers
 	// regular files. Since nothing will fulfill such a depend, do not generate one.
-	ignores := map[string]bool{"python3": true, "python": true, "sh": true, "awk": true}
+	//
+	// There are multiple variants of luajit; one maintained by OpenResty, and several
+	// per each fluent-bit stream. We don't want to pull in the incorrect variant so do
+	// not generate a dependency on cmd:luajit when found in a shebang.
+	ignores := map[string]bool{"python3": true, "python": true, "sh": true, "awk": true, "luajit": true}
 
 	buf := make([]byte, 80)
 	blen, err := io.ReadFull(fp, buf)


### PR DESCRIPTION
Both luajit and fluent-bit provide `cmd:luajit`. The `luajit` implementation for fluent-bit is specific to fluent-bit. `cmd:luajit` currently resolves to fluent-bit instead of luajit. A change in priority isn't enough as `cmd:luajit` will resolve to whatever's found first that satisfies the dependency (at the moment, that's fluent-bit)

Require that we're explicit with what we want here

This change does not impact any current packages in Wolfi