### PR TITLE
Add support for declarative file capabilities

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -977,6 +977,20 @@ func (b *Build) BuildPackage(ctx context.Context) error {
 		}
 	}
 
+	// For each `setcap` entry in the package/sub-package, pull out the capability and data and set the xattr
+	// For example:
+	// setcap:
+	//   - path: /usr/bin/scary
+	//     add:
+	//       cap_sys_admin: "+ep"
+	for _, c := range b.Configuration.Package.SetCap {
+		for attr, data := range c.Add {
+			if err := b.WorkspaceDirFS.SetXattr(c.Path, attr, []byte(data)); err != nil {
+				log.Warnf("failed to set capability %q on %s: %v\n", attr, c.Path, err)
+			}
+		}
+	}
+
 	if err := b.retrieveWorkspace(ctx, b.WorkspaceDirFS); err != nil {
 		return fmt.Errorf("retrieving workspace: %w", err)
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1819,10 +1819,10 @@ func (dep *Dependencies) Summarize(ctx context.Context) {
 // validCapabilities contains a list of _in-use_ capabilities and their respective bits from existing package specs.
 // https://github.com/torvalds/linux/blob/master/include/uapi/linux/capability.h#L106-L422
 var validCapabilities = map[string]uint32{
-	"cap_ipc_lock":         14,
-	"cap_net_admin":        12,
 	"cap_net_bind_service": 10,
+	"cap_net_admin":        12,
 	"cap_net_raw":          13,
+	"cap_ipc_lock":         14,
 	"cap_sys_admin":        21,
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -17,6 +17,7 @@ package config
 import (
 	"bytes"
 	"context"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -1815,13 +1816,21 @@ func (dep *Dependencies) Summarize(ctx context.Context) {
 	}
 }
 
-// validCapabilities contains a complete list of capabilities from existing package specs.
-var validCapabilities = map[string]struct{}{
-	"cap_ipc_lock":         {},
-	"cap_net_admin":        {},
-	"cap_net_bind_service": {},
-	"cap_net_raw":          {},
-	"cap_sys_admin":        {},
+// validCapabilities contains a list of _in-use_ capabilities and their respective bits from existing package specs.
+// https://github.com/torvalds/linux/blob/master/include/uapi/linux/capability.h#L106-L422
+var validCapabilities = map[string]uint32{
+	"cap_ipc_lock":         14,
+	"cap_net_admin":        12,
+	"cap_net_bind_service": 10,
+	"cap_net_raw":          13,
+	"cap_sys_admin":        21,
+}
+
+func getCapabilityValue(attr string) uint32 {
+	if value, ok := validCapabilities[attr]; ok {
+		return 1 << value
+	}
+	return 0
 }
 
 func validateCapabilities(setcap []Capability) error {
@@ -1847,4 +1856,82 @@ func validateCapabilities(setcap []Capability) error {
 	}
 
 	return errors.Join(errs...)
+}
+
+type capabilityData struct {
+	Effective   uint32
+	Permitted   uint32
+	Inheritable uint32
+}
+
+// ParseCapabilities processes all capabilities for a given path.
+func ParseCapabilities(caps []Capability) (map[string]capabilityData, error) {
+	pathCapabilities := map[string]capabilityData{}
+
+	for _, c := range caps {
+		for attr, data := range c.Add {
+			capValues := getCapabilityValue(attr)
+			effective, permitted, inheritable := parseCapability(data)
+
+			caps, ok := pathCapabilities[c.Path]
+			if !ok {
+				caps = struct {
+					Effective   uint32
+					Permitted   uint32
+					Inheritable uint32
+				}{}
+			}
+
+			if effective {
+				caps.Effective |= capValues
+			}
+			if permitted {
+				caps.Permitted |= capValues
+			}
+			if inheritable {
+				caps.Inheritable |= capValues
+			}
+
+			pathCapabilities[c.Path] = caps
+		}
+	}
+
+	return pathCapabilities, nil
+}
+
+// parseCapability determines which bits are set for a given capability.
+func parseCapability(capFlag string) (effective, permitted, inheritable bool) {
+	for _, c := range capFlag {
+		switch c {
+		case 'e':
+			effective = true
+		case 'p':
+			permitted = true
+		case 'i':
+			inheritable = true
+		}
+	}
+	return
+}
+
+// EncodeCapability returns the byte slice necessary to set the final capability xattr.
+func EncodeCapability(effectiveBits, permittedBits, inheritableBits uint32) []byte {
+	// https://github.com/torvalds/linux/blob/a33b5a08cbbdd7aadff95f40cbb45ab86841679e/include/uapi/linux/capability.h#L36
+	magic := uint32(0x20080522)
+	// Version 3; Version 2 is deprecated
+	version := uint32(0x3)
+
+	data := make([]byte, 20)
+	binary.LittleEndian.PutUint32(data[0:], magic)
+	binary.LittleEndian.PutUint32(data[4:], version)
+	binary.LittleEndian.PutUint32(data[8:], effectiveBits)
+	binary.LittleEndian.PutUint32(data[12:], permittedBits)
+	binary.LittleEndian.PutUint32(data[16:], inheritableBits)
+
+	rootid := uint32(0)
+	rootidBytes := make([]byte, 4)
+	binary.LittleEndian.PutUint32(rootidBytes, rootid)
+	data = append(data, rootidBytes...)
+
+	return data
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"encoding/binary"
 	"os"
 	"path/filepath"
 	"testing"
@@ -692,5 +693,220 @@ func TestSetCap(t *testing.T) {
 		if (err != nil) != test.err {
 			t.Errorf("validateCapabilities(%v) returned error %v, expected error: %v", test.setcap, err, test.err)
 		}
+	}
+}
+
+// Mock resources to test setcap capabilities
+type mockFS struct {
+	xattrs map[string]map[string][]byte
+}
+
+func newMockFS() *mockFS {
+	return &mockFS{
+		xattrs: make(map[string]map[string][]byte),
+	}
+}
+
+func (fs *mockFS) SetXattr(path, attr string, value []byte) error {
+	if _, ok := fs.xattrs[path]; !ok {
+		fs.xattrs[path] = make(map[string][]byte)
+	}
+	fs.xattrs[path][attr] = value
+	return nil
+}
+
+func (fs *mockFS) GetXattr(path, attr string) ([]byte, error) {
+	if attrs, ok := fs.xattrs[path]; ok {
+		if value, ok := attrs[attr]; ok {
+			return value, nil
+		}
+	}
+	return nil, os.ErrNotExist
+}
+
+func TestSetCapability(t *testing.T) {
+	type Config struct {
+		Package struct {
+			SetCap []Capability
+		}
+	}
+
+	type Builder struct {
+		Configuration  Config
+		WorkspaceDirFS *mockFS
+	}
+
+	testCases := []struct {
+		name          string
+		caps          []Capability
+		expectedAttrs map[string]map[string][]byte
+	}{
+		{
+			name: "Basic capability +ep",
+			caps: []Capability{
+				{
+					Path: "/usr/bin/fping",
+					Add: map[string]string{
+						"cap_net_raw": "+ep",
+					},
+					Reason: "foo",
+				},
+			},
+			expectedAttrs: map[string]map[string][]byte{
+				"/usr/bin/fping": {
+					"security.capability": nil,
+				},
+			},
+		},
+		{
+			name: "Multiple capabilities",
+			caps: []Capability{
+				{
+					Path: "/usr/bin/traceroute",
+					Add: map[string]string{
+						"cap_net_raw":   "+ep",
+						"cap_net_admin": "+eip",
+					},
+					Reason: "foo",
+				},
+			},
+			expectedAttrs: map[string]map[string][]byte{
+				"/usr/bin/traceroute": {
+					"security.capability": nil,
+				},
+			},
+		},
+		{
+			name: "Multiple paths",
+			caps: []Capability{
+				{
+					Path: "/bin/ping",
+					Add: map[string]string{
+						"cap_net_raw": "+ep",
+					},
+					Reason: "foo",
+				},
+				{
+					Path: "/usr/bin/traceroute",
+					Add: map[string]string{
+						"cap_net_admin": "+eip",
+					},
+					Reason: "foo",
+				},
+			},
+			expectedAttrs: map[string]map[string][]byte{
+				"/bin/ping": {
+					"security.capability": nil,
+				},
+				"/usr/bin/traceroute": {
+					"security.capability": nil,
+				},
+			},
+		},
+		{
+			name: "Single-line capabilities with same flags",
+			caps: []Capability{
+				{
+					Path: "/bin/custom-tool",
+					Add: map[string]string{
+						"cap_net_raw,cap_net_admin": "+ep",
+					},
+					Reason: "foo",
+				},
+			},
+			expectedAttrs: map[string]map[string][]byte{
+				"/bin/custom-tool": {
+					"security.capability": nil,
+				},
+			},
+		},
+		{
+			name: "Multiple comma-separated capabilities with different flags",
+			caps: []Capability{
+				{
+					Path: "/usr/bin/privileged-tool",
+					Add: map[string]string{
+						"cap_net_raw,cap_net_admin,cap_net_bind_service": "+eip",
+						"cap_sys_admin": "+p",
+					},
+					Reason: "foo",
+				},
+			},
+			expectedAttrs: map[string]map[string][]byte{
+				"/usr/bin/privileged-tool": {
+					"security.capability": nil,
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			b := &Builder{
+				WorkspaceDirFS: newMockFS(),
+			}
+			b.Configuration.Package.SetCap = tc.caps
+
+			caps, err := ParseCapabilities(b.Configuration.Package.SetCap)
+			if err != nil {
+				t.Fatalf("Failed to collect capabilities: %v", err)
+			}
+
+			for path, caps := range caps {
+				enc := EncodeCapability(caps.Effective, caps.Permitted, caps.Inheritable)
+				if err := b.WorkspaceDirFS.SetXattr(path, "security.capability", enc); err != nil {
+					t.Fatalf("Failed to set capability: %v", err)
+				}
+			}
+
+			for path, attrs := range tc.expectedAttrs {
+				for attr := range attrs {
+					data, err := b.WorkspaceDirFS.GetXattr(path, attr)
+					if err != nil {
+						t.Errorf("Failed to get xattr %s for path %s: %v", attr, path, err)
+						continue
+					}
+
+					if len(data) < 24 {
+						t.Errorf("Capability data for %s is too short: %d bytes", path, len(data))
+						continue
+					}
+
+					magic := binary.LittleEndian.Uint32(data[0:4])
+					if magic != 0x20080522 {
+						t.Errorf("Invalid magic number: %x", magic)
+					}
+
+					version := binary.LittleEndian.Uint32(data[4:8])
+					if version != 0x3 {
+						t.Errorf("Invalid version: %d, expected 3", version)
+					}
+
+					effective := binary.LittleEndian.Uint32(data[8:12])
+					permitted := binary.LittleEndian.Uint32(data[12:16])
+					inheritable := binary.LittleEndian.Uint32(data[16:20])
+
+					caps := b.Configuration.Package.SetCap
+					for _, c := range caps {
+						if c.Path == path {
+							for attr, flag := range c.Add {
+								capValues := getCapabilityValue(attr)
+								e, p, i := parseCapability(flag)
+
+								if e && (effective&capValues != capValues) {
+									t.Errorf("Expected capabilities %s to be in effective set for %s", attr, path)
+								}
+								if p && (permitted&capValues != capValues) {
+									t.Errorf("Expected capabilities %s to be in permitted set for %s", attr, path)
+								}
+								if i && (inheritable&capValues != capValues) {
+									t.Errorf("Expected capabilities %s to be in inheritable set for %s", attr, path)
+								}
+							}
+						}
+					}
+				}
+			}
+		})
 	}
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -539,7 +539,7 @@ func TestSetCap(t *testing.T) {
 	}{
 		{
 			[]Capability{
-				Capability{
+				{
 					Path:   "/bar",
 					Add:    map[string]string{"cap_net_bind_service": "+eip"},
 					Reason: "Needed for package foo because xyz",
@@ -549,7 +549,7 @@ func TestSetCap(t *testing.T) {
 		},
 		{
 			[]Capability{
-				Capability{
+				{
 					Path:   "/bar",
 					Add:    map[string]string{"cap_net_raw": "+eip"},
 					Reason: "Needed for package baz because xyz",
@@ -559,17 +559,85 @@ func TestSetCap(t *testing.T) {
 		},
 		{
 			[]Capability{
-				Capability{
+				{
 					Path:   "/bar",
 					Add:    map[string]string{"cap_net_raw,cap_net_admin,cap_net_bind_service": "+ep"},
-					Reason: "Valid combination of three capabilities",
+					Reason: "Valid combination of three capabilities on a single line",
 				},
 			},
 			false,
 		},
 		{
 			[]Capability{
-				Capability{
+				{
+					Path: "/bar",
+					Add: map[string]string{
+						"cap_net_raw":          "+ep",
+						"cap_net_admin":        "+ep",
+						"cap_net_bind_service": "+ep",
+					},
+					Reason: "Valid combination of three capabilities on separate lines",
+				},
+			},
+			false,
+		},
+		{
+			[]Capability{
+				{
+					Path: "/foo",
+					Add: map[string]string{
+						"cap_net_raw": "+ep",
+					},
+					Reason: "First package in a multi-package, multi-capability capability addition.",
+				},
+				{
+					Path: "/bar",
+					Add: map[string]string{
+						"cap_net_admin":        "+ep",
+						"cap_net_bind_service": "+ep",
+					},
+					Reason: "Second package in a multi-package, multi-capability capability addition.",
+				},
+				{
+					Path: "/baz",
+					Add: map[string]string{
+						"cap_net_raw,cap_net_admin,cap_net_bind_service": "+eip",
+					},
+					Reason: "Third package in a multi-package, multi-capability capability addition.",
+				},
+			},
+			false,
+		},
+		{
+			[]Capability{
+				{
+					Path: "/foo",
+					Add: map[string]string{
+						"cap_net_raw": "+ep",
+					},
+					Reason: "First package in a multi-package, multi-capability capability addition.",
+				},
+				{
+					Path: "/bar",
+					Add: map[string]string{
+						"cap_setfcap":          "+ep",
+						"cap_net_bind_service": "+ep",
+					},
+					Reason: "Tying to sneak an invalid capability into multiple paths.",
+				},
+				{
+					Path: "/baz",
+					Add: map[string]string{
+						"cap_net_raw,cap_net_admin,cap_net_bind_service": "+eip",
+					},
+					Reason: "Third package in a multi-package, multi-capability capability addition.",
+				},
+			},
+			true,
+		},
+		{
+			[]Capability{
+				{
 					Path:   "/bar",
 					Add:    map[string]string{"cap_sys_admin": "+ep"},
 					Reason: "Needed for package baz",
@@ -579,7 +647,7 @@ func TestSetCap(t *testing.T) {
 		},
 		{
 			[]Capability{
-				Capability{
+				{
 					Path:   "/bar",
 					Add:    map[string]string{"cap_ipc_lock": "+ep"},
 					Reason: "Needed for package baz",
@@ -589,17 +657,17 @@ func TestSetCap(t *testing.T) {
 		},
 		{
 			[]Capability{
-				Capability{
+				{
 					Path:   "/bar",
 					Add:    map[string]string{"cap_net_admin": "+ep"},
 					Reason: "Needed for package baz",
 				},
 			},
-			true,
+			false,
 		},
 		{
 			[]Capability{
-				Capability{
+				{
 					Path:   "/bar",
 					Add:    map[string]string{"cap_net_admin": "+ep"},
 					Reason: "",
@@ -609,7 +677,7 @@ func TestSetCap(t *testing.T) {
 		},
 		{
 			[]Capability{
-				Capability{
+				{
 					Path:   "/bar",
 					Add:    map[string]string{"cap_setfcap": "+ep"},
 					Reason: "I want to arbitrarily set capabilities",


### PR DESCRIPTION
This PR picks up the ideation from #1902 and adds support for declarative capabilities. This will [hopefully] avoid permissions issues via `setcap` and is a more controlled way of handling what is generally a rare occurrence.

Capabilities can be set one per line or on a single line and will look like this:
```yaml
package:
  name: fping
  version: "5.3"
  epoch: 40
  description: A utility to ping multiple hosts at once
  copyright:
    - license: GPL-2.0-only
  dependencies:
    runtime:
      - merged-usrsbin
      - wolfi-baselayout
  setcap:
    - path: /usr/bin/fping
      add:
        cap_net_raw: "+ep"
      reason: "cap_net_raw is needed if not using root or the setuid bit"
...
```

Multiple capabilities can be added one per line:
```yaml
setcap:
    - path: /usr/bin/fping
      add:
        cap_net_raw: "+ep"
        cap_net_admin: "+ep"
      reason: "cap_net_raw and cap_net_admin are needed if not using root or the setuid bit"
```

Or multiple capabilities can be added on the same line:
```yaml
setcap:
    - path: /usr/bin/fping
      add:
        cap_net_raw,cap_net_admin: "+ep"
      reason: "cap_net_raw and cap_net_admin are needed if not using root or the setuid bit"
```


Multiple paths are supported as well:
```yaml
setcap:
    - path: /usr/bin/xtables-legacy-multi
      add:
        cap_net_raw,cap_net_admin: "+eip"
      reason: "cap_net_raw and cap_net_admin are needed if not using root or the setuid bit"
    - path: /usr/bin/xtables-nft-multi
      add:
        cap_net_raw,cap_net_admin: "+eip"
      reason: "cap_net_raw and cap_net_admin are needed if not using root or the setuid bit"
```

If a reason for adding capabilities for the given path(s) is not provided, an error will be thrown.