### PR TITLE
fix(bump): Only update first git-checkout node with expected-commit

### DIFF
--- a/pkg/renovate/bump/bump.go
+++ b/pkg/renovate/bump/bump.go
@@ -140,7 +140,8 @@ func New(ctx context.Context, opts ...Option) renovate.Renovator {
 			RecurseNodes().
 			Filter(yit.WithMapValue("git-checkout"))
 
-		for gitCheckoutNode, ok := it(); ok; gitCheckoutNode, ok = it() {
+		// Only run updateGitCheckout once for the first git-checkout node
+		if gitCheckoutNode, ok := it(); ok {
 			if err := updateGitCheckout(ctx, gitCheckoutNode, bcfg.ExpectedCommit); err != nil {
 				return err
 			}

--- a/pkg/renovate/bump/bump_test.go
+++ b/pkg/renovate/bump/bump_test.go
@@ -176,6 +176,7 @@ func TestBump_withMultipleCheckouts(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, rs.Pipeline[0].With["expected-commit"], "1234abcd")
 	assert.Equal(t, rs.Pipeline[1].With["expected-commit"], "bar")
+	assert.Equal(t, rs.Pipeline[2].With["expected-commit"], "water")
 }
 
 func setupTestServer(t *testing.T) (error, *httptest.Server) {

--- a/pkg/renovate/bump/testdata/multiple_checkouts.yaml
+++ b/pkg/renovate/bump/testdata/multiple_checkouts.yaml
@@ -4,6 +4,9 @@ package:
   epoch: 2
   description: "a cheesy library"
 
+vars:
+  pasts: "7.1"
+
 pipeline:
   - uses: git-checkout
     with:
@@ -15,3 +18,8 @@ pipeline:
       repository: cheese/cheese
       expected-commit: bar
       tag: crackers
+  - uses: git-checkout
+    with:
+      repository: cheese/pasta
+      expected-commit: water
+      tag: ${{vars.pasts}}


### PR DESCRIPTION
- Previously, all git-checkout nodes in a config were updated with the same commit SHA.
- This caused incorrect updates when multiple git-checkout steps exist, each referring to different repositories or commits.
- Now, only the first git-checkout node is updated to prevent partial or broken updates.
- Reduces incorrect automated updates and the need for manual intervention.

## Melange Pull Request Template

<!--
*** PULL REQUEST CHECKLIST: PLEASE START HERE ***

The single most important feature of melange is that we can build Wolfi.

Many changes to melange introduce a risk of breaking the build, and sometimes
these are not flushed out until a package is changed (much) later.  This
pertains to basic execution, SCA changes, linter changes, and more.
-->

### Functional Changes

- [x] This change can build all of Wolfi without errors (describe results in notes)

Notes:

### SCA Changes

- [ ] Examining several representative APKs show no regression / the desired effect (details in notes)

Notes:

### Linter

- [ ] The new check is clean across Wolfi
- [ ] The new check is opt-in or a warning

Notes:
