### PR TITLE
QEMU runner tweaks

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -1123,7 +1123,6 @@ func (b *Build) buildWorkspaceConfig(ctx context.Context) *container.Config {
 		cfg.CPUModel = b.Configuration.Package.Resources.CPUModel
 		cfg.Memory = b.Configuration.Package.Resources.Memory
 		cfg.Disk = b.Configuration.Package.Resources.Disk
-		cfg.MicroVM = b.Configuration.Package.Resources.MicroVM
 	}
 	if b.Configuration.Capabilities.Add != nil {
 		cfg.Capabilities.Add = b.Configuration.Capabilities.Add

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -176,7 +176,6 @@ type Resources struct {
 	CPUModel string `json:"cpumodel,omitempty" yaml:"cpumodel,omitempty"`
 	Memory   string `json:"memory,omitempty" yaml:"memory,omitempty"`
 	Disk     string `json:"disk,omitempty" yaml:"disk,omitempty"`
-	MicroVM  bool   `json:"microvm,omitempty" yaml:"microvm,omitempty"`
 }
 
 // CPEString returns the CPE string for the package, suitable for matching

--- a/pkg/container/config.go
+++ b/pkg/container/config.go
@@ -60,5 +60,4 @@ type Config struct {
 	SSHHostKey            string
 	Disk                  string
 	Timeout               time.Duration
-	MicroVM               bool
 }

--- a/pkg/container/qemu_runner.go
+++ b/pkg/container/qemu_runner.go
@@ -1070,38 +1070,31 @@ func generateSSHKeys(ctx context.Context, cfg *Config) ([]byte, error) {
 	return ssh.MarshalAuthorizedKey(publicKey), nil
 }
 
+// Use binary values for all units
 const (
-	_   = iota
-	KiB = 1 << (10 * iota)
-	MiB
-	GiB
-	TiB
-)
-
-const (
-	B  int64 = 1
-	KB int64 = B * 1000
-	MB int64 = KB * 1000
-	GB int64 = MB * 1000
-	TB int64 = GB * 1000
+	_  = iota
+	KB = 1 << (10 * iota)
+	MB
+	GB
+	TB
 )
 
 func convertHumanToKB(memory string) (int64, error) {
 	// Map of unit multipliers
 	unitMultipliers := map[string]int64{
-		"Ki": KiB, // Kibibytes
-		"Mi": MiB, // Mebibytes
-		"Gi": GiB, // Gibibytes
-		"Ti": TiB, // Tebibytes
-		"K":  KB,  // Kilobytes
-		"M":  MB,  // Megabytes
-		"G":  GB,  // Gigabytes
-		"T":  TB,  // Terabytes
-		"k":  KB,  // Kilobytes
-		"m":  MB,  // Megabytes
-		"g":  GB,  // Gigabytes
-		"t":  TB,  // Terabytes
-		"B":  B,   // Bytes
+		"Ki": KB, // Kibibytes
+		"Mi": MB, // Mebibytes
+		"Gi": GB, // Gibibytes
+		"Ti": TB, // Tebibytes
+		"K":  KB, // Kilobytes
+		"M":  MB, // Megabytes
+		"G":  GB, // Gigabytes
+		"T":  TB, // Terabytes
+		"k":  KB, // Kilobytes
+		"m":  MB, // Megabytes
+		"g":  GB, // Gigabytes
+		"t":  TB, // Terabytes
+		"B":  1,  // Bytes
 	}
 
 	// Separate the numerical part from the unit part
@@ -1131,11 +1124,7 @@ func convertHumanToKB(memory string) (int64, error) {
 	}
 
 	// Return the value in kilobytes
-	div := KB
-	if strings.Contains(unit, "i") {
-		div = KiB
-	}
-	return num * multiplier / div, nil
+	return num * multiplier / 1024, nil
 }
 
 func getAvailableMemoryKB() int {

--- a/pkg/container/qemu_runner.go
+++ b/pkg/container/qemu_runner.go
@@ -1070,22 +1070,38 @@ func generateSSHKeys(ctx context.Context, cfg *Config) ([]byte, error) {
 	return ssh.MarshalAuthorizedKey(publicKey), nil
 }
 
+const (
+	_   = iota
+	KiB = 1 << (10 * iota)
+	MiB
+	GiB
+	TiB
+)
+
+const (
+	B  int64 = 1
+	KB int64 = B * 1000
+	MB int64 = KB * 1000
+	GB int64 = MB * 1000
+	TB int64 = GB * 1000
+)
+
 func convertHumanToKB(memory string) (int64, error) {
 	// Map of unit multipliers
 	unitMultipliers := map[string]int64{
-		"Ki": 1024,                      // Kibibytes
-		"Mi": 1024 * 1024,               // Mebibytes
-		"Gi": 1024 * 1024 * 1024,        // Gibibytes
-		"Ti": 1024 * 1024 * 1024 * 1024, // Tebibytes
-		"K":  1000,                      // Kilobytes (KB)
-		"M":  1000 * 1000,               // Megabytes (MB)
-		"G":  1000 * 1000 * 1000,        // Gigabytes (GB)
-		"T":  1000 * 1000 * 1000 * 1000, // Terabytes (TB)
-		"k":  1000,                      // Kilobytes (KB)
-		"m":  1000 * 1000,               // Megabytes (MB)
-		"g":  1000 * 1000 * 1000,        // Gigabytes (GB)
-		"t":  1000 * 1000 * 1000 * 1000, // Terabytes (TB)
-		"B":  1,
+		"Ki": KiB, // Kibibytes
+		"Mi": MiB, // Mebibytes
+		"Gi": GiB, // Gibibytes
+		"Ti": TiB, // Tebibytes
+		"K":  KB,  // Kilobytes (KB)
+		"M":  MB,  // Megabytes (MB)
+		"G":  GB,  // Gigabytes (GB)
+		"T":  TB,  // Terabytes (TB)
+		"k":  KB,  // Kilobytes (KB)
+		"m":  MB,  // Megabytes (MB)
+		"g":  GB,  // Gigabytes (GB)
+		"t":  TB,  // Terabytes (TB)
+		"B":  B,   // Bytes (B)
 	}
 
 	// Separate the numerical part from the unit part
@@ -1115,9 +1131,9 @@ func convertHumanToKB(memory string) (int64, error) {
 	}
 
 	// Return the value in kilobytes
-	div := int64(1000)
+	div := KB
 	if strings.Contains(unit, "i") {
-		div = int64(1024)
+		div = KiB
 	}
 	return num * multiplier / div, nil
 }

--- a/pkg/container/qemu_runner.go
+++ b/pkg/container/qemu_runner.go
@@ -1093,15 +1093,15 @@ func convertHumanToKB(memory string) (int64, error) {
 		"Mi": MiB, // Mebibytes
 		"Gi": GiB, // Gibibytes
 		"Ti": TiB, // Tebibytes
-		"K":  KB,  // Kilobytes (KB)
-		"M":  MB,  // Megabytes (MB)
-		"G":  GB,  // Gigabytes (GB)
-		"T":  TB,  // Terabytes (TB)
-		"k":  KB,  // Kilobytes (KB)
-		"m":  MB,  // Megabytes (MB)
-		"g":  GB,  // Gigabytes (GB)
-		"t":  TB,  // Terabytes (TB)
-		"B":  B,   // Bytes (B)
+		"K":  KB,  // Kilobytes
+		"M":  MB,  // Megabytes
+		"G":  GB,  // Gigabytes
+		"T":  TB,  // Terabytes
+		"k":  KB,  // Kilobytes
+		"m":  MB,  // Megabytes
+		"g":  GB,  // Gigabytes
+		"t":  TB,  // Terabytes
+		"B":  B,   // Bytes
 	}
 
 	// Separate the numerical part from the unit part

--- a/pkg/container/qemu_runner.go
+++ b/pkg/container/qemu_runner.go
@@ -476,13 +476,11 @@ func createMicroVM(ctx context.Context, cfg *Config) error {
 	}
 
 	baseargs := []string{}
-	microvm := false
-	// by default, cfg.MicroVM will be false
-	// override the MicroVM config value with the environment variable if present
-	// and said variable is parseable as a bool
-	if env, ok := os.LookupEnv("QEMU_USE_MICROVM"); ok {
-		if val, err := strconv.ParseBool(env); err == nil {
-			cfg.MicroVM = val
+	bios := false
+	useVM := false
+	if qemuVM, ok := os.LookupEnv("QEMU_USE_MICROVM"); ok {
+		if val, err := strconv.ParseBool(qemuVM); err == nil {
+			useVM = val
 		}
 	}
 
@@ -492,7 +490,7 @@ func createMicroVM(ctx context.Context, cfg *Config) error {
 		"-chardev", "stdio,id=charconsole0",
 		"-device", "virtconsole,chardev=charconsole0,id=console0",
 	}
-	if cfg.MicroVM {
+	if useVM {
 		// load microvm profile and bios, shave some milliseconds from boot
 		// using this will make a complete boot->initrd (with working network) In ~700ms
 		// instead of ~900ms.
@@ -507,21 +505,22 @@ func createMicroVM(ctx context.Context, cfg *Config) error {
 				// microvm in qemu any version tested will not send hvc0/virtconsole to stdout
 				kernelConsole = "console=ttyS0"
 				serialArgs = []string{"-serial", "stdio"}
-				microvm = true
+				bios = true
 				break
 			}
 		}
 	}
 
-	// we need to fallback to -machine virt, if not machine has been specified
-	if !microvm {
+	// we need to fall back to -machine virt if no microVM BIOS was found (or QEMU_USE_MICROVM is false)
+	if !bios {
 		// aarch64 supports virt machine type, let's use that if we're on it, else
 		// if we're on x86 arch, but without microvm machine type, let's go to q35
-		if cfg.Arch.ToAPK() == "aarch64" {
+		switch cfg.Arch.ToAPK() {
+		case "aarch64":
 			baseargs = append(baseargs, "-machine", "virt")
-		} else if cfg.Arch.ToAPK() == "x86_64" {
+		case "x86_64":
 			baseargs = append(baseargs, "-machine", "q35")
-		} else {
+		default:
 			return fmt.Errorf("unknown architecture: %s", cfg.Arch.ToAPK())
 		}
 	}
@@ -542,7 +541,8 @@ func createMicroVM(ctx context.Context, cfg *Config) error {
 
 		cfg.Memory = fmt.Sprintf("%dk", memKb)
 	} else {
-		cfg.Memory = fmt.Sprintf("%dk", getAvailableMemoryKB()/4)
+		// Use at most ~85% of the available host memory
+		cfg.Memory = fmt.Sprintf("%dk", int(float64(getAvailableMemoryKB())*0.85))
 	}
 	baseargs = append(baseargs, "-m", cfg.Memory)
 
@@ -552,33 +552,31 @@ func createMicroVM(ctx context.Context, cfg *Config) error {
 		baseargs = append(baseargs, "-smp", fmt.Sprintf("%d", runtime.NumCPU()))
 	}
 
-	// use kvm on linux, and Hypervisor.framework on macOS
-	if cfg.Arch.ToAPK() != apko_types.ParseArchitecture(runtime.GOARCH).ToAPK() {
+	// use kvm on linux, Hypervisor.framework on macOS, and software for cross-arch
+	switch {
+	case cfg.Arch.ToAPK() != apko_types.ParseArchitecture(runtime.GOARCH).ToAPK():
 		baseargs = append(baseargs, "-accel", "tcg,thread=multi")
-	} else {
-		if runtime.GOOS == "linux" {
-			baseargs = append(baseargs, "-accel", "kvm")
-		} else if runtime.GOOS == "darwin" {
-			baseargs = append(baseargs, "-accel", "hvf")
-		}
+	case runtime.GOOS == "linux":
+		baseargs = append(baseargs, "-accel", "kvm")
+	case runtime.GOOS == "darwin":
+		baseargs = append(baseargs, "-accel", "hvf")
+	default:
+		baseargs = append(baseargs, "-accel", "tcg,thread=multi")
 	}
 
-	if cfg.CPUModel != "" {
+	switch {
+	case cfg.CPUModel != "":
 		baseargs = append(baseargs, "-cpu", cfg.CPUModel)
-	} else {
-		baseargs = append(baseargs, "-cpu", "host")
-		// we cant use `-cpu host` when architecture does not match between host
-		// and guest
-		if cfg.Arch.ToAPK() != apko_types.ParseArchitecture(runtime.GOARCH).ToAPK() {
-			// let's use a recent default for those
-			if cfg.Arch.ToAPK() == "aarch64" {
-				baseargs = append(baseargs, "-cpu", "cortex-a76")
-			} else if cfg.Arch.ToAPK() == "x86_64" {
-				baseargs = append(baseargs, "-cpu", "Haswell-v4")
-			} else {
-				return fmt.Errorf("unknown architecture: %s", cfg.Arch.ToAPK())
-			}
+	case cfg.Arch.ToAPK() != apko_types.ParseArchitecture(runtime.GOARCH).ToAPK():
+		if cfg.Arch.ToAPK() == "aarch64" {
+			baseargs = append(baseargs, "-cpu", "cortex-a76")
+		} else if cfg.Arch.ToAPK() == "x86_64" {
+			baseargs = append(baseargs, "-cpu", "Haswell-v4")
+		} else {
+			return fmt.Errorf("unknown architecture: %s", cfg.Arch.ToAPK())
 		}
+	default:
+		baseargs = append(baseargs, "-cpu", "host")
 	}
 
 	// ensure we disable unneeded devices, this is less needed if we use microvm machines
@@ -1079,14 +1077,14 @@ func convertHumanToKB(memory string) (int64, error) {
 		"Mi": 1024 * 1024,               // Mebibytes
 		"Gi": 1024 * 1024 * 1024,        // Gibibytes
 		"Ti": 1024 * 1024 * 1024 * 1024, // Tebibytes
-		"K":  1024,                      // Kilobytes (KB)
-		"M":  1024 * 1024,               // Megabytes (MB)
-		"G":  1024 * 1024 * 1024,        // Gigabytes (GB)
-		"T":  1024 * 1024 * 1024 * 1024, // Terabytes (TB)
-		"k":  1024,                      // Kilobytes (KB)
-		"m":  1024 * 1024,               // Megabytes (MB)
-		"g":  1024 * 1024 * 1024,        // Gigabytes (GB)
-		"t":  1024 * 1024 * 1024 * 1024, // Terabytes (TB)
+		"K":  1000,                      // Kilobytes (KB)
+		"M":  1000 * 1000,               // Megabytes (MB)
+		"G":  1000 * 1000 * 1000,        // Gigabytes (GB)
+		"T":  1000 * 1000 * 1000 * 1000, // Terabytes (TB)
+		"k":  1000,                      // Kilobytes (KB)
+		"m":  1000 * 1000,               // Megabytes (MB)
+		"g":  1000 * 1000 * 1000,        // Gigabytes (GB)
+		"t":  1000 * 1000 * 1000 * 1000, // Terabytes (TB)
 		"B":  1,
 	}
 

--- a/pkg/container/qemu_runner.go
+++ b/pkg/container/qemu_runner.go
@@ -1115,7 +1115,11 @@ func convertHumanToKB(memory string) (int64, error) {
 	}
 
 	// Return the value in kilobytes
-	return num * multiplier / 1024, nil
+	div := int64(1000)
+	if strings.Contains(unit, "i") {
+		div = int64(1024)
+	}
+	return num * multiplier / div, nil
 }
 
 func getAvailableMemoryKB() int {


### PR DESCRIPTION
This PR makes a few tweaks to the QEMU runner code, namely:
- Increased memory usage instead of capping at 1/4th of the system's memory (we can go lower than 85%, too)
- Relying on a single way to specify microVM usage
- Pedantic change for units

TBD if we can land a fix for using QEMU on baremetal ARM instances.