### PR TITLE
Fixed command melange completion panicking by adding error handling

### DIFF
--- a/pkg/cli/completion.go
+++ b/pkg/cli/completion.go
@@ -16,7 +16,7 @@ package cli
 
 import (
 	"os"
-	"fmt"
+	"log"
 	"github.com/spf13/cobra"
 )
 
@@ -60,33 +60,32 @@ $ melange completion fish > ~/.config/fish/completions/melange.fish
 		Run: func(cmd *cobra.Command, args []string) {
 			if len(args) == 0 {
 				// Print an error message and exit if no argument is provided
-				fmt.Fprintln(os.Stderr, "Error: A shell type (bash, zsh, fish, powershell) is required.")
-				return
+					log.Fatal("A shell type (bash, zsh, fish, powershell) is required.")
 			}
 		
 			switch args[0] {
 			case "bash":
 				err := cmd.Root().GenBashCompletion(os.Stdout)
 				if err != nil {
-					fmt.Fprintln(os.Stderr, "Error generating Bash completion script:", err)
+					log.Fatalf("Error generating Bash completion script: %v", err)
 				}
 			case "zsh":
 				err := cmd.Root().GenZshCompletion(os.Stdout)
 				if err != nil {
-					fmt.Fprintln(os.Stderr, "Error generating Zsh completion script:", err)
+					log.Fatalf("Error generating Zsh completion script: %v", err)
 				}
 			case "fish":
 				err := cmd.Root().GenFishCompletion(os.Stdout, true)
 				if err != nil {
-					fmt.Fprintln(os.Stderr, "Error generating Fish completion script:", err)
+					log.Fatalf("Error generating fish completion script: %v", err)
 				}
 			case "powershell":
 				err := cmd.Root().GenPowerShellCompletion(os.Stdout)
 				if err != nil {
-					fmt.Fprintln(os.Stderr, "Error generating PowerShell completion script:", err)
+					log.Fatalf("Error generating PowerShell completion script: %v", err)
 				}
 			default:
-				fmt.Fprintln(os.Stderr, "Error: Invalid shell type. Use one of: bash, zsh, fish, powershell.")
+				log.Fatalf("A shell type (bash, zsh, fish, powershell) is required.")
 			}
 		},
 	}


### PR DESCRIPTION
## Melange Pull Request Template
Fixes #1718 
<!--
*** PULL REQUEST CHECKLIST: PLEASE START HERE ***

The single most important feature of melange is that we can build Wolfi.

Many changes to melange introduce a risk of breaking the build, and sometimes
these are not flushed out until a package is changed (much) later.  This
pertains to basic execution, SCA changes, linter changes, and more.
-->

### Functional Changes

- [ x] This change can build all of Wolfi without errors (describe results in notes)

Notes:

### SCA Changes

- [ ] Examining several representative APKs show no regression / the desired effect (details in notes)

Notes:

### Linter

- [ ] The new check is clean across Wolfi
- [ ] The new check is opt-in or a warning

Notes:

The command "melange completion" was panicking because the there was no error handling for zero arguments
