### PR TITLE
check diff after rebuilding

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -112,77 +112,16 @@ jobs:
           fi
 
           ./melange build $path --arch=x86_64 --namespace=wolfi
-          mv packages/x86_64/*.apk original.apk
 
       - name: Rebuild
         run: |
-          ./melange rebuild original.apk --arch=x86_64
-          mv rebuilt-packages/x86_64/*.apk rebuilt.apk
-
-      - name: Diff filesystem
-        if: always()
-        run: |
-          echo ::group::original
-          tar -tvf original.apk
-          echo ::endgroup::
-          echo ::group::rebuilt
-          tar -tvf rebuilt.apk
-          echo ::endgroup::
-          diff \
-            <(tar -tvf original.apk) \
-            <(tar -tvf rebuilt.apk) && echo "No diff!"
-
-      - name: Diff SBOM
-        if: always()
-        run: |
-          echo ::group::original
-          tar -Oxf original.apk var/lib/db/sbom/ | jq
-          echo ::endgroup::
-          echo ::group::rebuilt
-          tar -Oxf rebuilt.apk var/lib/db/sbom/ | jq
-          echo ::endgroup::
-          diff \
-            <(tar -Oxf original.apk var/lib/db/sbom/ | jq) \
-            <(tar -Oxf rebuilt.apk var/lib/db/sbom/ | jq) && echo "No diff!"
-
-      - name: Diff .melange.yaml
-        if: always()
-        run: |
-          echo ::group::original
-          tar -Oxf original.apk .melange.yaml
-          echo ::endgroup::
-          echo ::group::rebuilt
-          tar -Oxf rebuilt.apk .melange.yaml
-          echo ::endgroup::
-          diff \
-            <(tar -Oxf original.apk .melange.yaml) \
-            <(tar -Oxf rebuilt.apk .melange.yaml) && echo "No diff!"
-
-      - name: Diff .PKGINFO
-        if: always()
-        run: |
-          echo ::group::original
-          tar -Oxf original.apk .PKGINFO
-          echo ::endgroup::
-          echo ::group::rebuilt
-          tar -Oxf rebuilt.apk .PKGINFO
-          echo ::endgroup::
-          diff \
-            <(tar -Oxf original.apk .PKGINFO) \
-            <(tar -Oxf rebuilt.apk .PKGINFO) && echo "No diff!"
-
-      - name: Diff digest
-        if: always()
-        run: |
-          diff \
-            <(sha256sum original.apk | cut -d' ' -f1) \
-            <(sha256sum rebuilt.apk | cut -d' ' -f1) && echo "No diff!"
+          ./melange rebuild packages/x86_64/*.apk --arch=x86_64
 
       - name: Upload APKs
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         if: always()
         with:
           path: |
-            original.apk
-            rebuilt.apk
+            packages/**
+            rebuilt-packages/**
           name: rebuild-${{matrix.cfg}}

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -101,7 +101,7 @@ jobs:
           apk upgrade -Ua
           apk add go build-base git bubblewrap jq
 
-      - name: Build and rebuild
+      - name: Build
         run: |
           make melange
           ./melange keygen
@@ -114,8 +114,10 @@ jobs:
           ./melange build $path --arch=x86_64 --namespace=wolfi
           mv packages/x86_64/*.apk original.apk
 
+      - name: Rebuild
+        run: |
           ./melange rebuild original.apk --arch=x86_64
-          mv packages/x86_64/*.apk rebuilt.apk
+          mv rebuilt-packages/x86_64/*.apk rebuilt.apk
 
       - name: Diff filesystem
         if: always()

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -10,57 +10,6 @@ env:
   SOURCE_DATE_EPOCH: 1669683910
 
 jobs:
-  examples:
-    name: build examples
-    runs-on: ubuntu-22.04
-
-    permissions:
-      contents: read
-
-    strategy:
-      fail-fast: false
-      matrix:
-        example:
-          - cargo-build.yaml
-          - git-checkout.yaml
-          - gnu-hello.yaml
-          - go-build.yaml
-          - mbedtls.yaml
-          - minimal.yaml
-          - npm-install.yaml
-          - pnpm-install.yaml
-          - sshfs.yaml
-
-    steps:
-      - uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481 # v2.11.0
-        with:
-          egress-policy: audit
-
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
-        with:
-          go-version-file: "go.mod"
-      - name: Build package
-        run: |
-          sudo apt-get update -y
-          sudo apt-get install -y bubblewrap
-
-          make melange
-          ./melange keygen
-          ./melange build --pipeline-dir=pipelines examples/${{matrix.example}} --arch=x86_64 --empty-workspace --repository-append=https://apk.cgr.dev/chainguard
-
-      - name: Check SBOM Conformance
-        run: |
-          set -euxo pipefail
-          for f in packages/x86_64/*.apk; do
-            tar -Oxf "$f" var/lib/db/sbom > sbom.json
-            echo ::group::sbom.json
-            cat sbom.json
-            echo ::endgroup::
-
-            docker run --rm -v $(pwd)/sbom.json:/sbom.json --entrypoint "sh" cgr.dev/chainguard/wolfi-base -c "apk add spdx-tools-java && tools-java Verify /sbom.json"
-          done
-
   rebuild:
     name: rebuild
     runs-on: ubuntu-latest
@@ -115,7 +64,7 @@ jobs:
 
       - name: Rebuild
         run: |
-          ./melange rebuild packages/x86_64/*.apk --arch=x86_64
+          ./melange rebuild ./packages/x86_64/*.apk --arch=x86_64
 
       - name: Upload APKs
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -50,11 +50,13 @@ jobs:
           apk upgrade -Ua
           apk add go build-base git bubblewrap jq
 
-      - name: Build
+      - name: Build melange
         run: |
           make melange
           ./melange keygen
 
+      - name: Build package
+        run: |
           path=examples/${{matrix.cfg}}
           if [ "${{matrix.cfg}}" == "melange.yaml" ]; then
             path="melange.yaml"
@@ -62,7 +64,7 @@ jobs:
 
           ./melange build $path --arch=x86_64 --namespace=wolfi
 
-      - name: Rebuild
+      - name: Rebuild package
         run: |
           ./melange rebuild ./packages/x86_64/*.apk --arch=x86_64
 

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -61,7 +61,7 @@ jobs:
           if [ "${{matrix.cfg}}" == "melange.yaml" ]; then
             path="melange.yaml"
           fi
-          ./melange build $path --namespace=wolfi
+          ./melange build $path --arch=x86_64 --namespace=wolfi
 
       - name: Rebuild package
         run: |

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -61,12 +61,11 @@ jobs:
           if [ "${{matrix.cfg}}" == "melange.yaml" ]; then
             path="melange.yaml"
           fi
-
-          ./melange build $path --arch=x86_64 --namespace=wolfi
+          ./melange build $path --namespace=wolfi
 
       - name: Rebuild package
         run: |
-          ./melange rebuild ./packages/x86_64/*.apk --arch=x86_64
+          ./melange rebuild ./packages/x86_64/*.apk
 
       - name: Upload APKs
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1

--- a/examples/cargo-build.yaml
+++ b/examples/cargo-build.yaml
@@ -61,7 +61,7 @@ data:
       pika: 'ochotona princeps'
 
 subpackages:
-  - range: subpackage
+  - range: lagomorphs
     name: "lagomorph-${{range.key}}"
     description: "data about the lagomorph ${{range.value}}"
     pipeline:

--- a/examples/cargo-build.yaml
+++ b/examples/cargo-build.yaml
@@ -52,3 +52,18 @@ test:
     - runs: |
         eza
         eza --version
+
+data:
+  - name: lagomorphs
+    items:
+      hare: 'lepus saxatilis'
+      rabbit: 'sylvìlagus floridanus'
+      pika: 'ochotona princeps'
+
+subpackages:
+  - range: subpackage
+    name: "lagomorph-${{range.key}}"
+    description: "data about the lagomorph ${{range.value}}"
+    pipeline:
+      - runs: |
+          echo "${{range.value}}" > ${{targets.contextdir}}/${{range.key}}

--- a/examples/pnpm-install.yaml
+++ b/examples/pnpm-install.yaml
@@ -29,6 +29,6 @@ pipeline:
       version: ${{package.version}}
       npm-package: pnpm
       # TODO: pnpm with overrides seems to make the package non-reproducible
-      #overrides: |
-      #  yargs@^17.0.0       # If yargs had a CVE fixed in ^17.0.0
-      #  get-stdin@^9.0.0    # If get-stdin had a CVE fixed in ^9.0.0
+      overrides: |
+        yargs@^17.0.0       # If yargs had a CVE fixed in ^17.0.0
+        get-stdin@^9.0.0    # If get-stdin had a CVE fixed in ^9.0.0

--- a/examples/pnpm-install.yaml
+++ b/examples/pnpm-install.yaml
@@ -29,6 +29,6 @@ pipeline:
       version: ${{package.version}}
       npm-package: pnpm
       # TODO: pnpm with overrides seems to make the package non-reproducible
-      overrides: |
-        yargs@^17.0.0       # If yargs had a CVE fixed in ^17.0.0
-        get-stdin@^9.0.0    # If get-stdin had a CVE fixed in ^9.0.0
+      #overrides: |
+      #  yargs@^17.0.0       # If yargs had a CVE fixed in ^17.0.0
+      #  get-stdin@^9.0.0    # If get-stdin had a CVE fixed in ^9.0.0

--- a/pkg/cli/rebuild.go
+++ b/pkg/cli/rebuild.go
@@ -31,7 +31,7 @@ import (
 // TODO: Avoid rebuilding twice when rebuilding two subpackages of the same origin.
 
 func rebuild() *cobra.Command {
-	var runner, arch, outDir string
+	var runner, outDir string
 	var diff bool
 	cmd := &cobra.Command{
 		Use:               "rebuild",
@@ -65,6 +65,8 @@ func rebuild() *cobra.Command {
 					continue
 				}
 
+				arch := pkginfo.Arch
+
 				if err := BuildCmd(ctx,
 					[]apko_types.Architecture{apko_types.ParseArchitecture(arch)},
 					build.WithConfigFileRepositoryURL(fmt.Sprintf("https://github.com/%s/%s", cfgpurl.Namespace, cfgpurl.Name)),
@@ -91,7 +93,6 @@ func rebuild() *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&runner, "runner", "", fmt.Sprintf("which runner to use to enable running commands, default is based on your platform. Options are %q", build.GetAllRunners()))
-	cmd.Flags().StringVar(&arch, "arch", "x86_64", "architecture to build for") // TODO: determine this from the package
 	cmd.Flags().BoolVar(&diff, "diff", true, "fail and show differences between the original and rebuilt packages")
 	cmd.Flags().StringVar(&outDir, "out-dir", "./rebuilt-packages/", "directory where packages will be output")
 	return cmd

--- a/pkg/cli/rebuild.go
+++ b/pkg/cli/rebuild.go
@@ -171,7 +171,12 @@ func diffAPKs(old, new string) error {
 		return fmt.Errorf("failed to open old APK %s: %v", old, err)
 	}
 	defer oldf.Close()
-	oldm, err := filemap(tar.NewReader(oldf))
+	oldgr, err := gzip.NewReader(oldf)
+	if err != nil {
+		return fmt.Errorf("failed to create gzip reader for old APK %s: %v", old, err)
+	}
+	defer oldgr.Close()
+	oldm, err := filemap(tar.NewReader(oldgr))
 	if err != nil {
 		return fmt.Errorf("failed to create file map for old APK %s: %v", old, err)
 	}
@@ -181,7 +186,12 @@ func diffAPKs(old, new string) error {
 		return fmt.Errorf("failed to open new APK %s: %v", new, err)
 	}
 	defer newf.Close()
-	newm, err := filemap(tar.NewReader(newf))
+	newgr, err := gzip.NewReader(newf)
+	if err != nil {
+		return fmt.Errorf("failed to create gzip reader for old APK %s: %v", old, err)
+	}
+	defer oldgr.Close()
+	newm, err := filemap(tar.NewReader(newgr))
 	if err != nil {
 		return fmt.Errorf("failed to create file map for new APK %s: %v", new, err)
 	}

--- a/pkg/cli/rebuild.go
+++ b/pkg/cli/rebuild.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -73,7 +74,7 @@ func rebuild() *cobra.Command {
 
 				if diff {
 					old := a
-					new := fmt.Sprintf("%s/%s/%s-%s-r%d.apk", outDir, arch, cfg.Package.Name, cfg.Package.Version, cfg.Package.Epoch)
+					new := filepath.Join(outDir, arch, fmt.Sprintf("%s-%s-r%d.apk", cfg.Package.Name, cfg.Package.Version, cfg.Package.Epoch))
 					if err := diffAPKs(old, new); err != nil {
 						return fmt.Errorf("failed to diff APKs %s and %s: %v", old, new, err)
 					}

--- a/pkg/cli/rebuild.go
+++ b/pkg/cli/rebuild.go
@@ -245,7 +245,7 @@ func filemap(tr *tar.Reader) (map[string]entry, error) {
 		if _, err := io.Copy(w, tr); err != nil {
 			return nil, fmt.Errorf("failed to hash file %s: %v", hdr.Name, err)
 		}
-		entry := entry{digest: fmt.Sprintf("%x", d.Sum(nil))}
+		entry := entry{digest: fmt.Sprintf("%x", h.Sum(nil))}
 		if isImportantPath(hdr.Name) {
 			entry.contents = buf.String()
 		}

--- a/pkg/cli/rebuild.go
+++ b/pkg/cli/rebuild.go
@@ -203,9 +203,9 @@ func diffAPKs(old, new string) error {
 		if n, ok := newm[k]; !ok {
 			errs = append(errs, fmt.Errorf("removed: %s", k))
 		} else if o != n {
-			errs = append(errs, fmt.Errorf("changed: %s; %s -> %s", k, o, n))
+			errs = append(errs, fmt.Errorf("changed: %s: digests %s -> %s", k, o.digest, n.digest))
 			if o.contents != n.contents {
-				errs = append(errs, fmt.Errorf("contents: %s:\n%s", k, cmp.Diff(o.contents, n.contents)))
+				errs = append(errs, fmt.Errorf("contents: %s (-old,new):\n%s", k, cmp.Diff(o.contents, n.contents)))
 			}
 		}
 	}
@@ -219,6 +219,8 @@ func diffAPKs(old, new string) error {
 
 type entry struct{ digest, contents string }
 
+// Some files should especially not have diffs, and so we want to surface those changes even more prominently.
+// Other paths which may have a diff will just be shown as digest changes, and users should inspect those diffs manually.
 func isImportantPath(path string) bool {
 	switch path {
 	case ".PKGINFO", ".melange.yaml":

--- a/pkg/cli/rebuild.go
+++ b/pkg/cli/rebuild.go
@@ -19,7 +19,7 @@ import (
 	"chainguard.dev/apko/pkg/sbom/generator/spdx"
 	"chainguard.dev/melange/pkg/build"
 	"chainguard.dev/melange/pkg/config"
-	"github.com/charmbracelet/log"
+	"github.com/chainguard-dev/clog"
 	"github.com/google/go-cmp/cmp"
 	purl "github.com/package-url/packageurl-go"
 	"github.com/spf13/cobra"
@@ -61,7 +61,7 @@ func rebuild() *cobra.Command {
 				}
 
 				if pkginfo.Origin != pkginfo.Name {
-					log.Warnf("skipping %q because it is a subpackage", a)
+					clog.Warnf("skipping %q because it is a subpackage", a)
 					continue
 				}
 


### PR DESCRIPTION
This adds a `rebuild --diff` flag (default `true`) that checks the just-rebuilt package for diffs against its original.

If there are diffs to `.PKGINFO`, `.melange.yaml` or the SBOM, those diffs are printed out, otherwise if a path has a different digest, only the path+digest is printed in the error.

This changes CI e2e to _only_ test build+rebuild scenarios, since they were mostly the same as those in the old `e2e` job -- this will require changes to our required checks.

This also drops the `rebuild --arch` flag, since it can detect the arch of the original package and use that.

This also "handles" (by ignoring) packages which are subpackages, which we'll want to fix in a future change. Attempting to rebuild a subpackage will warn and exit successfully for now.