### PR TITLE
usrmerge: lint for lib64 usage

### DIFF
--- a/pkg/linter/linter.go
+++ b/pkg/linter/linter.go
@@ -792,9 +792,10 @@ func usrmergeLinter(ctx context.Context, _ *config.Configuration, _ string, fsys
 
 		// We don't really care if a package is re-adding a symlink and this catches wolfi-baselayout
 		// without special casing it with the package name.
-		if path == "sbin" || path == "bin" || path == "usr/sbin" {
+		symlinked := []string{"sbin", "bin", "usr/sbin", "lib64", "usr/lib64"}
+		if slices.Contains(symlinked, path) {
 			if d.IsDir() || d.Type().IsRegular() {
-				return fmt.Errorf("package contains non-symlink file at /sbin, /bin or /usr/sbin in violation of usrmerge")
+				return fmt.Errorf("package contains non-symlink file at /sbin, /bin, /usr/sbin, /lib64 or /usr/lib64 in violation of usrmerge")
 			} else {
 				return nil
 			}
@@ -810,6 +811,12 @@ func usrmergeLinter(ctx context.Context, _ *config.Configuration, _ string, fsys
 
 		if strings.HasPrefix(path, "usr/sbin") {
 			return fmt.Errorf("package writes to /usr/sbin in violation of usrmerge: %s", path)
+		}
+		if strings.HasPrefix(path, "lib64") {
+			return fmt.Errorf("package writes to /lib64 in violation of usrmerge, use /lib: %s", path)
+		}
+		if strings.HasPrefix(path, "usr/lib64") {
+			return fmt.Errorf("package writes to /usr/lib64 in violation of usrmerge, use /usr/lib: %s", path)
 		}
 
 		return nil

--- a/pkg/linter/linter_test.go
+++ b/pkg/linter/linter_test.go
@@ -212,6 +212,14 @@ func TestLinters(t *testing.T) {
 		linter:  "usrmerge",
 		pass:    false,
 	}, {
+		dirFunc: mkfile(t, "lib64/ld-linux.so"),
+		linter:  "usrmerge",
+		pass:    false,
+	}, {
+		dirFunc: mkfile(t, "usr/lib64/ld.so"),
+		linter:  "usrmerge",
+		pass:    false,
+	}, {
 		dirFunc: func() string {
 			d := t.TempDir()
 			assert.NoError(t, os.MkdirAll(filepath.Join(d, filepath.Dir("/sbin")), 0700))


### PR DESCRIPTION
lib64 has always been a symlink to lib in wolfi. However file
installation has been soft allowed into that location. As it sort of
worked if wolfi-baselayout is unpacked first. But it still leads to
`apk audit` failing. As we are getting more strict with file locations
in the .apks, add /lib64 and /usr/lib64 linting.

At this time one should use /lib and /usr/lib locations instead.
