### PR TITLE
Retrieve the full workspace.

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -1193,7 +1193,7 @@ func (b *Build) retrieveWorkspace(ctx context.Context, fs apkofs.FullFS) error {
 			}
 
 		case tar.TypeReg:
-			f, err := fs.OpenFile(hdr.Name, os.O_CREATE|os.O_EXCL|os.O_WRONLY, hdr.FileInfo().Mode())
+			f, err := fs.OpenFile(hdr.Name, os.O_CREATE|os.O_WRONLY, hdr.FileInfo().Mode())
 			if err != nil {
 				return fmt.Errorf("unable to open file %s: %w", hdr.Name, err)
 			}

--- a/pkg/container/qemu_runner.go
+++ b/pkg/container/qemu_runner.go
@@ -401,7 +401,7 @@ func (bw *qemu) WorkspaceTar(ctx context.Context, cfg *Config) (io.ReadCloser, e
 		nil,
 		outFile,
 		false,
-		[]string{"sh", "-c", "cd /home/build && tar cvpzf - --xattrs --acls melange-out"},
+		[]string{"sh", "-c", "cd /home/build && tar cvpzf - --xattrs --acls *"},
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This changes the QEMU runner to retrieve the full workspace, not just `melange-out`.  This is because the license checker is failing to extract livense files from the workspace.

This also changes the `retrieveWorkspace` logic to allow overwriting files, since we otherwise see issues with files we seeded the workspace with prior to the build.

We see this using the QEMU runner on `db.yaml` and other builds with `license-path` set.