### PR TITLE
Add `directory` parameter for `fetch` to be passed to `tar -C`

### DIFF
--- a/examples/fetch-directory.yaml
+++ b/examples/fetch-directory.yaml
@@ -1,0 +1,23 @@
+package:
+  name: fetch-directory
+  version: 0.0.1
+  epoch: 0
+  description: "an example of how to use the directory option in the fetch pipeline"
+  copyright:
+    - license: Not-Applicable
+
+environment:
+  contents:
+    repositories:
+      - https://packages.wolfi.dev/os
+    keyring:
+      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    packages:
+      - busybox
+
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://unofficial-builds.nodejs.org/download/release/v22.9.0/node-v22.9.0-linux-x64-glibc-217.tar.gz
+      directory: /home/node/
+      delete: true

--- a/examples/fetch-directory.yaml
+++ b/examples/fetch-directory.yaml
@@ -20,4 +20,6 @@ pipeline:
     with:
       uri: https://unofficial-builds.nodejs.org/download/release/v22.9.0/node-v22.9.0-linux-x64-glibc-217.tar.gz
       directory: /home/node/
-      delete: true
+      delete: false
+
+  - runs: ls /home/node/*.tar.gz

--- a/pkg/build/pipelines/README.md
+++ b/pkg/build/pipelines/README.md
@@ -20,7 +20,7 @@ Fetch and extract external object into workspace
 | Name | Required | Description | Default |
 | ---- | -------- | ----------- | ------- |
 | delete | false | Whether to delete the fetched artifact after unpacking.  | false |
-| directory | false | The directory to extract the artifact into (passed to `tar -C`) | . |
+| directory | false | The directory to extract the artifact into (passed to `tar -C`)  | . |
 | dns-timeout | false | The timeout (in seconds) to use for DNS lookups. The fetch will fail if the timeout is hit.  | 20 |
 | expected-sha256 | false | The expected SHA256 of the downloaded artifact.  |  |
 | expected-sha512 | false | The expected SHA512 of the downloaded artifact.  |  |

--- a/pkg/build/pipelines/README.md
+++ b/pkg/build/pipelines/README.md
@@ -20,6 +20,7 @@ Fetch and extract external object into workspace
 | Name | Required | Description | Default |
 | ---- | -------- | ----------- | ------- |
 | delete | false | Whether to delete the fetched artifact after unpacking.  | false |
+| directory | false | The directory to extract the artifact into (passed to `tar -C`) | . |
 | dns-timeout | false | The timeout (in seconds) to use for DNS lookups. The fetch will fail if the timeout is hit.  | 20 |
 | expected-sha256 | false | The expected SHA256 of the downloaded artifact.  |  |
 | expected-sha512 | false | The expected SHA512 of the downloaded artifact.  |  |

--- a/pkg/build/pipelines/README.md
+++ b/pkg/build/pipelines/README.md
@@ -2,6 +2,7 @@
 
 This directory contains built-in pipelines. For more information on how to add
 new built-in pipelines, consult [Creating a new built-in pipeline](/docs/PIPELINES.md#creating-new-built-in-pipelines).
+
 <!-- start:pipeline-reference-gen -->
 # Pipeline Reference
 

--- a/pkg/build/pipelines/fetch.yaml
+++ b/pkg/build/pipelines/fetch.yaml
@@ -109,7 +109,7 @@ pipeline:
       fi
 
       if [ "${{inputs.extract}}" = "true" ]; then
-        tar -x '--strip-components=${{inputs.strip-components}}' '-C=${{inputs.directory}}' -f $bn
+        tar -x '--strip-components=${{inputs.strip-components}}' '-C ${{inputs.directory}}' -f $bn
       fi
 
       if [ "${{inputs.delete}}" = "true" ]; then

--- a/pkg/build/pipelines/fetch.yaml
+++ b/pkg/build/pipelines/fetch.yaml
@@ -109,7 +109,7 @@ pipeline:
       fi
 
       if [ "${{inputs.extract}}" = "true" ]; then
-        tar -x '--strip-components=${{inputs.strip-components}}' '-C ${{inputs.directory}}' -f $bn
+        tar -x '--strip-components=${{inputs.strip-components}}' -C '${{inputs.directory}}' -f $bn
       fi
 
       if [ "${{inputs.delete}}" = "true" ]; then

--- a/pkg/build/pipelines/fetch.yaml
+++ b/pkg/build/pipelines/fetch.yaml
@@ -10,6 +10,11 @@ inputs:
       The number of path components to strip while extracting.
     default: 1
 
+  directory:
+    description: |
+      The directory to extract the artifact into (passed to `tar -C`)
+    default: .
+
   extract:
     description: |
       Whether to extract the downloaded artifact as a source tarball.
@@ -104,7 +109,7 @@ pipeline:
       fi
 
       if [ "${{inputs.extract}}" = "true" ]; then
-        tar -x '--strip-components=${{inputs.strip-components}}' -f $bn
+        tar -x '--strip-components=${{inputs.strip-components}}' '-C=${{inputs.directory}}' -f $bn
       fi
 
       if [ "${{inputs.delete}}" = "true" ]; then


### PR DESCRIPTION
Howdy all 👋 I used https://github.com/chainguard-dev/melange/pull/1792 as a meter stick to compare this change against for conventions, etc. Next steps for me are:

- [x] 🧪 Ensure tests pass in CI
- [x] 👔 Ensure lint passes in CI
- [x] 🔐 Ensure my commits are properly signed
- [x] 🏗️ Use local `melange` build to build `wolfi`
- [x] ✅ Mark this PR as `Ready to Review` 

### Functional Changes

- [x] This change can build all of Wolfi without errors (describe results in notes)

Notes:

### SCA Changes

- [x] Examining several representative APKs show no regression / the desired effect (details in notes)

Notes:

### Linter

- [x] The new check is clean across Wolfi
- [x] The new check is opt-in or a warning

Notes:

👶🍼 This is my first contribution to `melange`, first time using it to build wolfi, etc. Your patience as I work through the checklist is appreciated 🙏 
