### PR TITLE
Set acpi=off for micro VMs; attempt to use micro VMs by default

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -1251,7 +1251,6 @@ func (b *Build) buildWorkspaceConfig(ctx context.Context) *container.Config {
 		cfg.CPUModel = b.Configuration.Package.Resources.CPUModel
 		cfg.Memory = b.Configuration.Package.Resources.Memory
 		cfg.Disk = b.Configuration.Package.Resources.Disk
-		cfg.MicroVM = b.Configuration.Package.Resources.MicroVM
 	}
 	if b.Configuration.Capabilities.Add != nil {
 		cfg.Capabilities.Add = b.Configuration.Capabilities.Add

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -176,7 +176,6 @@ type Resources struct {
 	CPUModel string `json:"cpumodel,omitempty" yaml:"cpumodel,omitempty"`
 	Memory   string `json:"memory,omitempty" yaml:"memory,omitempty"`
 	Disk     string `json:"disk,omitempty" yaml:"disk,omitempty"`
-	MicroVM  bool   `json:"microvm,omitempty" yaml:"microvm,omitempty"`
 }
 
 // CPEString returns the CPE string for the package, suitable for matching

--- a/pkg/container/config.go
+++ b/pkg/container/config.go
@@ -60,5 +60,4 @@ type Config struct {
 	SSHHostKey            string
 	Disk                  string
 	Timeout               time.Duration
-	MicroVM               bool
 }

--- a/pkg/container/qemu_runner.go
+++ b/pkg/container/qemu_runner.go
@@ -507,6 +507,8 @@ func createMicroVM(ctx context.Context, cfg *Config) error {
 
 	// we need to fallback to -machine virt, if not machine has been specified
 	if !useVM {
+		// aarch64 supports virt machine type, let's use that if we're on it, else
+		// if we're on x86 arch, but without microvm machine type, let's go to q35
 		log.Infof("qemu: not attempting to use a microVM")
 		if cfg.Arch.ToAPK() == "aarch64" {
 			baseargs = append(baseargs, "-machine", "virt")


### PR DESCRIPTION
@smoser noted that setting `acpi=off` resolved the issues alluded to in #1945. 

Given that, this PR adds that option in the `-machine` args and now defaults to using a microVM as opposed to what was previously defined in the aforementioned PR. 

The package-level config was also not ideal so this behavior is now opt-out solely via `QEMU_USE_MICROVM`.