### PR TITLE
feat: Add support for secrets in the build environment

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -141,6 +141,7 @@ type Build struct {
 	DefaultTimeout        time.Duration
 	Auth                  map[string]options.Auth
 	IgnoreSignatures      bool
+	Secrets               []string
 
 	EnabledBuildOptions []string
 
@@ -1225,6 +1226,20 @@ func (b *Build) buildWorkspaceConfig(ctx context.Context) *container.Config {
 
 	for k, v := range b.Configuration.Environment.Environment {
 		cfg.Environment[k] = v
+	}
+
+	for _, secret := range b.Secrets {
+		// Split secret into key value pair
+		parsedSecret := strings.Split(secret, "=")
+
+		// Append to environment if successfully split
+		if len(parsedSecret) == 2 {
+			k := parsedSecret[0]
+			v := parsedSecret[1]
+			cfg.Environment[k] = v
+		} else {
+			log.Errorf("could not parse secret: %s", parsedSecret)
+		}
 	}
 
 	return &cfg

--- a/pkg/build/options.go
+++ b/pkg/build/options.go
@@ -422,3 +422,11 @@ func WithIgnoreSignatures(ignore bool) Option {
 		return nil
 	}
 }
+
+// WithSecrets specifies secrets that are appended to the build environment.
+func WithSecrets(secrets []string) Option {
+	return func(b *Build) error {
+		b.Secrets = secrets
+		return nil
+	}
+}

--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -81,6 +81,7 @@ func buildCmd() *cobra.Command {
 	var configFileGitCommit string
 	var configFileGitRepoURL string
 	var configFileLicense string
+	var secrets []string
 
 	var traceFile string
 
@@ -191,6 +192,7 @@ func buildCmd() *cobra.Command {
 				build.WithConfigFileRepositoryCommit(configFileGitCommit),
 				build.WithConfigFileRepositoryURL(configFileGitRepoURL),
 				build.WithConfigFileLicense(configFileLicense),
+				build.WithSecrets(secrets),
 			}
 
 			if len(args) > 0 {
@@ -263,6 +265,7 @@ func buildCmd() *cobra.Command {
 	cmd.Flags().StringVar(&configFileGitCommit, "git-commit", "", "commit hash of the git repository containing the build config file (defaults to detecting HEAD)")
 	cmd.Flags().StringVar(&configFileGitRepoURL, "git-repo-url", "", "URL of the git repository containing the build config file (defaults to detecting from configured git remotes)")
 	cmd.Flags().StringVar(&configFileLicense, "license", "NOASSERTION", "license to use for the build config file itself")
+	cmd.Flags().StringSliceVarP(&secrets, "secret", "s", []string{}, "secrets to pass to the build environment")
 
 	_ = cmd.Flags().Bool("fail-on-lint-warning", false, "DEPRECATED: DO NOT USE")
 	_ = cmd.Flags().MarkDeprecated("fail-on-lint-warning", "use --lint-require and --lint-warn instead")


### PR DESCRIPTION
This allows secrets to be passed to the build environment. Unlike env vars, secrets will not end up in the parsed melange config shipped with APKs