### PR TITLE
rebuild: don't require original file to rebuild

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ melange
 melange.rsa
 melange.rsa.pub
 packages/
+rebuilt-packages/
 .idea/
 bin/
 generated/

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -837,17 +837,18 @@ func (b *Build) BuildPackage(ctx context.Context) error {
 
 	if b.EmptyWorkspace {
 		log.Debugf("empty workspace requested")
-	} else if b.SourceDir == "" {
-		log.Debugf("no source dir provided")
 	} else {
 		// Prepare workspace directory
 		if err := os.MkdirAll(b.WorkspaceDir, 0o755); err != nil {
 			return fmt.Errorf("mkdir -p %s: %w", b.WorkspaceDir, err)
 		}
 
-		log.Infof("populating workspace %s from %s", b.WorkspaceDir, b.SourceDir)
-		if err := b.populateWorkspace(ctx, apkofs.DirFS(b.SourceDir)); err != nil {
-			return fmt.Errorf("unable to populate workspace: %w", err)
+		fs := apkofs.DirFS(b.SourceDir)
+		if fs != nil {
+			log.Infof("populating workspace %s from %s", b.WorkspaceDir, b.SourceDir)
+			if err := b.populateWorkspace(ctx, fs); err != nil {
+				return fmt.Errorf("unable to populate workspace: %w", err)
+			}
 		}
 	}
 

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -837,6 +837,8 @@ func (b *Build) BuildPackage(ctx context.Context) error {
 
 	if b.EmptyWorkspace {
 		log.Debugf("empty workspace requested")
+	} else if b.SourceDir == "" {
+		log.Debugf("no source dir provided")
 	} else {
 		// Prepare workspace directory
 		if err := os.MkdirAll(b.WorkspaceDir, 0o755); err != nil {

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -609,7 +609,7 @@ func (b *Build) populateCache(ctx context.Context) error {
 		return nil
 	}
 
-	cmm, err := cacheItemsForBuild(b.ConfigFile)
+	cmm, err := cacheItemsForBuild(b.Configuration)
 	if err != nil {
 		return fmt.Errorf("while determining which objects to fetch: %w", err)
 	}

--- a/pkg/build/cache.go
+++ b/pkg/build/cache.go
@@ -21,6 +21,7 @@ import (
 	"github.com/dprotaso/go-yit"
 	"gopkg.in/yaml.v3"
 
+	"chainguard.dev/melange/pkg/config"
 	"chainguard.dev/melange/pkg/renovate"
 )
 
@@ -62,12 +63,16 @@ func visitFetch(fetchNode *yaml.Node, cmm *CacheMembershipMap) error {
 
 // cacheItemsForBuild returns the relevant hashes to check against
 // a source cache for a given build as a CacheMembershipMap.
-func cacheItemsForBuild(configFile string) (CacheMembershipMap, error) {
+func cacheItemsForBuild(config *config.Configuration) (CacheMembershipMap, error) {
 	cmm := CacheMembershipMap{}
 
 	var rootNode yaml.Node
-	if err := loadConfig(configFile, &rootNode); err != nil {
-		return cmm, err
+	b, err := yaml.Marshal(config)
+	if err != nil {
+		return nil, err
+	}
+	if err := yaml.Unmarshal(b, &rootNode); err != nil {
+		return nil, err
 	}
 
 	// Find our main pipeline YAML node.

--- a/pkg/build/cache.go
+++ b/pkg/build/cache.go
@@ -16,7 +16,6 @@ package build
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/dprotaso/go-yit"
 	"gopkg.in/yaml.v3"
@@ -28,16 +27,6 @@ import (
 // CacheMembershipMap describes a mapping where keys map to 'true'
 // if present.
 type CacheMembershipMap map[string]bool
-
-// loadConfig loads a configuration into a rootNode.
-func loadConfig(configFile string, rootNode *yaml.Node) error {
-	configData, err := os.ReadFile(configFile)
-	if err != nil {
-		return err
-	}
-
-	return yaml.Unmarshal(configData, rootNode)
-}
 
 // visitFetch processes a fetch node, updating the cache membership map.
 func visitFetch(fetchNode *yaml.Node, cmm *CacheMembershipMap) error {

--- a/pkg/build/test.go
+++ b/pkg/build/test.go
@@ -237,7 +237,7 @@ func (t *Test) PopulateCache(ctx context.Context) error {
 		return nil
 	}
 
-	cmm, err := cacheItemsForBuild(t.ConfigFile)
+	cmm, err := cacheItemsForBuild(&t.Configuration)
 	if err != nil {
 		return fmt.Errorf("while determining which objects to fetch: %w", err)
 	}

--- a/pkg/cli/rebuild.go
+++ b/pkg/cli/rebuild.go
@@ -28,7 +28,7 @@ import (
 )
 
 func rebuild() *cobra.Command {
-	var runner, outDir string
+	var runner, outDir, sourceDir string
 	var diff bool
 	cmd := &cobra.Command{
 		Use:               "rebuild",
@@ -74,6 +74,7 @@ func rebuild() *cobra.Command {
 						build.WithBuildDate(time.Unix(pkginfo.BuildDate, 0).UTC().Format(time.RFC3339)),
 						build.WithRunner(r),
 						build.WithOutDir(outDir),
+						build.WithSourceDir(sourceDir),
 						build.WithConfiguration(cfg, cfgpurl.Subpath)); err != nil {
 						return fmt.Errorf("failed to rebuild %q: %v", a, err)
 					}
@@ -97,6 +98,7 @@ func rebuild() *cobra.Command {
 	cmd.Flags().StringVar(&runner, "runner", "", fmt.Sprintf("which runner to use to enable running commands, default is based on your platform. Options are %q", build.GetAllRunners()))
 	cmd.Flags().BoolVar(&diff, "diff", true, "fail and show differences between the original and rebuilt packages")
 	cmd.Flags().StringVar(&outDir, "out-dir", "./rebuilt-packages/", "directory where packages will be output")
+	cmd.Flags().StringVar(&sourceDir, "source-dir", "", "directory used for included sources")
 	return cmd
 }
 

--- a/pkg/cli/rebuild.go
+++ b/pkg/cli/rebuild.go
@@ -28,7 +28,7 @@ import (
 )
 
 func rebuild() *cobra.Command {
-	var runner, outDir, sourceDir string
+	var runner, outDir string
 	var diff bool
 	cmd := &cobra.Command{
 		Use:               "rebuild",
@@ -74,7 +74,6 @@ func rebuild() *cobra.Command {
 						build.WithBuildDate(time.Unix(pkginfo.BuildDate, 0).UTC().Format(time.RFC3339)),
 						build.WithRunner(r),
 						build.WithOutDir(outDir),
-						build.WithSourceDir(sourceDir),
 						build.WithConfiguration(cfg, cfgpurl.Subpath)); err != nil {
 						return fmt.Errorf("failed to rebuild %q: %v", a, err)
 					}
@@ -98,7 +97,6 @@ func rebuild() *cobra.Command {
 	cmd.Flags().StringVar(&runner, "runner", "", fmt.Sprintf("which runner to use to enable running commands, default is based on your platform. Options are %q", build.GetAllRunners()))
 	cmd.Flags().BoolVar(&diff, "diff", true, "fail and show differences between the original and rebuilt packages")
 	cmd.Flags().StringVar(&outDir, "out-dir", "./rebuilt-packages/", "directory where packages will be output")
-	cmd.Flags().StringVar(&sourceDir, "source-dir", "", "directory used for included sources")
 	return cmd
 }
 


### PR DESCRIPTION
Previously every time we'd tested `melange rebuild` it was just after we `melange build`ed, which meant we had the original config.yaml there.

When we don't, like when we `melange rebuild $WOLFI/packages/aarch64/foo.apk`, we might not have the original config _file_, but we will have the original config _struct_.

To rebuild reproducibly you still need the original private key though, if the package you're rebuilding is signed.

You also need the original `--source-dir`, so let's also add the `--source-dir` flag.