### PR TITLE
rebuild: support subpackages

### DIFF
--- a/examples/cargo-build.yaml
+++ b/examples/cargo-build.yaml
@@ -52,18 +52,3 @@ test:
     - runs: |
         eza
         eza --version
-
-data:
-  - name: lagomorphs
-    items:
-      hare: 'lepus saxatilis'
-      rabbit: 'sylvìlagus floridanus'
-      pika: 'ochotona princeps'
-
-subpackages:
-  - range: lagomorphs
-    name: "lagomorph-${{range.key}}"
-    description: "data about the lagomorph ${{range.value}}"
-    pipeline:
-      - runs: |
-          echo "${{range.value}}" > ${{targets.contextdir}}/${{range.key}}

--- a/examples/minimal.yaml
+++ b/examples/minimal.yaml
@@ -17,3 +17,18 @@ pipeline:
   - runs: |
       mkdir -p "${{targets.destdir}}"
       echo "hello" > "${{targets.destdir}}/hello"
+
+data:
+  - name: lagomorphs
+    items:
+      hare: 'lepus saxatilis'
+      rabbit: 'sylvìlagus floridanus'
+      pika: 'ochotona princeps'
+
+subpackages:
+  - range: lagomorphs
+    name: "lagomorph-${{range.key}}"
+    description: "data about the lagomorph ${{range.value}}"
+    pipeline:
+      - runs: |
+          echo "${{range.value}}" > ${{targets.contextdir}}/${{range.key}}

--- a/pkg/cli/rebuild.go
+++ b/pkg/cli/rebuild.go
@@ -62,7 +62,7 @@ func rebuild() *cobra.Command {
 				arch := pkginfo.Arch
 
 				if pkginfo.Origin != pkginfo.Name && origins[pkginfo.Origin] {
-					clog.Warnf("skipping %q because it is a subpackage of package %q which was already rebuilt", a, pkginfo.Origin)
+					clog.Warnf("not rebuilding %q because it is a subpackage of package %q which was already rebuilt", a, pkginfo.Origin)
 				} else {
 					clog.Infof("rebuilding %q", a)
 					if err := BuildCmd(ctx,
@@ -83,7 +83,7 @@ func rebuild() *cobra.Command {
 
 				if diff {
 					old := a
-					new := filepath.Join(outDir, arch, fmt.Sprintf("%s-%s-r%d.apk", cfg.Package.Name, cfg.Package.Version, cfg.Package.Epoch))
+					new := filepath.Join(outDir, arch, fmt.Sprintf("%s-%s-r%d.apk", pkginfo.Name, pkginfo.Version, cfg.Package.Epoch))
 					clog.Infof("diffing %s and %s", old, new)
 					if err := diffAPKs(old, new); err != nil {
 						return fmt.Errorf("failed to diff APKs %s and %s: %v", old, new, err)

--- a/pkg/cli/rebuild.go
+++ b/pkg/cli/rebuild.go
@@ -61,8 +61,8 @@ func rebuild() *cobra.Command {
 
 				arch := pkginfo.Arch
 
-				if pkginfo.Origin != pkginfo.Name && origins[pkginfo.Origin] {
-					clog.Warnf("not rebuilding %q because it is a subpackage of package %q which was already rebuilt", a, pkginfo.Origin)
+				if origins[pkginfo.Origin] {
+					clog.Warnf("not rebuilding %q because was already rebuilt", a)
 				} else {
 					clog.Infof("rebuilding %q", a)
 					if err := BuildCmd(ctx,

--- a/pkg/cli/rebuild.go
+++ b/pkg/cli/rebuild.go
@@ -83,7 +83,7 @@ func rebuild() *cobra.Command {
 
 				if diff {
 					old := a
-					new := filepath.Join(outDir, arch, fmt.Sprintf("%s-%s-r%d.apk", pkginfo.Name, pkginfo.Version, cfg.Package.Epoch))
+					new := filepath.Join(outDir, arch, fmt.Sprintf("%s-%s.apk", pkginfo.Name, pkginfo.Version))
 					clog.Infof("diffing %s and %s", old, new)
 					if err := diffAPKs(old, new); err != nil {
 						return fmt.Errorf("failed to diff APKs %s and %s: %v", old, new, err)


### PR DESCRIPTION
In the last change, we'd just skip subpackages.

With this change, we'll rebuild a subpackage (effectively rebuilding its origin and all of its subpackages), and skip re-rebuilding other subpackages that share the same origins.

The intention is that if you `melange rebuild sub-a.apk origin.apk, sub-b.apk`, we'll:

1. rebuild `sub-a.apk` (effectively rebuilding `origin` and all its subpackages))
  a. diff `sub-a.apk` vs `./rebuilt-packages/sub-a.apk`
2. _not_ rebuild `origin.apk` (since it's already built)
  a. diff `origin.apk` vs `./rebuilt-packages/origin.apk`
3. _not_ rebuild `sub-b.apk` (since it's already built)
  a. diff `sub-b.apk` vs `./rebuilt-packages/sub-b.apk`.

Moved example subpackages from `examples/cargo-build.yaml` to `examples/minimal.yaml`.