### PR TITLE
test.go: Invoke `apkofs.DirFS` with option to create dir if missing

### DIFF
--- a/pkg/build/test.go
+++ b/pkg/build/test.go
@@ -311,7 +311,11 @@ func (t *Test) PopulateWorkspace(ctx context.Context, src fs.FS) error {
 
 	log.Infof("populating workspace %s from %s", t.WorkspaceDir, t.SourceDir)
 
-	fsys := apkofs.DirFS(t.SourceDir)
+	fsys := apkofs.DirFS(t.SourceDir, apkofs.WithCreateDir())
+
+	if fsys == nil {
+		return fmt.Errorf("unable to create/use directory %s", t.SourceDir)
+	}
 
 	return fs.WalkDir(fsys, ".", func(path string, d fs.DirEntry, err error) error {
 		if err != nil {


### PR DESCRIPTION
In our Makefiles we currently need to manually create the source directory if it doesn't exist.  If we forget to do that, melange will segfault (see
https://github.com/chainguard-dev/extra-packages/pull/2165 for an example of such case).

melange can do better here and create the missing source directory by itself, so that's what this commit does.

Relates: https://github.com/chainguard-dev/extra-packages/pull/2165