### PR TITLE
add securityContext stanza

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -923,3 +923,35 @@ func TestSetCapability(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateSecurityContext(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		sc      *SecurityContext
+		wantErr bool
+	}{{
+		name: "valid security context",
+		sc: &SecurityContext{
+			Privileged: true,
+			Reason:     "Valid reason",
+		},
+		wantErr: false,
+	}, {
+		name: "invalid security context with empty reason",
+		sc: &SecurityContext{
+			Privileged: true,
+			Reason:     "",
+		},
+		wantErr: true,
+	}, {
+		name:    "nil security context",
+		sc:      nil,
+		wantErr: false, // nil is valid
+	}} {
+		t.Run(test.name, func(t *testing.T) {
+			if err := validateSecurityContext(test.sc); (err != nil) != test.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, test.wantErr)
+			}
+		})
+	}
+}

--- a/pkg/config/schema.json
+++ b/pkg/config/schema.json
@@ -90,6 +90,25 @@
       "type": "object",
       "description": "Capabilities is the configuration for Linux capabilities for the runner."
     },
+    "Capability": {
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "add": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "reason": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "Capability stores paths and an associated map of capabilities and justification to include in a package."
+    },
     "Checks": {
       "properties": {
         "disabled": {
@@ -166,6 +185,10 @@
         "test": {
           "$ref": "#/$defs/Test",
           "description": "Test section for the main package."
+        },
+        "securityContext": {
+          "$ref": "#/$defs/SecurityContext",
+          "description": "Optional: The security context to use when running this build as a Pod in a Kubernetes cluster."
         }
       },
       "additionalProperties": false,
@@ -211,7 +234,7 @@
         },
         "detection-override": {
           "type": "string",
-          "description": "Optional: The detected license that should be overriden, used in cases where the automation is wrong."
+          "description": "Optional: License override"
         }
       },
       "additionalProperties": false,
@@ -627,6 +650,13 @@
           "$ref": "#/$defs/CPE",
           "description": "The CPE field values to be used for matching against NVD vulnerability\nrecords, if known."
         },
+        "setcap": {
+          "items": {
+            "$ref": "#/$defs/Capability"
+          },
+          "type": "array",
+          "description": "Capabilities to set after the pipeline completes."
+        },
         "timeout": {
           "type": "integer",
           "description": "Optional: The amount of time to allow this build to take before timing out."
@@ -824,6 +854,9 @@
         },
         "disk": {
           "type": "string"
+        },
+        "microvm": {
+          "type": "boolean"
         }
       },
       "additionalProperties": false,
@@ -877,6 +910,41 @@
       "additionalProperties": false,
       "type": "object"
     },
+    "SecurityContext": {
+      "properties": {
+        "reason": {
+          "type": "string",
+          "description": "Human-readable description of why this package build needs a non-default security context."
+        },
+        "Runner": {
+          "type": "string",
+          "description": "Unset means use the default runner."
+        },
+        "TestRunner": {
+          "type": "string",
+          "description": "If unset, use the same as Runner; if both unset, use the default runner."
+        },
+        "Privileged": {
+          "type": "boolean",
+          "description": "Whether to run the build and test pipelines in a privileged container."
+        },
+        "addCaps": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Linux process capabilities to add to the the Pod."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "Runner",
+        "TestRunner",
+        "Privileged"
+      ],
+      "description": "This holds information about the security constraints when building the package."
+    },
     "Subpackage": {
       "properties": {
         "if": {
@@ -928,6 +996,13 @@
         "test": {
           "$ref": "#/$defs/Test",
           "description": "Test section for the subpackage."
+        },
+        "setcap": {
+          "items": {
+            "$ref": "#/$defs/Capability"
+          },
+          "type": "array",
+          "description": "Capabilities to set after the pipeline completes."
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
This lets packages opt in to more caps, privilege and custom runner and test runner on a per-package basis.

The build system will define a default policy that this config overrides.