### PR TITLE
sbin-merge: reorder default pipeline path

### DIFF
--- a/.github/workflows/wolfi-presubmit.yaml
+++ b/.github/workflows/wolfi-presubmit.yaml
@@ -70,6 +70,7 @@ jobs:
           - perl-yaml-syck
           - ncurses
           - fping
+          - subversion
           # TODO: https://github.com/wolfi-dev/os/issues/26442
           #- xmlto
 

--- a/pkg/build/pipeline.go
+++ b/pkg/build/pipeline.go
@@ -207,7 +207,7 @@ func (r *pipelineRunner) runPipeline(ctx context.Context, pipeline *config.Pipel
 
 	// Pipelines can have their own environment variables, which override the global ones.
 	envOverride := map[string]string{
-		"PATH": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+		"PATH": "/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin",
 	}
 
 	for k, v := range pipeline.Environment {


### PR DESCRIPTION
Stock default PATH variables are widely documented. Unfortunately
setting PATH in the envFile passed to melange yields no effect, as
pipeline overrides start with a PATH provided. It is understandable,
as the PATH set here is more comprehensive and in a better order than
the one built-into busybox ash (quiet unusual order, and lacks
/usr/local).

On the other hand programs and users get confused when the canonical
location of the binaries, is not the one discovered by PATH.

Without breaking existing workflows, and ability to keep building
pre-usrsbinmerge package repositories, reorder the default pipeline
PATH slightly. Specifically ensure that `/usr/bin` leads before
`/sbin`, `/usr/sbin`, `/bin` locations. This way discovery of binaries
in the post usrsbin-merge world will find the canonical location
first. Whilst preserving ability to build non-usrsbinmerged
distribtuions.

This fixes subversion FTBFS in wolfi, post usrsbin-merge.

References:
- https://wiki.ubuntu.com/PATH
```
PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
```

- busybox path

```
$ env -i busybox ash -c 'echo $PATH'
/sbin:/usr/sbin:/bin:/usr/bin
```

This change fixes the subversion build in the bubblewrap runner, will need to dig more as to how to make this work in the qemu runner too. Possibly as a follow up.