### PR TITLE
pipelines/ruby/clean: remove build logs

### DIFF
--- a/pkg/build/pipelines/ruby/clean.yaml
+++ b/pkg/build/pipelines/ruby/clean.yaml
@@ -15,3 +15,5 @@ pipeline:
       INSTALL_DIR=${{targets.contextdir}}/$(ruby -e 'puts Gem.default_dir')
       rm -rf ${INSTALL_DIR}/build_info \
              ${INSTALL_DIR}/cache
+      find ${INSTALL_DIR} -name 'gem_make.out' -exec rm {} \;
+      find ${INSTALL_DIR} -name 'mkmf.log' -exec rm {} \;


### PR DESCRIPTION
We don't need them and they're causing reproducibility isuses.

```
❯ diff (curl -sL https://packages.wolfi.dev/os/aarch64/ruby3.2-date-3.4.1-r0.apk | tar -t | psub) (tar -tf ./package
s/aarch64/ruby3.2-date-3.4.1-r0.apk | psub)
0a1
> .SIGN.RSA256.local-melange.rsa.pub
1a3
> .melange.yaml
15,16d16
< usr/lib/ruby/gems/3.2.0/extensions/aarch64-linux-gnu/3.2.0/date-3.4.1/gem_make.out
< usr/lib/ruby/gems/3.2.0/extensions/aarch64-linux-gnu/3.2.0/date-3.4.1/mkmf.log
```