### PR TITLE
fix(pipelines/git-checkout): preserve ownership of existing files

### DIFF
--- a/e2e-tests/git-checkout-build.yaml
+++ b/e2e-tests/git-checkout-build.yaml
@@ -262,7 +262,7 @@ pipeline:
       if [[ $runner_user == $melange_user ]]; then
         # Ownership of existing files match the ownership of files created within the runner
         # (i.e. by the git-checkout pipeline tar --extract command).
-        expected=48
+        expected=49
       else
         # Ownership of existing files is not changed.
         expected=43

--- a/e2e-tests/git-checkout-build.yaml
+++ b/e2e-tests/git-checkout-build.yaml
@@ -253,21 +253,41 @@ pipeline:
   #       - host: root
   #       - runner: root
   #
+  # QEMU runner:
+  #   File ownership inside and outside of the runner VM always match.
+  #
   - name: "check ownership of existing files"
     runs: |
-      set -u
+      set -eu
       runner_user=$(id -u)
       melange_user=$(stat -c "%u" .)
-      expected=""
+      expected_runner=""
+      expected_melange=""
       if [[ $runner_user == $melange_user ]]; then
         # Ownership of existing files match the ownership of files created within the runner
         # (i.e. by the git-checkout pipeline tar --extract command).
-        expected=49
+        expected_runner=48
+        expected_melange=2
       else
         # Ownership of existing files is not changed.
-        expected=43
+        expected_runner=42
+        expected_melange=6
       fi
-      found=$(find . -user $runner_user | wc -l)
-      [[ $found == $expected ]] || \
-        { echo "Expected $expected files owned by $runner_user, found $found"; exit 1; }
+      exclude_args="! -regex ^\.\/\.ssh.*$ ! -regex ^./.gitconfig$"
+      found_runner=$(find . -user $runner_user $exclude_args | wc -l)
+      mismatch=""
+      if [[ $found_runner != $expected_runner ]]; then
+        echo "Expected $expected_runner files owned by $runner_user, found $found_runner"
+        find . -user $runner_user $exclude_args
+        mismatch=true
+      fi
+      if [[ $melange_user != $runner_user ]]; then
+        found_melange=$(find . -user $melange_user $exclude_args | wc -l)
+        if [[ $found_runner != $expected_runner || $found_melange != $expected_melange ]]; then
+          echo "Expected $expected_melange files owned by $melange_user, found $found_melange"
+          find . -user $melange_user $exclude_args
+          mismatch=true
+        fi
+      fi
+      [[ $mismatch != "" ]] && exit 1
 

--- a/e2e-tests/git-checkout-build.yaml
+++ b/e2e-tests/git-checkout-build.yaml
@@ -206,3 +206,68 @@ pipeline:
       [ "$hash" != "$expected_hash" ]
       cd ..
       rm -R cherry-pick-test
+
+  # When ownership of files created inside and outside of the runner container do not
+  # match, if mode is restrictive on files like 0700 on the Melange workspace, if the git-checkout
+  # pipeline changes ownership on them, being that it runs inside the runner container, subsequent
+  # filesystem operations run outside of the runner fail because of missing permissions.
+  # This happens specifically with tar --extract without preserving ownership of existing files,
+  # like '.', which in case of the default input and standard usage of the pipeline, is the
+  # workspace directory.
+  # This results in subsequent operations like xattrs restore to fail as they are run outside of
+  # the runner container.
+  #
+  # Bubblewrap runner:
+  #   Since the user namespace is unshared and that the runner uid is mapped to the
+  #   uid of the user who runs Melange, ownership always match.
+  #   - Melange run by root -> runner user: root.
+  #     Owner of files created outside of the runner:
+  #       - host: root
+  #       - runner: root
+  #     Owner of files creted inside the runner:
+  #       - host: root
+  #       - runner: root
+  #   - Melange run by non-root -> runner user: build (1000 mapped to non-root).
+  #     Owner of files created outside of the runner:
+  #       - host: non-root
+  #       - runner: build (1000 -> host's non-root)
+  #     Owner of files creted inside the runner:
+  #       - host: non-root
+  #       - runner: build (1000 -> host's non-root)
+  #
+  # Docker runner:
+  #   Since the user namespace is shared, ownership between files created inside and
+  #   outside the runner, match only when the user who runs Melange is root.
+  #   - Melange run by root -> runner user: root.
+  #     Owner of files created outside of the runner:
+  #       - host: root
+  #       - runner: root
+  #     Owner of files creted inside the runner:
+  #       - host: root
+  #       - runner: root
+  #   - Melange run by non-root -> runner user: root.
+  #     Owner of files created outside of the runner:
+  #       - host: non-root
+  #       - runner: non-root
+  #     Owner of files creted inside the runner:
+  #       - host: root
+  #       - runner: root
+  #
+  - name: "check ownership of existing files"
+    runs: |
+      set -u
+      runner_user=$(id -u)
+      melange_user=$(stat -c "%u" .)
+      expected=""
+      if [[ $runner_user == $melange_user ]]; then
+        # Ownership of existing files match the ownership of files created within the runner
+        # (i.e. by the git-checkout pipeline tar --extract command).
+        expected=48
+      else
+        # Ownership of existing files is not changed.
+        expected=43
+      fi
+      found=$(find . -user $runner_user | wc -l)
+      [[ $found == $expected ]] || \
+        { echo "Expected $expected files owned by $runner_user, found $found"; exit 1; }
+

--- a/e2e-tests/run-tests
+++ b/e2e-tests/run-tests
@@ -14,6 +14,7 @@ MELANGE=${MELANGE:-melange}
 if [ "$MELANGE" = "melange" ]; then
     MELANGE=$(which melange)
 fi
+ARGS=${ARGS:-""}
 
 echo "Testing with melange from $MELANGE"
 $MELANGE version --json
@@ -32,7 +33,7 @@ fi
 
 fails=""
 for yaml in "$@"; do
-  args=""
+  args="${ARGS}"
   ops=""
   base=${yaml%.yaml}
   case "$base" in

--- a/pkg/build/pipelines/git-checkout.yaml
+++ b/pkg/build/pipelines/git-checkout.yaml
@@ -187,7 +187,7 @@ pipeline:
 
           vr cd "$workdir"
           msg "tar -c . | tar -C \"$dest_fullpath\" -x"
-          ( tar -c . ; echo $? > "$rcfile") | tar -C "$dest_fullpath" -x
+          ( tar -c . ; echo $? > "$rcfile") | tar -C "$dest_fullpath" -x --no-same-owner
           read rc < "$rcfile" || fail "failed to read rc file"
           [ $rc -eq 0 ] || fail "tar creation in $workdir failed"
 


### PR DESCRIPTION
This commit adds explicit `--no-same-owner` to tar extraction of
the git repository to the destination directory, which in most
of the cases is the Melange workspace.
--no-same-owner option makes:
>Extract files as yourself (default for ordinary users).

which means that when the Melange runner is root, ownership
of existing files is overwritten when the option is not set.

When the git-checkout pipelines extracts the content of the
git repositories locally from the temporary directory to the
destination directory [1], which is usually the Melange pipeline
workspace (/home/build inside the runner container), does not
preserve ownership of the directories that already existed in
the destination directory.

When the runner user does not match the user who runs Melange,
this ends up in permission errors for all the operation on
the workspace that happen after the pipelines have run, which
means the user that runs Melange tries to write to the
workspace that no longer owns.

This is the case of Melange run by non-root with the Docker
runner, and operations like `xattrs` restore [2].

This commit makes the git repository content extraction to run
with `tar --extract --no-same-owner`, preserving the ownership of
the workspace and all the directories inside the workspace that
already existed, like '.' in the workspace, as tar runs with `-C
$destination`.

1. https://github.com/chainguard-dev/melange/blob/a5d28473b9091cf7a45a0864bb149ae9fddfff99/pkg/build/pipelines/git-checkout.yaml#L190
2.
https://github.com/chainguard-dev/melange/blob/a5d28473b9091cf7a45a0864bb149ae9fddfff99/pkg/build/build.go#L956


## Melange Pull Request Template

<!--
*** PULL REQUEST CHECKLIST: PLEASE START HERE ***

The single most important feature of melange is that we can build Wolfi.

Many changes to melange introduce a risk of breaking the build, and sometimes
these are not flushed out until a package is changed (much) later.  This
pertains to basic execution, SCA changes, linter changes, and more.
-->

### Functional Changes

- [x] This change can build all of Wolfi without errors (describe results in notes)

Notes:

