### PR TITLE
Fix mode bit persistence for bind mounts

### DIFF
--- a/.github/workflows/wolfi-presubmit.yaml
+++ b/.github/workflows/wolfi-presubmit.yaml
@@ -71,6 +71,7 @@ jobs:
           - ncurses
           - fping
           - subversion
+          - sudo
           # TODO: https://github.com/wolfi-dev/os/issues/26442
           #- xmlto
 
@@ -150,6 +151,14 @@ jobs:
         run: |
           make SHELL="/bin/bash" MELANGE="sudo melange" test/${{ matrix.package }}
 
+      - name: Run tests to verify mode bits with bubblewrap runner
+        if: matrix.runner == 'bubblewrap' && matrix.package == 'sudo'
+        run: |
+          for pkg in packages/x86_64/*.apk; do
+            sudo tar --xattrs --xattrs-include='*.*' -xf "${pkg}" -C packages/x86_64/
+          done
+          ls -hal packages/x86_64/usr/bin/sudo
+
       - name: Check package ${{ matrix.package }} xattrs for QEMU-built package
         if: matrix.runner == 'qemu' && matrix.package == 'fping'
         run: |
@@ -157,6 +166,14 @@ jobs:
             sudo tar --xattrs --xattrs-include='*.*' -xf "${pkg}" -C packages/x86_64/
           done
           getcap packages/x86_64/usr/sbin/fping
+
+      - name: Check package ${{ matrix.package }} mode bits for QEMU-built package
+        if: matrix.runner == 'qemu' && matrix.package == 'sudo'
+        run: |
+          for pkg in packages/x86_64/*.apk; do
+            sudo tar --xattrs --xattrs-include='*.*' -xf "${pkg}" -C packages/x86_64/
+          done
+          ls -hal packages/x86_64/usr/bin/sudo
 
       - name: "Retrieve Wolfi advisory data"
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -168,6 +185,8 @@ jobs:
         run: |
           if [[ "${{ matrix.package }}" == "fping" ]]; then
             docker run --rm -v $(pwd):/work --workdir /work cgr.dev/chainguard/wolfi-base /bin/sh -c "sed 's|=.*||' -i /etc/apk/world; apk add --allow-untrusted -X ./packages/ packages/x86_64/${{ matrix.package }}-*.apk; apk add libcap-utils; getcap /usr/sbin/fping"
+          elif [[ "${{ matrix.package }}" == "sudo" ]]; then
+            docker run --rm -v $(pwd):/work --workdir /work cgr.dev/chainguard/wolfi-base /bin/sh -c "sed 's|=.*||' -i /etc/apk/world; apk add --allow-untrusted -X ./packages/ packages/x86_64/${{ matrix.package }}-*.apk; ls -hal /usr/bin/sudo"
           else
             docker run --rm -v $(pwd):/work --workdir /work cgr.dev/chainguard/wolfi-base /bin/sh -c "sed 's|=.*||' -i /etc/apk/world; apk add --allow-untrusted -X ./packages/ packages/x86_64/${{ matrix.package }}-*.apk"
           fi

--- a/.github/workflows/wolfi-presubmit.yaml
+++ b/.github/workflows/wolfi-presubmit.yaml
@@ -151,14 +151,6 @@ jobs:
         run: |
           make SHELL="/bin/bash" MELANGE="sudo melange" test/${{ matrix.package }}
 
-      - name: Run tests to verify mode bits with bubblewrap runner
-        if: matrix.runner == 'bubblewrap' && matrix.package == 'sudo'
-        run: |
-          for pkg in packages/x86_64/*.apk; do
-            sudo tar --xattrs --xattrs-include='*.*' -xf "${pkg}" -C packages/x86_64/
-          done
-          ls -hal packages/x86_64/usr/bin/sudo
-
       - name: Check package ${{ matrix.package }} xattrs for QEMU-built package
         if: matrix.runner == 'qemu' && matrix.package == 'fping'
         run: |
@@ -167,8 +159,8 @@ jobs:
           done
           getcap packages/x86_64/usr/sbin/fping
 
-      - name: Check package ${{ matrix.package }} mode bits for QEMU-built package
-        if: matrix.runner == 'qemu' && matrix.package == 'sudo'
+      - name: Check package ${{ matrix.package }} for mode bits
+        if: matrix.package == 'sudo'
         run: |
           for pkg in packages/x86_64/*.apk; do
             sudo tar --xattrs --xattrs-include='*.*' -xf "${pkg}" -C packages/x86_64/

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -952,8 +952,8 @@ func (b *Build) BuildPackage(ctx context.Context) error {
 		linterQueue = append(linterQueue, lintTarget)
 	}
 
-	// Store xattrs for use after the workspace is loaded into memory
-	xattrs, err := storeXattrs(b.WorkspaceDir)
+	// Store xattrs and modes for use after the workspace is loaded into memory
+	xattrs, modes, err := storeXattrs(b.WorkspaceDir)
 	if err != nil {
 		return fmt.Errorf("failed to store workspace xattrs: %w", err)
 	}
@@ -968,6 +968,12 @@ func (b *Build) BuildPackage(ctx context.Context) error {
 			if err := b.WorkspaceDirFS.SetXattr(path, attr, data); err != nil {
 				log.Warnf("failed to restore xattr %s on %s: %v\n", attr, path, err)
 			}
+		}
+	}
+
+	for path, mode := range modes {
+		if err := b.WorkspaceDirFS.Chmod(path, mode); err != nil {
+			log.Warnf("failed to apply mode %04o (%s) to %s: %v", mode, mode, path, err)
 		}
 	}
 
@@ -1354,18 +1360,35 @@ func sourceDateEpoch(defaultTime time.Time) (time.Time, error) {
 	return time.Unix(sec, 0).UTC(), nil
 }
 
-// Record on-disk xattrs set during package builds in order to apply them in the new in-memory filesystem
+// Record on-disk xattrs and mode bits set during package builds in order to apply them in the new in-memory filesystem
 // This will allow in-memory and bind mount runners to persist xattrs correctly
-func storeXattrs(dir string) (map[string]map[string][]byte, error) {
+func storeXattrs(dir string) (map[string]map[string][]byte, map[string]fs.FileMode, error) {
 	xattrs := make(map[string]map[string][]byte)
-	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+	modes := make(map[string]fs.FileMode)
+	err := filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
 
+		if d.IsDir() || d.Type()&fs.ModeSymlink == fs.ModeSymlink {
+			return nil
+		}
+
+		fi, err := d.Info()
+		if err != nil {
+			return err
+		}
+		mode := fi.Mode()
+
 		relPath, err := filepath.Rel(dir, path)
 		if err != nil {
 			return err
+		}
+
+		// If the file is within the melange-out directory and has [any] modified bits, store the relative path and mode bits
+		if strings.Contains(path, melangeOutputDirName) &&
+			(mode&fs.ModeSetuid != 0 || mode&fs.ModeSetgid != 0 || mode&fs.ModeSticky != 0) {
+			modes[relPath] = mode
 		}
 
 		size, err := unix.Listxattr(path, nil)
@@ -1399,7 +1422,7 @@ func storeXattrs(dir string) (map[string]map[string][]byte, error) {
 		return nil
 	})
 
-	return xattrs, err
+	return xattrs, modes, err
 }
 
 // stringsFromByteSlice converts a sequence of attributes to a []string.

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -1385,9 +1385,8 @@ func storeXattrs(dir string) (map[string]map[string][]byte, map[string]fs.FileMo
 			return err
 		}
 
-		// If the file is within the melange-out directory and has [any] modified bits, store the relative path and mode bits
-		if strings.Contains(path, melangeOutputDirName) &&
-			(mode&fs.ModeSetuid != 0 || mode&fs.ModeSetgid != 0 || mode&fs.ModeSticky != 0) {
+		// If the path is within the melange-out directory, store the relative path and mode bits
+		if strings.Contains(path, melangeOutputDirName) {
 			modes[relPath] = mode
 		}
 


### PR DESCRIPTION
#1867 fixed xattrs for bind mounts but did not address mode bits.

@sergiodj pointed out that building the `sudo` package no longer showed the `setuid` bit being set and @astrojerms also encountered the same thing with the `fixuid` package.

This PR stores the mode bits of files within `melange-out` and sets them appropriately similar to xattrs.

I tested these changes in Docker with `fixuid` and it looks like the bits are being persisted correctly now (previously only QEMU worked):
```
Building package fixuid with version fixuid-0.6.0-r0 from file fixuid.yaml
/Library/Developer/CommandLineTools/usr/bin/make yamlfile=fixuid.yaml pkgname=fixuid packages/aarch64/fixuid-0.6.0-r0.apk
@SOURCE_DATE_EPOCH= .../melange build fixuid.yaml --runner=docker --repository-append .../wolfi-dev/os/packages --keyring-append local-melange.rsa.pub --signing-key local-melange.rsa --arch aarch64 --env-file build-aarch64.env --namespace wolfi --license 'Apache-2.0' --git-repo-url 'https://github.com/wolfi-dev/os' --generate-index false  --pipeline-dir ./pipelines/  -k https://packages.wolfi.dev/os/wolfi-signing.rsa.pub -r https://packages.wolfi.dev/os --repository-append .../wolfi-dev/os/packages --keyring-append local-melange.rsa.pub --signing-key local-melange.rsa --arch aarch64 --env-file build-aarch64.env --namespace wolfi --license 'Apache-2.0' --git-repo-url 'https://github.com/wolfi-dev/os' --generate-index false  --pipeline-dir ./pipelines/  -k https://packages.wolfi.dev/os/wolfi-signing.rsa.pub -r https://packages.wolfi.dev/os --source-dir ./fixuid/
2025/04/16 15:59:17 WARN SOURCE_DATE_EPOCH is specified but empty, setting it to 1969-12-31 18:00:00 -0600 CST
...
2025/04/16 15:59:18 INFO installing wolfi-baselayout (20230201-r20)
2025/04/16 15:59:18 INFO installing ca-certificates-bundle (20241121-r40)
2025/04/16 15:59:18 INFO installing glibc-locale-posix (2.41-r1)
2025/04/16 15:59:18 INFO installing libgcc (14.2.0-r12)
2025/04/16 15:59:18 INFO installing glibc (2.41-r1)
2025/04/16 15:59:18 INFO installing ld-linux (2.41-r1)
2025/04/16 15:59:18 INFO installing ncurses-terminfo-base (6.5_p20241228-r1)
2025/04/16 15:59:18 INFO installing ncurses (6.5_p20241228-r1)
2025/04/16 15:59:18 INFO installing bash (5.2.37-r30)
2025/04/16 15:59:18 INFO installing libstdc++ (14.2.0-r12)
2025/04/16 15:59:18 INFO installing libzstd1 (1.5.7-r1)
2025/04/16 15:59:18 INFO installing binutils-gold (2.44-r2)
2025/04/16 15:59:18 INFO installing binutils (2.44-r2)
2025/04/16 15:59:18 INFO installing libxcrypt (4.4.38-r1)
2025/04/16 15:59:18 INFO installing libxcrypt-dev (4.4.38-r1)
2025/04/16 15:59:18 INFO installing linux-headers (6.14.2-r0)
2025/04/16 15:59:19 INFO installing nss-db (2.41-r1)
2025/04/16 15:59:19 INFO installing nss-hesiod (2.41-r1)
2025/04/16 15:59:19 INFO installing glibc-dev (2.41-r1)
2025/04/16 15:59:19 INFO installing libquadmath (14.2.0-r12)
2025/04/16 15:59:19 INFO installing libstdc++-dev (14.2.0-r12)
2025/04/16 15:59:19 INFO installing openssf-compiler-options (20240627-r18)
2025/04/16 15:59:19 INFO installing posix-cc-wrappers (1-r5)
2025/04/16 15:59:19 INFO installing libatomic (14.2.0-r12)
2025/04/16 15:59:19 INFO installing gmp (6.3.0-r4)
2025/04/16 15:59:19 INFO installing libgo (14.2.0-r12)
2025/04/16 15:59:19 INFO installing libgomp (14.2.0-r12)
2025/04/16 15:59:19 INFO installing isl (0.27-r0)
2025/04/16 15:59:19 INFO installing mpfr (4.2.2-r0)
2025/04/16 15:59:19 INFO installing mpc (1.3.1-r5)
2025/04/16 15:59:19 INFO installing zlib (1.3.1-r6)
2025/04/16 15:59:19 INFO installing gcc (14.2.0-r12)
2025/04/16 15:59:19 INFO installing make (4.4.1-r4)
2025/04/16 15:59:19 INFO installing pkgconf (2.4.3-r1)
2025/04/16 15:59:19 INFO installing build-base (1-r8)
2025/04/16 15:59:19 INFO installing libcrypt1 (2.41-r1)
2025/04/16 15:59:19 INFO installing busybox (1.37.0-r40)
2025/04/16 15:59:19 INFO installing readline (8.2.13-r1)
2025/04/16 15:59:19 INFO installing sqlite-libs (3.49.1-r1)
2025/04/16 15:59:19 INFO installing heimdal-libs (7.8.0-r40)
2025/04/16 15:59:19 INFO installing libcrypto3 (3.4.1-r3)
2025/04/16 15:59:19 INFO installing gdbm (1.25-r0)
2025/04/16 15:59:19 INFO installing cyrus-sasl (2.1.28-r40)
2025/04/16 15:59:19 INFO installing libbrotlicommon1 (1.1.0-r4)
2025/04/16 15:59:19 INFO installing libbrotlidec1 (1.1.0-r4)
2025/04/16 15:59:19 INFO installing krb5-conf (1.0-r5)
2025/04/16 15:59:19 INFO installing libcom_err (1.47.2-r21)
2025/04/16 15:59:19 INFO installing keyutils-libs (1.6.3-r31)
2025/04/16 15:59:19 INFO installing libssl3 (3.4.1-r3)
2025/04/16 15:59:19 INFO installing libverto (0.3.2-r4)
2025/04/16 15:59:19 INFO installing krb5-libs (1.21.3-r40)
2025/04/16 15:59:19 INFO installing libldap (2.6.9-r41)
2025/04/16 15:59:19 INFO installing libnghttp2-14 (1.65.0-r0)
2025/04/16 15:59:19 INFO installing libunistring (1.3-r1)
2025/04/16 15:59:19 INFO installing libidn2 (2.3.8-r0)
2025/04/16 15:59:19 INFO installing libpsl (0.21.5-r4)
2025/04/16 15:59:19 INFO installing libcurl-openssl4 (8.12.1-r2)
2025/04/16 15:59:19 INFO installing libexpat1 (2.7.1-r0)
2025/04/16 15:59:19 INFO installing libpcre2-8-0 (10.45-r1)
2025/04/16 15:59:19 INFO installing git (2.49.0-r1)
2025/04/16 15:59:19 INFO installing go-1.24 (1.24.2-r0)
2025/04/16 15:59:20 INFO installing scanelf (1.3.8-r3)
2025/04/16 15:59:21 INFO layer digest: sha256:38aee686eaa5050c002c936b8a32d9f7fb689b4e527e8e0ca84ed3d9b30535db
2025/04/16 15:59:21 INFO layer diffID: sha256:3c58fd0fbdba1d610f5275e2e0bc7728a92d7ac93f901ea6d724f22d5c54fa83
2025/04/16 15:59:21 INFO saving OCI image locally: apko.local/cache:dc26ea2502518acb891ba0756718643aae6f9c778f2eac62d4fd812625a448e9
2025/04/16 15:59:26 INFO running step "git-checkout"
2025/04/16 15:59:26 INFO [git checkout] repo='https://github.com/boxboat/fixuid' dest='.' depth='unset' branch='' tag='v0.6.0' expcommit='c639d9b3d183248f8de031679654bf2146f88083' recurse='false'
2025/04/16 15:59:26 INFO [git checkout] execute: git config --global --add safe.directory /tmp/tmp.6uPsL3
2025/04/16 15:59:26 INFO [git checkout] execute: git config --global --add safe.directory /home/build
2025/04/16 15:59:26 INFO [git checkout] execute: git clone --quiet --origin=origin --config=user.name=Melange Build --config=user.email=melange-build@cgr.dev --config=advice.detachedHead=false --branch=v0.6.0 --depth=1 https://github.com/boxboat/fixuid /tmp/tmp.6uPsL3
2025/04/16 15:59:26 INFO [git checkout] execute: cd /tmp/tmp.6uPsL3
2025/04/16 15:59:26 INFO [git checkout] tar -c . | tar -C "/home/build" -x
2025/04/16 15:59:26 INFO [git checkout] execute: cd /home/build
2025/04/16 15:59:26 INFO [git checkout] execute: git config --global --add safe.directory /home/build
2025/04/16 15:59:26 INFO [git checkout] execute: git fetch --quiet origin --depth=1 --no-tags +refs/tags/v0.6.0:refs/origin/tags/v0.6.0
2025/04/16 15:59:27 INFO [git checkout] execute: git checkout --quiet origin/tags/v0.6.0
2025/04/16 15:59:27 INFO [git checkout] tag v0.6.0 is c639d9b3d183248f8de031679654bf2146f88083
2025/04/16 15:59:27 INFO [git checkout] Setting commit date to Jan 1, 1980 (SOURCE_DATE_EPOCH found 0)
2025/04/16 15:59:27 INFO running step "go/build"
2025/04/16 15:59:27 WARN go: downloading github.com/go-ozzo/ozzo-config v0.0.0-20160627170238-0ff174cf5aa6
2025/04/16 15:59:27 WARN go: downloading golang.org/x/exp v0.0.0-20230811145659-89c5cff77bcb
2025/04/16 15:59:27 WARN go: downloading github.com/hnakamur/jsonpreprocess v0.0.0-20171017030034-a4e954386171
2025/04/16 15:59:27 WARN go: downloading gopkg.in/yaml.v2 v2.4.0
2025/04/16 15:59:27 WARN go: downloading github.com/BurntSushi/toml v1.3.2
2025/04/16 15:59:29 INFO running step "strip"
2025/04/16 15:59:30 INFO retrieving workspace from builder: c1508263c7ea93bdec6a951cfd9e56d671ce6d15e3a730ad5eddb0fd2264fc26
2025/04/16 15:59:30 INFO retrieved and wrote post-build workspace to: /var/folders/n6/xxn5d2zd3l1gghpx_7qppzs00000gn/T/melange-workspace-1274369326
2025/04/16 15:59:30 INFO running package linters for fixuid
2025/04/16 15:59:30 INFO linting apk: fixuid
2025/04/16 15:59:30 INFO writing SBOM for fixuid
2025/04/16 15:59:30 INFO generating package fixuid-0.6.0-r0
2025/04/16 15:59:30 INFO scanning for ld.so.conf.d files...
2025/04/16 15:59:30 INFO scanning for shared object dependencies...
2025/04/16 15:59:30 INFO scanning for commands...
2025/04/16 15:59:30 INFO   found command usr/bin/fixuid
2025/04/16 15:59:30 INFO scanning for -doc package...
2025/04/16 15:59:30 INFO scanning for pkg-config data...
2025/04/16 15:59:30 INFO scanning for python modules...
2025/04/16 15:59:30 INFO scanning for ruby gems...
2025/04/16 15:59:30 INFO scanning for shbang deps...
2025/04/16 15:59:30 INFO   provides:
2025/04/16 15:59:30 INFO     cmd:fixuid=0.6.0-r0
2025/04/16 15:59:30 INFO   installed-size: 3014742
2025/04/16 15:59:30 INFO   data.tar.gz digest: df1f9f8129dcc3c53599dbc6213dc572fe9709948edb171429c60e498680e4bd
2025/04/16 15:59:30 INFO wrote packages/aarch64/fixuid-0.6.0-r0.apk
2025/04/16 15:59:30 INFO cleaning Workspace by removing 19 file/directories in /home/build
2025/04/16 15:59:31 INFO generating apk index from packages in packages/aarch64
2025/04/16 15:59:31 INFO processing package packages/aarch64/fixuid-0.6.0-r0.apk
2025/04/16 15:59:31 INFO updating index at packages/aarch64/APKINDEX.tar.gz with new packages: [fixuid-0.6.0-r0]
2025/04/16 15:59:31 INFO signing apk index at packages/aarch64/APKINDEX.tar.gz
2025/04/16 15:59:31 INFO signing index packages/aarch64/APKINDEX.tar.gz with key local-melange.rsa
2025/04/16 15:59:31 INFO appending signature RSA256 to index packages/aarch64/APKINDEX.tar.gz
2025/04/16 15:59:31 INFO writing signed index to packages/aarch64/APKINDEX.tar.gz
2025/04/16 15:59:31 INFO signed index packages/aarch64/APKINDEX.tar.gz with key local-melange.rsa
2025/04/16 15:59:31 INFO pod c1508263c7ea93bdec6a951cfd9e56d671ce6d15e3a730ad5eddb0fd2264fc26 terminated
2025/04/16 15:59:31 INFO deleting image apko.local/cache:dc26ea2502518acb891ba0756718643aae6f9c778f2eac62d4fd812625a448e9
2025/04/16 15:59:31 INFO untagged apko.local/cache:dc26ea2502518acb891ba0756718643aae6f9c778f2eac62d4fd812625a448e9
2025/04/16 15:59:31 INFO deleted sha256:b944e3ce7680cfa9a8411a365d94515a7b901423a16954c3727e4c6bf59011e4
2025/04/16 15:59:31 INFO deleted sha256:3c58fd0fbdba1d610f5275e2e0bc7728a92d7ac93f901ea6d724f22d5c54fa83
Testing package fixuid with version fixuid-0.6.0-r0 from file fixuid.yaml
...
2025/04/16 15:59:31 INFO building test workspace in: '/var/folders/n6/xxn5d2zd3l1gghpx_7qppzs00000gn/T/melange-guest-1508523766-main' with apko
2025/04/16 15:59:32 INFO image configuration:
2025/04/16 15:59:32 INFO   contents:
2025/04/16 15:59:32 INFO     build repositories: []
2025/04/16 15:59:32 INFO     runtime repositories: []
2025/04/16 15:59:32 INFO     keyring:      []
2025/04/16 15:59:32 INFO     packages:     [fixuid]
2025/04/16 15:59:32 INFO   accounts:
2025/04/16 15:59:32 INFO     runas:
2025/04/16 15:59:32 INFO     users:
2025/04/16 15:59:32 INFO       - uid=1000(build) gid=1000
2025/04/16 15:59:32 INFO     groups:
2025/04/16 15:59:32 INFO       - gid=1000(build) members=[build]
2025/04/16 15:59:32 INFO installing fixuid (0.6.0-r0)
2025/04/16 15:59:32 INFO installing wolfi-keys (1-r10)
2025/04/16 15:59:32 INFO installing wolfi-baselayout (20230201-r20)
2025/04/16 15:59:32 INFO installing ca-certificates-bundle (20241121-r40)
2025/04/16 15:59:32 INFO installing libgcc (14.2.0-r12)
2025/04/16 15:59:32 INFO installing ld-linux (2.41-r1)
2025/04/16 15:59:32 INFO installing glibc-locale-posix (2.41-r1)
2025/04/16 15:59:32 INFO installing glibc (2.41-r1)
2025/04/16 15:59:32 INFO installing zlib (1.3.1-r6)
2025/04/16 15:59:32 INFO installing libcrypto3 (3.4.1-r3)
2025/04/16 15:59:32 INFO installing libssl3 (3.4.1-r3)
2025/04/16 15:59:32 INFO installing apk-tools (2.14.10-r2)
2025/04/16 15:59:32 INFO installing libxcrypt (4.4.38-r1)
2025/04/16 15:59:32 INFO installing libcrypt1 (2.41-r1)
2025/04/16 15:59:32 INFO installing busybox (1.37.0-r40)
2025/04/16 15:59:32 INFO installing wolfi-base (1-r7)
2025/04/16 15:59:32 INFO layer digest: sha256:e97669549a24e206f3fd160aa17faa48c4226d02b7131405cc970f2c1a97b91a
2025/04/16 15:59:32 INFO layer diffID: sha256:8c5537f447032118a45138a23ff68eeefa248527a1e0405539d596fd89f4d7a2
2025/04/16 15:59:32 INFO saving OCI image locally: apko.local/cache:96e2668d8d4190ccd943fe85d43890f81d972f5978011f6548176f060df0b7c8
2025/04/16 15:59:32 INFO populating workspace /var/folders/n6/xxn5d2zd3l1gghpx_7qppzs00000gn/T/melange-workspace-4226329922 from ./fixuid/
2025/04/16 15:59:33 INFO running the main test pipeline
2025/04/16 15:59:33 WARN + '[' -d /home/build ]
2025/04/16 15:59:33 WARN + cd /home/build
2025/04/16 15:59:33 WARN + fixuid -h
2025/04/16 15:59:33 WARN Usage of fixuid:
2025/04/16 15:59:33 WARN   -q    quiet mode
2025/04/16 15:59:33 WARN + mkdir -p /etc/fixuid
2025/04/16 15:59:33 WARN + mkdir -p /var/run
2025/04/16 15:59:33 WARN + printf 'user: root\ngroup: root\n'
2025/04/16 15:59:33 WARN + ls -hal /usr/bin/fixuid
2025/04/16 15:59:33 INFO -rwsr-xr-x    1 root     root        2.9M Jan  1  1970 /usr/bin/fixuid
2025/04/16 15:59:33 WARN + exit 0
2025/04/16 15:59:33 INFO running step "run-fixuid"
2025/04/16 15:59:33 WARN + '[' -d /home/build ]
2025/04/16 15:59:33 WARN + cd /home/build
2025/04/16 15:59:33 WARN + exit 0
2025/04/16 15:59:33 INFO pod b1ef5d7480e5cc269b4f528f449259ab341f701af75e730a86f49b0e602d10c5 terminated
```

To that end, I added `sudo` to the pre-submit Checks so that we can verify that the mode bits are being persisted correctly.