### PR TITLE
Validity check to prevent builds failing when the install location is customized

### DIFF
--- a/pkg/build/pipelines/ruby/clean.yaml
+++ b/pkg/build/pipelines/ruby/clean.yaml
@@ -15,5 +15,7 @@ pipeline:
       INSTALL_DIR=${{targets.contextdir}}/$(ruby -e 'puts Gem.default_dir')
       rm -rf ${INSTALL_DIR}/build_info \
              ${INSTALL_DIR}/cache
-      find ${INSTALL_DIR} -name 'gem_make.out' -exec rm {} \;
-      find ${INSTALL_DIR} -name 'mkmf.log' -exec rm {} \;
+      if [ -d "${INSTALL_DIR}" ]; then
+        find "${INSTALL_DIR}" -name 'gem_make.out' -exec rm {} \;
+        find "${INSTALL_DIR}" -name 'mkmf.log' -exec rm {} \;
+      fi


### PR DESCRIPTION
If the install location is customized at all, these find commands will fail and cause the build to exit. Wrapping it in a validity check is a simple way to prevent this from failing outright. This can be seen in ruby-rails packages like [ruby3.4-rails-7.2 for example ](https://github.com/chainguard-dev/enterprise-packages/blob/488a49accda28c6205fe5e83773c8d778ffd9849/ruby3.4-rails-7.2.yaml#L48-L51). As well as[ where this will fail in CI](https://console.cloud.google.com/logs/query;query=logName%3Dprojects%2Fprod-wolfi-os%2Flogs%2Fstderr%0Aresource.type%3D%22k8s_container%22%0Aresource.labels.cluster_name%3D%22elastic-pre-a%22%0Aresource.labels.location%3D%22us-central1%22%0Aresource.labels.namespace_name%3D%22pre-wolfi%22%0Alabels.%22k8s-pod%2Fmelange_chainguard_dev%2Fbuild-id%22%3D%2200dea9c4-520e-4101-ab18-2eb464cf5721%22%0Alabels.%22k8s-pod%2Fmelange_chainguard_dev%2Farch%22%3D%22amd64%22%0Alabels.%22k8s-pod%2Fapp_kubernetes_io%2Fcomponent%22%3D%22ruby3.2-rails-8.0%22%0Atimestamp%3E%3D%222025-04-22T23:03:27Z%22%0Atimestamp%3C%3D%222025-04-22T23:17:52Z%22%0Alabels.%22k8s-pod%2Fmelange_chainguard_dev%2Ftest%22%3D%22false%22%0A;summaryFields=labels%252F%2522k8s-pod%252Fapp_kubernetes_io%252Fcomponent%2522,labels%252F%2522k8s-pod%252Fmelange_chainguard_dev%252Farch%2522:false:32:beginning;cursorTimestamp=2025-04-22T23:07:48.793700866Z;duration=PT1H?project=prod-wolfi-os). I came upon this after builds/tests succeeding locally on melange v0.23.5, but not in CI, upgrading local to [v0.23.8](https://github.com/chainguard-dev/melange/releases/tag/v0.23.8) results in reproducing CI behavior.


### Functional Changes

- [ ] This change can build all of Wolfi without errors (describe results in notes)
- Honestly I am not sure how to build -all- of wolfi in a one-shot command, maybe we can add instructions for this to a more evident readme, or link it here?


