### PR TITLE
Update declarative capabilities; add functionality to set within QEMU

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -997,7 +997,9 @@ func (b *Build) BuildPackage(ctx context.Context) error {
 			fullPath := filepath.Join(WorkDir, melangeOutputDirName, pkg.Name, path)
 			hex := fmt.Sprintf("0x%s", hex.EncodeToString(enc))
 			cmd := []string{"/bin/sh", "-c", fmt.Sprintf("setfattr -n security.capability -v %s %s", hex, fullPath)}
-			b.Runner.Run(ctx, pr.config, map[string]string{}, cmd...)
+			if err := b.Runner.Run(ctx, pr.config, map[string]string{}, cmd...); err != nil {
+				return fmt.Errorf("failed to set capabilities within VM on %s: %v\n", path, err)
+			}
 		} else {
 			if err := b.WorkspaceDirFS.SetXattr(fullPath, "security.capability", enc); err != nil {
 				log.Warnf("failed to set capabilities on %s: %v\n", path, err)

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -18,6 +18,7 @@ import (
 	"archive/tar"
 	"compress/gzip"
 	"context"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -313,6 +314,7 @@ func (b *Build) buildGuest(ctx context.Context, imgConfig apko_types.ImageConfig
 		b.ExtraPackages = append(b.ExtraPackages, []string{
 			"melange-microvm-init",
 			"gnutar",
+			"attr",
 		}...)
 	}
 
@@ -990,8 +992,16 @@ func (b *Build) BuildPackage(ctx context.Context) error {
 
 	for path, cap := range caps {
 		enc := config.EncodeCapability(cap.Effective, cap.Permitted, cap.Inheritable)
-		if err := b.WorkspaceDirFS.SetXattr(path, "security.capability", enc); err != nil {
-			log.Warnf("failed to set capabilities on %s: %v\n", path, err)
+		fullPath := filepath.Join(melangeOutputDirName, pkg.Name, path)
+		if b.Runner.Name() == container.QemuName {
+			fullPath := filepath.Join(WorkDir, melangeOutputDirName, pkg.Name, path)
+			hex := fmt.Sprintf("0x%s", hex.EncodeToString(enc))
+			cmd := []string{"/bin/sh", "-c", fmt.Sprintf("setfattr -n security.capability -v %s %s", hex, fullPath)}
+			b.Runner.Run(ctx, pr.config, map[string]string{}, cmd...)
+		} else {
+			if err := b.WorkspaceDirFS.SetXattr(fullPath, "security.capability", enc); err != nil {
+				log.Warnf("failed to set capabilities on %s: %v\n", path, err)
+			}
 		}
 	}
 


### PR DESCRIPTION
Follow-up for #1938. There were a few gaps since the tests weren't emulating what the runners actually do (it'll be nice to have a real testcase now that we're parsing the capabilities correctly as of this PR). The path also wasn't correct and the path is different depending on the runner.

I tested these changes with Bubblewrap and QEMU and was able to set capabilities without privilege, though testing still requires privilege.

Setting via QEMU:
```
2025/04/23 21:19:19 INFO retrieving workspace from builder:
[1 0 0 3 0 32 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0] // debug output
2025/04/23 21:19:19 INFO fetching remote workspace
setting xattr security.capability on melange-out/fping/usr/bin/fping
```

Setting via Bubblewrap:
```
2025/04/23 21:21:51 INFO retrieving workspace from builder:
[1 0 0 3 0 32 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0] // debug output
2025/04/23 21:21:51 INFO retrieved and wrote post-build workspace to: /tmp/melange-workspace-1872161713
```

Testing via QEMU (unprivileged):
```
$ make test/fping
Testing package fping with version fping-5.3-r40 from file fping.yaml
...
2025/04/23 21:16:46 INFO image configuration:
2025/04/23 21:16:46 INFO   contents:
2025/04/23 21:16:46 INFO     build repositories: []
2025/04/23 21:16:46 INFO     runtime repositories: []
2025/04/23 21:16:46 INFO     keyring:      []
2025/04/23 21:16:46 INFO     packages:     [fping libcap-utils]
2025/04/23 21:16:46 INFO   accounts:
2025/04/23 21:16:46 INFO     runas:
2025/04/23 21:16:46 INFO     users:
2025/04/23 21:16:46 INFO       - uid=1000(build) gid=1000
2025/04/23 21:16:46 INFO     groups:
2025/04/23 21:16:46 INFO       - gid=1000(build) members=[build]
2025/04/23 21:16:47 INFO installing wolfi-baselayout (20230201-r20)
2025/04/23 21:16:47 INFO installing ca-certificates-bundle (20241121-r40)
2025/04/23 21:16:47 INFO installing ld-linux (2.41-r2)
2025/04/23 21:16:47 INFO installing libgcc (14.2.0-r12)
2025/04/23 21:16:47 INFO installing glibc-locale-posix (2.41-r2)
2025/04/23 21:16:47 INFO installing glibc (2.41-r2)
2025/04/23 21:16:47 INFO installing fping (5.3-r40)
2025/04/23 21:16:47 INFO installing libcap (2.76-r0)
2025/04/23 21:16:47 INFO installing libcap-utils (2.76-r0)
2025/04/23 21:16:47 INFO installing wolfi-keys (1-r10)
2025/04/23 21:16:47 INFO installing zlib (1.3.1-r6)
2025/04/23 21:16:47 INFO installing libcrypto3 (3.5.0-r0)
2025/04/23 21:16:47 INFO installing libssl3 (3.5.0-r0)
2025/04/23 21:16:47 INFO installing apk-tools (2.14.10-r2)
2025/04/23 21:16:47 INFO installing libxcrypt (4.4.38-r1)
2025/04/23 21:16:47 INFO installing libcrypt1 (2.41-r2)
2025/04/23 21:16:47 INFO installing busybox (1.37.0-r40)
2025/04/23 21:16:47 INFO installing wolfi-base (1-r7)
2025/04/23 21:16:47 ERRO ERROR: failed to test package. the test environment has been preserved:
2025/04/23 21:16:47 ERRO failed to test package: unable to build guest: unable to set xattr security.capability on usr/bin/fping: operation not permitted
make: *** [Makefile:123: test/fping] Error 1
```

Testing via QEMU (privileged):
```
$ sudo -E env PATH="$PATH" make test/fping
...
2025/04/23 21:17:29 INFO image configuration:
2025/04/23 21:17:29 INFO   contents:
2025/04/23 21:17:29 INFO     build repositories: []
2025/04/23 21:17:29 INFO     runtime repositories: []
2025/04/23 21:17:29 INFO     keyring:      []
2025/04/23 21:17:29 INFO     packages:     [fping libcap-utils]
2025/04/23 21:17:29 INFO   accounts:
2025/04/23 21:17:29 INFO     runas:
2025/04/23 21:17:29 INFO     users:
2025/04/23 21:17:29 INFO       - uid=1000(build) gid=1000
2025/04/23 21:17:29 INFO     groups:
2025/04/23 21:17:29 INFO       - gid=1000(build) members=[build]                                                                                            2025/04/23 21:17:30 INFO installing wolfi-baselayout (20230201-r20)                                                                                         2025/04/23 21:17:30 INFO installing ca-certificates-bundle (20241121-r40)
2025/04/23 21:17:30 INFO installing ld-linux (2.41-r2)
2025/04/23 21:17:30 INFO installing libgcc (14.2.0-r12)
2025/04/23 21:17:30 INFO installing glibc-locale-posix (2.41-r2)
2025/04/23 21:17:30 INFO installing glibc (2.41-r2)
2025/04/23 21:17:30 INFO installing fping (5.3-r40)
2025/04/23 21:17:30 INFO installing libcap (2.76-r0)
2025/04/23 21:17:30 INFO installing libcap-utils (2.76-r0)
2025/04/23 21:17:30 INFO installing wolfi-keys (1-r10)
2025/04/23 21:17:30 INFO installing zlib (1.3.1-r6)
2025/04/23 21:17:30 INFO installing libcrypto3 (3.5.0-r0)
2025/04/23 21:17:30 INFO installing libssl3 (3.5.0-r0)
2025/04/23 21:17:30 INFO installing apk-tools (2.14.10-r2)
2025/04/23 21:17:30 INFO installing libxcrypt (4.4.38-r1)
2025/04/23 21:17:30 INFO installing libcrypt1 (2.41-r2)
2025/04/23 21:17:30 INFO installing busybox (1.37.0-r40)
2025/04/23 21:17:30 INFO installing wolfi-base (1-r7)
2025/04/23 21:17:30 INFO populating workspace /tmp/melange-workspace-2914174909 from ./fping/
2025/04/23 21:17:30 INFO running the main test pipeline
2025/04/23 21:17:30 WARN + '[' -d /home/build ]
2025/04/23 21:17:30 WARN + cd /home/build
2025/04/23 21:17:30 WARN + fping --version
2025/04/23 21:17:30 INFO fping: Version 5.3
2025/04/23 21:17:30 WARN + fping --help
2025/04/23 21:17:30 INFO Usage: fping [options] [targets...]
2025/04/23 21:17:30 INFO
2025/04/23 21:17:30 INFO Probing options:
2025/04/23 21:17:30 INFO    -4, --ipv4         only ping IPv4 addresses
2025/04/23 21:17:30 INFO    -6, --ipv6         only ping IPv6 addresses
2025/04/23 21:17:30 INFO    -b, --size=BYTES   amount of ping data to send, in bytes (default: 56)
2025/04/23 21:17:30 INFO    -B, --backoff=N    set exponential backoff factor to N (default: 1.5)
2025/04/23 21:17:30 INFO    -c, --count=N      count mode: send N pings to each target and report stats
2025/04/23 21:17:30 INFO    -f, --file=FILE    read list of targets from a file ( - means stdin)
2025/04/23 21:17:30 INFO    -g, --generate     generate target list (only if no -f specified),
2025/04/23 21:17:30 INFO                       limited to at most 131070 targets
2025/04/23 21:17:30 INFO                       (give start and end IP in the target list, or a CIDR address)
2025/04/23 21:17:30 INFO                       (ex. fping -g 192.168.1.0 192.168.1.255 or fping -g 192.168.1.0/24)
2025/04/23 21:17:30 INFO    -H, --ttl=N        set the IP TTL value (Time To Live hops)
2025/04/23 21:17:30 INFO    -i, --interval=MSEC  interval between sending ping packets (default: 10 ms)                                                     2025/04/23 21:17:30 INFO    -I, --iface=IFACE  bind to a particular interface                                                                               2025/04/23 21:17:30 INFO    -k, --fwmark=FWMARK set the routing mark
2025/04/23 21:17:30 INFO    -l, --loop         loop mode: send pings forever
2025/04/23 21:17:30 INFO    -m, --all          use all IPs of provided hostnames (e.g. IPv4 and IPv6), use with -A
2025/04/23 21:17:30 INFO    -M, --dontfrag     set the Don't Fragment flag
2025/04/23 21:17:30 INFO    -O, --tos=N        set the type of service (tos) flag on the ICMP packets
2025/04/23 21:17:30 INFO    -p, --period=MSEC  interval between ping packets to one target (in ms)
2025/04/23 21:17:30 INFO                       (in loop and count modes, default: 1000 ms)
2025/04/23 21:17:30 INFO    -r, --retry=N      number of retries (default: 3)
2025/04/23 21:17:30 INFO    -R, --random       random packet data (to foil link data compression)
2025/04/23 21:17:30 INFO    -S, --src=IP       set source address
2025/04/23 21:17:30 INFO    -t, --timeout=MSEC individual target initial timeout (default: 500 ms,
2025/04/23 21:17:30 INFO                       except with -l/-c/-C, where it's the -p period up to 2000 ms)
2025/04/23 21:17:30 INFO        --check-source discard replies not from target address
2025/04/23 21:17:30 INFO        --icmp-timestamp use ICMP Timestamp instead of ICMP Echo
2025/04/23 21:17:30 INFO
2025/04/23 21:17:30 INFO Output options:
2025/04/23 21:17:30 INFO    -a, --alive        show targets that are alive
2025/04/23 21:17:30 INFO    -A, --addr         show targets by address
2025/04/23 21:17:30 INFO    -C, --vcount=N     same as -c, report results (not stats) in verbose format
2025/04/23 21:17:30 INFO    -d, --rdns         show targets by name (force reverse-DNS lookup)
2025/04/23 21:17:30 INFO    -D, --timestamp    print timestamp before each output line
2025/04/23 21:17:30 INFO        --timestamp-format=FORMAT  show timestamp in the given format (-D required): ctime|iso|rfc3339
2025/04/23 21:17:30 INFO    -e, --elapsed      show elapsed time on return packets
2025/04/23 21:17:30 INFO    -n, --name         show targets by name (reverse-DNS lookup for target IPs)
2025/04/23 21:17:30 INFO    -N, --netdata      output compatible for netdata (-l -Q are required)
2025/04/23 21:17:30 INFO    -o, --outage       show the accumulated outage time (lost packets * packet interval)
2025/04/23 21:17:30 INFO    -q, --quiet        quiet (don't show per-target/per-ping results)
2025/04/23 21:17:30 INFO    -Q, --squiet=SECS[,cumulative]  same as -q, but add interval summary every SECS seconds,
2025/04/23 21:17:30 INFO                                    with 'cumulative', print stats since beginning
2025/04/23 21:17:30 INFO    -s, --stats        print final stats
2025/04/23 21:17:30 INFO    -u, --unreach      show targets that are unreachable
2025/04/23 21:17:30 INFO    -v, --version      show version
2025/04/23 21:17:30 INFO    -x, --reachable=N  shows if >=N hosts are reachable or not
2025/04/23 21:17:30 INFO    -X, --fast-reachable=N exits true immediately when N hosts are found
2025/04/23 21:17:30 INFO        --print-tos    show received TOS value
2025/04/23 21:17:30 INFO        --print-ttl    show IP TTL value
2025/04/23 21:17:30 WARN + exit 0
2025/04/23 21:17:30 INFO running step "Test file capabilities"
2025/04/23 21:17:30 WARN + '[' -d /home/build ]
2025/04/23 21:17:30 WARN + cd /home/build
2025/04/23 21:17:30 WARN + getcap /usr/bin/fping
2025/04/23 21:17:30 WARN + cut -d ' ' -f2
2025/04/23 21:17:30 WARN + grep -q -E '^cap_net_raw=+ep$'
2025/04/23 21:17:30 WARN + exit 0
2025/04/23 21:17:30 INFO running test pipeline for subpackage fping-doc
2025/04/23 21:17:30 INFO building test workspace in: '/tmp/melange-guest-3143922646-fping-doc' with apko
2025/04/23 21:17:30 INFO image configuration:
2025/04/23 21:17:30 INFO   contents:
2025/04/23 21:17:30 INFO     build repositories: []
2025/04/23 21:17:30 INFO     runtime repositories: []
2025/04/23 21:17:30 INFO     keyring:      []
2025/04/23 21:17:30 INFO     packages:     [apk-tools fping-doc grep man-db texinfo]
2025/04/23 21:17:30 INFO   accounts:
2025/04/23 21:17:30 INFO     runas:
2025/04/23 21:17:30 INFO     users:
2025/04/23 21:17:30 INFO       - uid=1000(build) gid=1000
2025/04/23 21:17:30 INFO     groups:
2025/04/23 21:17:30 INFO       - gid=1000(build) members=[build]
2025/04/23 21:17:30 INFO installing wolfi-baselayout (20230201-r20)
2025/04/23 21:17:30 INFO installing ca-certificates-bundle (20241121-r40)
2025/04/23 21:17:30 INFO installing ld-linux (2.41-r2)
2025/04/23 21:17:30 INFO installing libgcc (14.2.0-r12)
2025/04/23 21:17:30 INFO installing glibc-locale-posix (2.41-r2)
2025/04/23 21:17:30 INFO installing glibc (2.41-r2)
2025/04/23 21:17:30 INFO installing zlib (1.3.1-r6)
2025/04/23 21:17:30 INFO installing libcrypto3 (3.5.0-r0)
2025/04/23 21:17:30 INFO installing libssl3 (3.5.0-r0)
2025/04/23 21:17:30 INFO installing apk-tools (2.14.10-r2)
2025/04/23 21:17:30 INFO installing libpipeline (1.5.8-r0)
2025/04/23 21:17:30 INFO installing libstdc++ (14.2.0-r12)
2025/04/23 21:17:30 INFO installing groff-base (1.23.0-r5)
2025/04/23 21:17:30 INFO installing libbz2-1 (1.0.8-r11)
2025/04/23 21:17:30 INFO installing libxcrypt (4.4.38-r1)
2025/04/23 21:17:30 INFO installing libcrypt1 (2.41-r2)
2025/04/23 21:17:30 INFO installing perl (5.40.2-r0)
2025/04/23 21:17:31 INFO installing groff (1.23.0-r5)
2025/04/23 21:17:31 INFO installing libseccomp (2.6.0-r1)
2025/04/23 21:17:31 INFO installing gdbm (1.25-r0)
2025/04/23 21:17:31 INFO installing man-db (2.13.0-r40)
2025/04/23 21:17:31 INFO installing fping-doc (5.3-r40)
2025/04/23 21:17:31 INFO installing libpcre2-8-0 (10.45-r1)
2025/04/23 21:17:31 INFO installing grep (3.12-r0)
2025/04/23 21:17:31 INFO installing ncurses-terminfo-base (6.5_p20241228-r1)
2025/04/23 21:17:31 INFO installing ncurses (6.5_p20241228-r1)
2025/04/23 21:17:31 INFO installing texinfo (7.2-r1)
2025/04/23 21:17:31 INFO installing wolfi-keys (1-r10)
2025/04/23 21:17:31 INFO installing busybox (1.37.0-r40)
2025/04/23 21:17:31 INFO installing wolfi-base (1-r7)
2025/04/23 21:17:31 INFO running step "test/docs"
2025/04/23 21:17:31 WARN + '[' -d /home/build ]
2025/04/23 21:17:31 WARN + cd /home/build
2025/04/23 21:17:31 WARN + exit 0
2025/04/23 21:17:31 INFO running step "docs readability check"
2025/04/23 21:17:31 WARN + '[' -d /home/build ]
2025/04/23 21:17:31 WARN + cd /home/build
2025/04/23 21:17:31 WARN + basename /home/build/melange-out/fping-doc
2025/04/23 21:17:31 WARN + doc_pkg=fping-doc
2025/04/23 21:17:31 WARN + apk info -qL fping-doc
2025/04/23 21:17:31 WARN + grep -v ^var/lib/db/sbom
2025/04/23 21:17:31 WARN + grep -v '^$'
2025/04/23 21:17:31 WARN + wc -l
2025/04/23 21:17:31 WARN + '[' 1 -eq 0 ]
2025/04/23 21:17:31 WARN + cd /
2025/04/23 21:17:31 WARN + doc_files=false
2025/04/23 21:17:31 WARN + apk info -qL fping-doc
2025/04/23 21:17:31 WARN + grep ^usr/share/man/
2025/04/23 21:17:31 WARN + '[' -f /usr/share/man/man8/fping.8 ]
2025/04/23 21:17:31 WARN + man -l /usr/share/man/man8/fping.8
2025/04/23 21:17:31 WARN troff:<standard input>:126: warning: cannot select font 'CW'
2025/04/23 21:17:31 WARN troff:<standard input>:132: warning: cannot select font 'CW'
2025/04/23 21:17:31 WARN troff:<standard input>:159: warning: cannot select font 'CW'
2025/04/23 21:17:31 WARN troff:<standard input>:174: warning: cannot select font 'CW'
2025/04/23 21:17:31 WARN troff:<standard input>:180: warning: cannot select font 'CW'
2025/04/23 21:17:31 WARN troff:<standard input>:307: warning: cannot select font 'CW'
2025/04/23 21:17:31 WARN troff:<standard input>:330: warning: cannot select font 'CW'
2025/04/23 21:17:31 WARN troff:<standard input>:330: warning: cannot select font 'CW'
2025/04/23 21:17:31 WARN troff:<standard input>:334: warning: cannot select font 'CW'
2025/04/23 21:17:31 WARN troff:<standard input>:342: warning: cannot select font 'CW'
2025/04/23 21:17:31 WARN + doc_files=true
2025/04/23 21:17:31 WARN + apk info -qL fping-doc
2025/04/23 21:17:31 WARN + grep ^usr/share/info/
2025/04/23 21:17:31 WARN + apk info -qL fping-doc
2025/04/23 21:17:31 WARN + grep ^usr/share/
2025/04/23 21:17:31 WARN + '[' -f /usr/share/man/man8/fping.8 ]
2025/04/23 21:17:31 WARN + cat /usr/share/man/man8/fping.8
2025/04/23 21:17:31 WARN + doc_files=true
2025/04/23 21:17:31 WARN + '[' true '=' false ]
2025/04/23 21:17:31 WARN + exit 0
```

Bubblewrap works the same way.