### PR TITLE
Added error handling for panic in melange completion command

### DIFF
--- a/pkg/cli/completion.go
+++ b/pkg/cli/completion.go
@@ -16,7 +16,7 @@ package cli
 
 import (
 	"os"
-
+	"fmt"
 	"github.com/spf13/cobra"
 )
 
@@ -58,27 +58,35 @@ $ melange completion fish > ~/.config/fish/completions/melange.fish
 		ValidArgs:             []string{"bash", "zsh", "fish", "powershell"},
 		Args:                  cobra.MaximumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
+			if len(args) == 0 {
+				// Print an error message and exit if no argument is provided
+				fmt.Fprintln(os.Stderr, "Error: A shell type (bash, zsh, fish, powershell) is required.")
+				return
+			}
+		
 			switch args[0] {
 			case "bash":
 				err := cmd.Root().GenBashCompletion(os.Stdout)
 				if err != nil {
-					return
+					fmt.Fprintln(os.Stderr, "Error generating Bash completion script:", err)
 				}
 			case "zsh":
 				err := cmd.Root().GenZshCompletion(os.Stdout)
 				if err != nil {
-					return
+					fmt.Fprintln(os.Stderr, "Error generating Zsh completion script:", err)
 				}
 			case "fish":
 				err := cmd.Root().GenFishCompletion(os.Stdout, true)
 				if err != nil {
-					return
+					fmt.Fprintln(os.Stderr, "Error generating Fish completion script:", err)
 				}
 			case "powershell":
 				err := cmd.Root().GenPowerShellCompletion(os.Stdout)
 				if err != nil {
-					return
+					fmt.Fprintln(os.Stderr, "Error generating PowerShell completion script:", err)
 				}
+			default:
+				fmt.Fprintln(os.Stderr, "Error: Invalid shell type. Use one of: bash, zsh, fish, powershell.")
 			}
 		},
 	}


### PR DESCRIPTION
## Melange Pull Request Template
Fixes #1718 
<!--
*** PULL REQUEST CHECKLIST: PLEASE START HERE ***

The single most important feature of melange is that we can build Wolfi.

Many changes to melange introduce a risk of breaking the build, and sometimes
these are not flushed out until a package is changed (much) later.  This
pertains to basic execution, SCA changes, linter changes, and more.
-->

### Functional Changes

- [ x] This change can build all of Wolfi without errors (describe results in notes)

Notes:

### SCA Changes

- [ ] Examining several representative APKs show no regression / the desired effect (details in notes)

Notes:

### Linter

- [ ] The new check is clean across Wolfi
- [ ] The new check is opt-in or a warning

Notes:

melange completion was panicking because there was no error handling for empty arguments. Added error handling 
