### PR TITLE
Include /usr/local paths in generateShbangDeps; drop /bin

### DIFF
--- a/pkg/sca/sca.go
+++ b/pkg/sca/sca.go
@@ -822,7 +822,10 @@ func generateShbangDeps(ctx context.Context, hdl SCAHandle, generated *config.De
 			return nil
 		}
 
-		if !strings.HasPrefix(path, "usr/bin/") && !strings.HasPrefix(path, "bin/") {
+		if !strings.HasPrefix(path, "usr/bin/") &&
+			!strings.HasPrefix(path, "usr/local/bin/") &&
+			!strings.HasPrefix(path, "usr/local/sbin/") &&
+			!strings.HasPrefix(path, "usr/sbin/") {
 			return nil
 		}
 

--- a/pkg/sca/sca.go
+++ b/pkg/sca/sca.go
@@ -824,8 +824,7 @@ func generateShbangDeps(ctx context.Context, hdl SCAHandle, generated *config.De
 
 		if !strings.HasPrefix(path, "usr/bin/") &&
 			!strings.HasPrefix(path, "usr/local/bin/") &&
-			!strings.HasPrefix(path, "usr/local/sbin/") &&
-			!strings.HasPrefix(path, "usr/sbin/") {
+			!strings.HasPrefix(path, "usr/local/sbin/") {
 			return nil
 		}
 


### PR DESCRIPTION
This PR adds `/usr/local/bin` and `/usr/local/sbin` to the paths considered when generating shbang dependencies and drops `/bin` which is no longer used.