### PR TITLE
fix: propagate Range field of subpackages

### DIFF
--- a/pkg/build/build_test.go
+++ b/pkg/build/build_test.go
@@ -59,22 +59,26 @@ func TestConfiguration_Load(t *testing.T) {
 					},
 				},
 				Subpackages: []config.Subpackage{{
-					Name: "cats",
+					Name:  "cats",
+					Range: "animals",
 					Pipeline: []config.Pipeline{{
 						Runs: "cats are angry",
 					}},
 				}, {
-					Name: "dogs",
+					Name:  "dogs",
+					Range: "animals",
 					Pipeline: []config.Pipeline{{
 						Runs: "dogs are loyal",
 					}},
 				}, {
-					Name: "turtles",
+					Name:  "turtles",
+					Range: "animals",
 					Pipeline: []config.Pipeline{{
 						Runs: "turtles are slow",
 					}},
 				}, {
-					Name: "donatello",
+					Name:  "donatello",
+					Range: "ninja-turtles",
 					Pipeline: []config.Pipeline{
 						{
 							Runs: "donatello's color is purple",
@@ -85,7 +89,8 @@ func TestConfiguration_Load(t *testing.T) {
 						},
 					},
 				}, {
-					Name: "leonardo",
+					Name:  "leonardo",
+					Range: "ninja-turtles",
 					Pipeline: []config.Pipeline{
 						{
 							Runs: "leonardo's color is blue",
@@ -96,7 +101,8 @@ func TestConfiguration_Load(t *testing.T) {
 						},
 					},
 				}, {
-					Name: "michelangelo",
+					Name:  "michelangelo",
+					Range: "ninja-turtles",
 					Pipeline: []config.Pipeline{
 						{
 							Runs: "michelangelo's color is orange",
@@ -107,7 +113,8 @@ func TestConfiguration_Load(t *testing.T) {
 						},
 					},
 				}, {
-					Name: "raphael",
+					Name:  "raphael",
+					Range: "ninja-turtles",
 					Pipeline: []config.Pipeline{
 						{
 							Runs: "raphael's color is red",

--- a/pkg/build/test_test.go
+++ b/pkg/build/test_test.go
@@ -178,7 +178,8 @@ func TestConfigurationLoad(t *testing.T) {
 					},
 				},
 				Subpackages: []config.Subpackage{{
-					Name: "cats",
+					Name:  "cats",
+					Range: "animals",
 					Test: &config.Test{
 						Environment: defaultEnv(),
 						Pipeline: []config.Pipeline{{
@@ -186,7 +187,8 @@ func TestConfigurationLoad(t *testing.T) {
 						}},
 					},
 				}, {
-					Name: "dogs",
+					Name:  "dogs",
+					Range: "animals",
 					Test: &config.Test{
 						Environment: defaultEnv(),
 						Pipeline: []config.Pipeline{{
@@ -194,7 +196,8 @@ func TestConfigurationLoad(t *testing.T) {
 						}},
 					},
 				}, {
-					Name: "turtles",
+					Name:  "turtles",
+					Range: "animals",
 					Test: &config.Test{
 						Environment: defaultEnv(),
 						Pipeline: []config.Pipeline{{
@@ -202,7 +205,8 @@ func TestConfigurationLoad(t *testing.T) {
 						}},
 					},
 				}, {
-					Name: "donatello",
+					Name:  "donatello",
+					Range: "ninja-turtles",
 					Test: &config.Test{
 						Environment: defaultEnv(),
 						Pipeline: []config.Pipeline{
@@ -216,7 +220,8 @@ func TestConfigurationLoad(t *testing.T) {
 						},
 					},
 				}, {
-					Name: "leonardo",
+					Name:  "leonardo",
+					Range: "ninja-turtles",
 					Test: &config.Test{
 						Environment: defaultEnv(),
 						Pipeline: []config.Pipeline{
@@ -229,7 +234,8 @@ func TestConfigurationLoad(t *testing.T) {
 							},
 						}},
 				}, {
-					Name: "michelangelo",
+					Name:  "michelangelo",
+					Range: "ninja-turtles",
 					Test: &config.Test{
 						Environment: defaultEnv(),
 						Pipeline: []config.Pipeline{
@@ -242,7 +248,8 @@ func TestConfigurationLoad(t *testing.T) {
 							},
 						}},
 				}, {
-					Name: "raphael",
+					Name:  "raphael",
+					Range: "ninja-turtles",
 					Test: &config.Test{
 						Environment: defaultEnv(),
 						Pipeline: []config.Pipeline{

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1293,6 +1293,7 @@ func replaceSubpackage(r *strings.Replacer, detectedCommit string, in Subpackage
 		Commit:       replaceCommit(detectedCommit, in.Commit),
 		Checks:       in.Checks,
 		Test:         replaceTest(r, in.Test),
+		Range:        in.Range,
 	}
 }
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -221,6 +221,7 @@ subpackages:
 	require.Equal(t, cfg.Subpackages[0].Dependencies.Runtime[0], "wow-some-kinda-dynamically-linked-library-i-guess=1.0")
 	require.True(t, cfg.Subpackages[0].Options.NoProvides)
 	require.Equal(t, cfg.Subpackages[0].Test.Environment.Contents.Packages[1], "A-default-jvm")
+	require.Equal(t, cfg.Subpackages[0].Range, "I-am-a-range")
 }
 
 func Test_rangeSubstitutionsPriorities(t *testing.T) {
@@ -276,6 +277,8 @@ subpackages:
 	require.Equal(t, cfg.Subpackages[1].Pipeline[0].Needs.Packages[0], "b")
 	require.Equal(t, cfg.Subpackages[0].Pipeline[0].Pipeline[0].Runs, "exit 1")
 	require.Equal(t, cfg.Subpackages[1].Pipeline[0].Pipeline[0].Runs, "exit 1")
+	require.Equal(t, cfg.Subpackages[0].Range, "I-am-a-range")
+	require.Equal(t, cfg.Subpackages[1].Range, "I-am-a-range")
 }
 
 func Test_propagatePipelines(t *testing.T) {


### PR DESCRIPTION
## Melange Pull Request Template


### Functional Changes

- ParseConfiguration does NOT propagate the `Range` field on the subpackages when set on the yaml definition.
