### PR TITLE
autoconf: default bindir and sbindir to a usrmerged option

### DIFF
--- a/pkg/build/pipelines/autoconf/configure.yaml
+++ b/pkg/build/pipelines/autoconf/configure.yaml
@@ -39,6 +39,7 @@ pipeline:
         --host=${{inputs.host}} \
         --build=${{inputs.build}} \
         --prefix=/usr \
+        --sbindir=/usr/bin \
         --sysconfdir=/etc \
         --libdir=/usr/lib \
         --mandir=/usr/share/man \


### PR DESCRIPTION
## Melange Pull Request Template

<!--
*** PULL REQUEST CHECKLIST: PLEASE START HERE ***

The single most important feature of melange is that we can build Wolfi.

Many changes to melange introduce a risk of breaking the build, and sometimes
these are not flushed out until a package is changed (much) later.  This
pertains to basic execution, SCA changes, linter changes, and more.
-->

### Functional Changes

- [ ] This change can build all of Wolfi without errors (describe results in notes)

Notes:

### SCA Changes

- [X] Examining several representative APKs show no regression / the desired effect (details in notes)

Notes:

Tested with nsd.yaml in Wolfi as a representative. Succeeds in building yaml where `--sbindir` is specified (package-specified options correctly take precedence). Succeeds where `--sbindir` is not specified and produces usr/sbin merged packages by default. I did not test a whole world rebuild.

This would cause problems for any package which specifies `--prefix` as a value besides `/usr`, but does not specify `--sbindir`, relying on the default of `${prefix}/sbin`.

Here's the list of packages that this would change:
```
amelia-crate@amelia-crate-16 ~/w/os (main)> for pkg in (grep '\--prefix' (grep -ls autoconf/configure *) | grep -vE '=["\']?/usr/?["\']?(( .*$)|$)'); grep '\--sbindir' $(echo $pkg | sed 's/:.*//' ) >/dev/null || echo "$pkg has --prefix set t- non-user but
no --sbindir"; end
openjdk-11.yaml:        --prefix=/usr/lib/jvm/java-11-openjdk \ has --prefix set t- non-user but no --sbindir
openjdk-12.yaml:        --prefix=/usr/lib/jvm/java-12-openjdk \ has --prefix set t- non-user but no --sbindir
openjdk-13.yaml:        --prefix=/usr/lib/jvm/java-13-openjdk \ has --prefix set t- non-user but no --sbindir
openjdk-14.yaml:        --prefix=/usr/lib/jvm/java-14-openjdk \ has --prefix set t- non-user but no --sbindir
openjdk-15.yaml:        --prefix=/usr/lib/jvm/java-15-openjdk \ has --prefix set t- non-user but no --sbindir
openjdk-16.yaml:        --prefix=/usr/lib/jvm/java-16-openjdk \ has --prefix set t- non-user but no --sbindir
openjdk-17.yaml:        --prefix=/usr/lib/jvm/java-17-openjdk \ has --prefix set t- non-user but no --sbindir
openjdk-18.yaml:        --prefix=/usr/lib/jvm/java-18-openjdk \ has --prefix set t- non-user but no --sbindir
openjdk-19.yaml:        --prefix=/usr/lib/jvm/java-19-openjdk \ has --prefix set t- non-user but no --sbindir
openjdk-20.yaml:        --prefix=/usr/lib/jvm/java-20-openjdk \ has --prefix set t- non-user but no --sbindir
openjdk-21.yaml:        --prefix=/usr/lib/jvm/java-21-openjdk \ has --prefix set t- non-user but no --sbindir
openjdk-22.yaml:        --prefix=/usr/lib/jvm/java-22-openjdk \ has --prefix set t- non-user but no --sbindir
openjdk-23.yaml:        --prefix=/usr/lib/jvm/java-23-openjdk \ has --prefix set t- non-user but no --sbindir
openjdk-24.yaml:        --prefix=/usr/lib/jvm/java-24-openjdk \ has --prefix set t- non-user but no --sbindir
tomcat-native.yaml:        --prefix=/usr/lib/tomcat-native \ has --prefix set t- non-user but no --sbindir
amelia-crate@amelia-crate-16 ~/w/os (main)>
```