### PR TITLE
Store and apply xattrs correctly for all builds

### DIFF
--- a/.github/workflows/wolfi-presubmit.yaml
+++ b/.github/workflows/wolfi-presubmit.yaml
@@ -2,9 +2,9 @@ name: ci
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
 
 jobs:
   build-melange:
@@ -23,7 +23,7 @@ jobs:
 
       - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
-          go-version-file: './go.mod'
+          go-version-file: "./go.mod"
           check-latest: true
 
       - name: build
@@ -63,7 +63,7 @@ jobs:
           - tini
           - lzo
           - bubblewrap
-#          - gdk-pixbuf # Looks like this is broken again, see: https://gitlab.gnome.org/GNOME/gobject-introspection/-/issues/515
+          #- gdk-pixbuf # Looks like this is broken again, see: https://gitlab.gnome.org/GNOME/gobject-introspection/-/issues/515
           - gitsign
           - guac
           - mdbook
@@ -114,14 +114,14 @@ jobs:
         if: matrix.runner == 'qemu'
         run: |
           sudo apt-get update
-          sudo apt-get -y install qemu-system qemu-kvm
+          sudo apt-get -y install qemu-system-x86-64 qemu-kvm
 
       - name: Enable KVM group perms
         if: matrix.runner == 'qemu'
         run: |
-            echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
-            sudo udevadm control --reload-rules
-            sudo udevadm trigger --name-match=kvm
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
 
       - name: Make package ${{matrix.package}} with QEMU Runner
         if: matrix.runner == 'qemu'
@@ -134,6 +134,19 @@ jobs:
             MELANGE_EXTRA_OPTS="--runner qemu" \
             package/${{ matrix.package }}
 
+      - name: Run tests to verify xattrs with bubblewrap runner
+        if: matrix.runner == 'bubblewrap' && contains(fromJSON('["coredns", "fping"]'), matrix.package)
+        run: |
+          make SHELL="/bin/bash" MELANGE="sudo melange" test/${{ matrix.package }}
+
+      - name: Check package ${{ matrix.package }} xattrs for QEMU-built package
+        if: matrix.runner == 'qemu' && matrix.package == 'fping'
+        run: |
+          for pkg in packages/x86_64/*.apk; do
+            sudo tar --xattrs --xattrs-include='*.*' -xvf "${pkg}" -C packages/x86_64/
+          done
+          getcap packages/x86_64/usr/sbin/fping
+
       - name: "Retrieve Wolfi advisory data"
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -145,13 +158,13 @@ jobs:
 
       - name: Test installable and Scan for CVEs
         run: |
-            docker run --rm -v $(pwd):/work --workdir /work cgr.dev/chainguard/wolfi-base apk add --allow-untrusted packages/x86_64/${{ matrix.package }}-*.apk
+          docker run --rm -v $(pwd):/work --workdir /work cgr.dev/chainguard/wolfi-base apk add --allow-untrusted packages/x86_64/${{ matrix.package }}-*.apk
 
-            # There is a huge fixed cost for every wolfictl scan invocation for grype DB init.
-            # Do this outside of the loop in one invocation with every package.
-            wolfictl scan \
-            --advisories-repo-dir 'data/wolfi-advisories' \
-            --advisory-filter 'resolved' \
-            --require-zero \
-            packages/x86_64/${{ matrix.package }}-*.apk \
-            2> /dev/null # The error message renders strangely on GitHub Actions, and the important information is already being sent to stdout.
+          # There is a huge fixed cost for every wolfictl scan invocation for grype DB init.
+          # Do this outside of the loop in one invocation with every package.
+          wolfictl scan \
+          --advisories-repo-dir 'data/wolfi-advisories' \
+          --advisory-filter 'resolved' \
+          --require-zero \
+          packages/x86_64/${{ matrix.package }}-*.apk \
+          2> /dev/null # The error message renders strangely on GitHub Actions, and the important information is already being sent to stdout.

--- a/.github/workflows/wolfi-presubmit.yaml
+++ b/.github/workflows/wolfi-presubmit.yaml
@@ -143,7 +143,7 @@ jobs:
         if: matrix.runner == 'qemu' && matrix.package == 'fping'
         run: |
           for pkg in packages/x86_64/*.apk; do
-            sudo tar --xattrs --xattrs-include='*.*' -xvf "${pkg}" -C packages/x86_64/
+            sudo tar --xattrs --xattrs-include='*.*' -xf "${pkg}" -C packages/x86_64/
           done
           getcap packages/x86_64/usr/sbin/fping
 
@@ -158,8 +158,11 @@ jobs:
 
       - name: Test installable and Scan for CVEs
         run: |
-          docker run --rm -v $(pwd):/work --workdir /work cgr.dev/chainguard/wolfi-base apk add --allow-untrusted packages/x86_64/${{ matrix.package }}-*.apk
-
+          if [[ "${{ matrix.package }}" == "fping" ]]; then
+            docker run --rm -v $(pwd):/work --workdir /work cgr.dev/chainguard/wolfi-base /bin/sh -c "apk add --allow-untrusted packages/x86_64/${{ matrix.package }}-*.apk; apk add libcap-utils; getcap /usr/sbin/fping"
+          else
+            docker run --rm -v $(pwd):/work --workdir /work cgr.dev/chainguard/wolfi-base apk add --allow-untrusted packages/x86_64/${{ matrix.package }}-*.apk
+          fi
           # There is a huge fixed cost for every wolfictl scan invocation for grype DB init.
           # Do this outside of the loop in one invocation with every package.
           wolfictl scan \

--- a/.github/workflows/wolfi-presubmit.yaml
+++ b/.github/workflows/wolfi-presubmit.yaml
@@ -135,7 +135,7 @@ jobs:
             package/${{ matrix.package }}
 
       - name: Run tests to verify xattrs with bubblewrap runner
-        if: matrix.runner == 'bubblewrap' && contains(fromJSON('["coredns", "fping"]'), matrix.package)
+        if: matrix.runner == 'bubblewrap' && matrix.package == 'fping'
         run: |
           make SHELL="/bin/bash" MELANGE="sudo melange" test/${{ matrix.package }}
 

--- a/go.mod
+++ b/go.mod
@@ -42,6 +42,7 @@ require (
 	golang.org/x/crypto v0.36.0
 	golang.org/x/exp v0.0.0-20250218142911-aa4b98e5adaa
 	golang.org/x/sync v0.12.0
+	golang.org/x/sys v0.31.0
 	golang.org/x/term v0.30.0
 	golang.org/x/text v0.23.0
 	golang.org/x/time v0.11.0
@@ -215,7 +216,6 @@ require (
 	golang.org/x/mod v0.23.0 // indirect
 	golang.org/x/net v0.37.0 // indirect
 	golang.org/x/oauth2 v0.28.0 // indirect
-	golang.org/x/sys v0.31.0 // indirect
 	google.golang.org/genproto v0.0.0-20250303144028-a0af3efb3deb // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20250303144028-a0af3efb3deb // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250303144028-a0af3efb3deb // indirect

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -46,6 +46,7 @@ import (
 	"github.com/zealic/xignore"
 	"go.opentelemetry.io/otel"
 	"golang.org/x/exp/maps"
+	"golang.org/x/sys/unix"
 	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
 	"k8s.io/kube-openapi/pkg/util/sets"
@@ -949,9 +950,24 @@ func (b *Build) BuildPackage(ctx context.Context) error {
 		linterQueue = append(linterQueue, lintTarget)
 	}
 
+	// Store xattrs for use after the workspace is loaded into memory
+	xattrs, err := storeXattrs(b.WorkspaceDir)
+	if err != nil {
+		return fmt.Errorf("failed to store workspace xattrs: %w", err)
+	}
+
 	// Retrieve the post build workspace from the runner
 	log.Infof("retrieving workspace from builder: %s", cfg.PodID)
 	b.WorkspaceDirFS = apkofs.DirFS(b.WorkspaceDir)
+
+	// Apply xattrs to files in the new in-memory filesystem
+	for path, attrs := range xattrs {
+		for attr, data := range attrs {
+			if err := b.WorkspaceDirFS.SetXattr(path, attr, data); err != nil {
+				log.Warnf("failed to restore xattr %s on %s: %v\n", attr, path, err)
+			}
+		}
+	}
 
 	if err := b.retrieveWorkspace(ctx, b.WorkspaceDirFS); err != nil {
 		return fmt.Errorf("retrieving workspace: %w", err)
@@ -1334,4 +1350,67 @@ func sourceDateEpoch(defaultTime time.Time) (time.Time, error) {
 	}
 
 	return time.Unix(sec, 0).UTC(), nil
+}
+
+// Record on-disk xattrs set during package builds in order to apply them in the new in-memory filesystem
+// This will allow in-memory and bind mount runners to persist xattrs correctly
+func storeXattrs(dir string) (map[string]map[string][]byte, error) {
+	xattrs := make(map[string]map[string][]byte)
+	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		relPath, err := filepath.Rel(dir, path)
+		if err != nil {
+			return err
+		}
+
+		size, err := unix.Listxattr(path, nil)
+		if err != nil || size == 0 {
+			return nil
+		}
+
+		buf := make([]byte, size)
+		read, err := unix.Listxattr(path, buf)
+		if err != nil {
+			return nil
+		}
+
+		attrs := stringsFromByteSlice(buf[:read])
+		result := make(map[string][]byte)
+		for _, attr := range attrs {
+			s, err := unix.Getxattr(path, attr, nil)
+			if err != nil {
+				continue
+			}
+
+			data := make([]byte, s)
+			_, err = unix.Getxattr(path, attr, data)
+			if err != nil {
+				continue
+			}
+
+			result[attr] = data
+		}
+		xattrs[relPath] = result
+		return nil
+	})
+
+	return xattrs, err
+}
+
+// stringsFromByteSlice converts a sequence of attributes to a []string.
+// On Linux, each entry is a NULL-terminated string.
+// Taken from golang.org/x/sys/unix/syscall_linux_test.go.
+func stringsFromByteSlice(buf []byte) []string {
+	var result []string
+	off := 0
+	for i, b := range buf {
+		if b == 0 {
+			result = append(result, string(buf[off:i]))
+			off = i + 1
+		}
+	}
+	return result
 }

--- a/pkg/container/bubblewrap_runner.go
+++ b/pkg/container/bubblewrap_runner.go
@@ -287,16 +287,13 @@ func (b *bubblewrapOCILoader) LoadImage(ctx context.Context, layer v1.Layer, arc
 			continue
 		}
 
-		// only set xattrs if bubblewrap is effectively running as root
-		if os.Geteuid() == 0 {
-			for k, v := range hdr.PAXRecords {
-				if !strings.HasPrefix(k, "SCHILY.xattr.") {
-					continue
-				}
-				attrName := strings.TrimPrefix(k, "SCHILY.xattr.")
-				if err := unix.Setxattr(fullname, attrName, []byte(v), 0); err != nil {
-					return ref, fmt.Errorf("unable to set xattr %s on %s: %w", attrName, hdr.Name, err)
-				}
+		for k, v := range hdr.PAXRecords {
+			if !strings.HasPrefix(k, "SCHILY.xattr.") {
+				continue
+			}
+			attrName := strings.TrimPrefix(k, "SCHILY.xattr.")
+			if err := unix.Setxattr(fullname, attrName, []byte(v), 0); err != nil {
+				return ref, fmt.Errorf("unable to set xattr %s on %s: %w", attrName, hdr.Name, err)
 			}
 		}
 	}

--- a/pkg/container/qemu_runner.go
+++ b/pkg/container/qemu_runner.go
@@ -669,7 +669,7 @@ func createMicroVM(ctx context.Context, cfg *Config) error {
 		nil,
 		nil,
 		false,
-		[]string{"sh", "-c", "cp -r /mnt/. /home/build"},
+		[]string{"sh", "-c", "cp -a /mnt/. /home/build"},
 	)
 }
 


### PR DESCRIPTION
#1836 allowed xattrs to work for QEMU but broke xattrs for Bubblewrap and Docker. This PR stores any xattrs in the workspace directory prior to the in-memory filesystem being created and then applies them to the new filesystem afterward.

I tested this with all three runners and it seemed to work, though QEMU errored during extraction which is expected:
```
usr/sbin/fping
tar: setxattrat: Cannot set 'security.capability' extended attribute for file 'usr/sbin/fping': Operation not supported
```

This PR does not fix `getcap` tests in pipelines, but I'm not sure if that ever worked regularly or not. For example the fping `getcap` test shows nothing on `v0.22.2` prior to the QEMU changes:
```
2025/03/24 22:38:25 INFO running step "Test file capabilities"
2025/03/24 22:38:25 WARN + '[' -d /home/build ]
2025/03/24 22:38:25 WARN + cd /home/build
2025/03/24 22:38:25 WARN + getcap /usr/sbin/fping
2025/03/24 22:38:25 WARN + exit 0
```

That said, it does seem to work in QEMU with the current changes (which is the exact situation builds were in prior to this PR):
```
2025/03/24 17:43:17 INFO running step "Test file capabilities"
2025/03/24 17:43:17 WARN + '[' -d /home/build ]
2025/03/24 17:43:17 WARN + cd /home/build
2025/03/24 17:43:17 WARN + getcap /usr/sbin/fping
2025/03/24 17:43:17 WARN + exit 0
2025/03/24 17:43:17 INFO /usr/sbin/fping cap_net_raw=ep
```