### PR TITLE
pipelines: cmake/build: Use verbose mode by default

### DIFF
--- a/pkg/build/pipelines/cmake/build.yaml
+++ b/pkg/build/pipelines/cmake/build.yaml
@@ -13,4 +13,4 @@ inputs:
 
 pipeline:
   - runs: |
-      cmake --build ${{inputs.output-dir}}
+      VERBOSE=1 cmake --build ${{inputs.output-dir}}


### PR DESCRIPTION
This will make it easier to debug failures.

Signed-off-by: dann frazier <dann.frazier@chainguard.dev>
