### PR TITLE
github: fixup presubmit workflow

### DIFF
--- a/.github/workflows/wolfi-presubmit.yaml
+++ b/.github/workflows/wolfi-presubmit.yaml
@@ -93,6 +93,12 @@ jobs:
           sudo chmod a+x /usr/bin/melange
           melange version
 
+      # this need to point to main to always get the latest action
+      - uses: wolfi-dev/actions/install-wolfictl@main # main
+
+      - run: |
+          wolfictl bump ${{ matrix.package }}
+
       - if: matrix.runner == 'bubblewrap'
         run: |
           sudo apt-get -y install bubblewrap
@@ -157,15 +163,12 @@ jobs:
           repository: "wolfi-dev/advisories"
           path: "data/wolfi-advisories"
 
-      # this need to point to main to always get the latest action
-      - uses: wolfi-dev/actions/install-wolfictl@main # main
-
       - name: Test installable and Scan for CVEs
         run: |
           if [[ "${{ matrix.package }}" == "fping" ]]; then
-            docker run --rm -v $(pwd):/work --workdir /work cgr.dev/chainguard/wolfi-base /bin/sh -c "apk add --allow-untrusted packages/x86_64/${{ matrix.package }}-*.apk; apk add libcap-utils; getcap /usr/sbin/fping"
+            docker run --rm -v $(pwd):/work --workdir /work cgr.dev/chainguard/wolfi-base /bin/sh -c "sed 's|=.*||' -i /etc/apk/world; apk add --allow-untrusted -X ./packages/ packages/x86_64/${{ matrix.package }}-*.apk; apk add libcap-utils; getcap /usr/sbin/fping"
           else
-            docker run --rm -v $(pwd):/work --workdir /work cgr.dev/chainguard/wolfi-base apk add --allow-untrusted packages/x86_64/${{ matrix.package }}-*.apk
+            docker run --rm -v $(pwd):/work --workdir /work cgr.dev/chainguard/wolfi-base /bin/sh -c "sed 's|=.*||' -i /etc/apk/world; apk add --allow-untrusted -X ./packages/ packages/x86_64/${{ matrix.package }}-*.apk"
           fi
           # There is a huge fixed cost for every wolfictl scan invocation for grype DB init.
           # Do this outside of the loop in one invocation with every package.


### PR DESCRIPTION
Bump epochs prior to building new packages, such that just rebuilt
packages are tested later on.

During apk installability tests, pass through the full registry of
packages such that they can resolve any new dependants, when needed.

This should fix CI when making invasive SCA changes.