### PR TITLE
Turn relative working-dir into absolute paths.

### DIFF
--- a/pkg/build/pipeline.go
+++ b/pkg/build/pipeline.go
@@ -216,7 +216,7 @@ func (r *pipelineRunner) runPipeline(ctx context.Context, pipeline *config.Pipel
 
 	workdir := WorkDir
 	if pipeline.WorkDir != "" {
-		workdir = pipeline.WorkDir
+		workdir = filepath.Join(WorkDir, pipeline.WorkDir)
 	}
 
 	// We might have called signal.Ignore(os.Interrupt) as part of a previous debug step,


### PR DESCRIPTION
The QEMU runner doesn't handle relative `working-directory` paths properly because unlike the bubblewrap runner it doesn't start each invocation by changing into `/home/build`.

Prior to this change `php-8.3-pecl-pdosqlsrv.yaml` failed with the QEMU runner and now it builds just fine!
