### PR TITLE
linter: update usrmerge to include /usr/sbin

### DIFF
--- a/e2e-tests/ipset-build-test.yaml
+++ b/e2e-tests/ipset-build-test.yaml
@@ -36,7 +36,8 @@ pipeline:
         --build=${{host.triplet.gnu}} \
         --host=${{host.triplet.gnu}} \
         --with-kmod=no \
-        --prefix=/usr
+        --prefix=/usr \
+        --sbindir=/usr/bin \
 
   - uses: autoconf/make
 

--- a/pkg/linter/linter.go
+++ b/pkg/linter/linter.go
@@ -191,7 +191,7 @@ var linterMap = map[string]linter{
 	},
 	"usrmerge": {
 		LinterFunc:      usrmergeLinter,
-		Explain:         "Move binary to /usr/{bin,sbin}",
+		Explain:         "Move binary to /usr/bin",
 		defaultBehavior: Require,
 	},
 }
@@ -792,7 +792,7 @@ func usrmergeLinter(ctx context.Context, _ *config.Configuration, _ string, fsys
 
 		// We don't really care if a package is re-adding a symlink and this catches wolfi-baselayout
 		// without special casing it with the package name.
-		if path == "sbin" || path == "bin" {
+		if path == "sbin" || path == "bin" || path == "usr/sbin" {
 			if d.IsDir() || d.Type().IsRegular() {
 				return fmt.Errorf("package contains non-symlink file at /sbin or /bin in violation of usrmerge")
 			} else {
@@ -806,6 +806,10 @@ func usrmergeLinter(ctx context.Context, _ *config.Configuration, _ string, fsys
 
 		if strings.HasPrefix(path, "bin") {
 			return fmt.Errorf("package writes to /bin in violation of usrmerge: %s", path)
+		}
+
+		if strings.HasPrefix(path, "usr/sbin") {
+			return fmt.Errorf("package writes to /usr/sbin in violation of usrmerge: %s", path)
 		}
 
 		return nil

--- a/pkg/linter/linter_test.go
+++ b/pkg/linter/linter_test.go
@@ -192,6 +192,10 @@ func TestLinters(t *testing.T) {
 		cfg:     subpkgtlddcheckCfg,
 		pass:    true,
 	}, {
+		dirFunc: mkfile(t, "usr/sbin/test.sh"),
+		linter:  "usrmerge",
+		pass:    false,
+	}, {
 		dirFunc: mkfile(t, "sbin/test.sh"),
 		linter:  "usrmerge",
 		pass:    false,
@@ -204,10 +208,23 @@ func TestLinters(t *testing.T) {
 		linter:  "usrmerge",
 		pass:    false,
 	}, {
+		dirFunc: mkfile(t, "usr/sbin"),
+		linter:  "usrmerge",
+		pass:    false,
+	}, {
 		dirFunc: func() string {
 			d := t.TempDir()
 			assert.NoError(t, os.MkdirAll(filepath.Join(d, filepath.Dir("/sbin")), 0700))
 			_ = os.Symlink("/sbin", "/dev/null")
+			return d
+		},
+		linter: "usrmerge",
+		pass:   true,
+	}, {
+		dirFunc: func() string {
+			d := t.TempDir()
+			assert.NoError(t, os.MkdirAll(filepath.Join(d, filepath.Dir("/usr/sbin")), 0700))
+			_ = os.Symlink("/usr/sbin", "/dev/null")
 			return d
 		},
 		linter: "usrmerge",


### PR DESCRIPTION
## Melange Pull Request Template

Notes:

### Linter

- [X] The new check is clean across Wolfi
We've just usrmerged all of /usr/sbin in Wolfi.

Example run of select packages:
```
amelia-crate@amelia-crate-16 ~/w/packages> ~/work/melange/melange lint wolfi-baselayout-20230201-r20.apk
2025/03/31 13:36:44 INFO Required checks: [dev infodir tempdir usrmerge varempty]
2025/03/31 13:36:44 INFO Warning checks: [lddcheck object opt pkgconf python/docs python/multiple python/test setuidgid srv strip usrlocal worldwrite]
2025/03/31 13:36:44 INFO linting apk: wolfi-baselayout (size: 13 kB)
2025/03/31 13:36:44 WARN linter "usrlocal" failed on package "wolfi-baselayout": /usr/local path found in non-compat package: usr/local/lib64; suggest: This package should be a -compat package
amelia-crate@amelia-crate-16 ~/w/packages> ~/work/melange/melange lint wolfi-baselayout-20230201-r19.apk
2025/03/31 13:36:47 INFO Required checks: [dev infodir tempdir usrmerge varempty]
2025/03/31 13:36:47 INFO Warning checks: [lddcheck object opt pkgconf python/docs python/multiple python/test setuidgid srv strip usrlocal worldwrite]
2025/03/31 13:36:47 INFO linting apk: wolfi-baselayout (size: 13 kB)
2025/03/31 13:36:47 WARN linter "usrlocal" failed on package "wolfi-baselayout": /usr/local path found in non-compat package: usr/local/lib64; suggest: This package should be a -compat package
2025/03/31 13:36:47 ERRO linter "usrmerge" failed on package "wolfi-baselayout": package contains non-symlink file at /sbin or /bin in violation of usrmerge; suggest: Move binary to /usr/bin
amelia-crate@amelia-crate-16 ~/w/packages [1]> ~/work/melange/melange lint shadow-4.17.4-r40.apk
2025/03/31 13:39:33 INFO Required checks: [dev infodir tempdir usrmerge varempty]
2025/03/31 13:39:33 INFO Warning checks: [lddcheck object opt pkgconf python/docs python/multiple python/test setuidgid srv strip usrlocal worldwrite]
2025/03/31 13:39:33 INFO linting apk: shadow (size: 3.1 MB)
2025/03/31 13:39:33 WARN linter "setuidgid" failed on package "shadow": file is setuid; suggest: Unset the setuid/setgid bit on the relevant files, or remove this linter
amelia-crate@amelia-crate-16 ~/w/packages> ~/work/melange/melange lint shadow-4.17.4-r2.apk
2025/03/31 13:39:36 INFO Required checks: [dev infodir tempdir usrmerge varempty]
2025/03/31 13:39:36 INFO Warning checks: [lddcheck object opt pkgconf python/docs python/multiple python/test setuidgid srv strip usrlocal worldwrite]
2025/03/31 13:39:36 INFO linting apk: shadow (size: 3.1 MB)
2025/03/31 13:39:36 WARN linter "setuidgid" failed on package "shadow": file is setuid; suggest: Unset the setuid/setgid bit on the relevant files, or remove this linter
2025/03/31 13:39:36 ERRO linter "usrmerge" failed on package "shadow": package contains non-symlink file at /sbin or /bin in violation of usrmerge; suggest: Move binary to /usr/bin
amelia-crate@amelia-crate-16 ~/w/packages [1]>
```