### PR TITLE
test: add --ignore-signatures

### DIFF
--- a/docs/md/melange_test.md
+++ b/docs/md/melange_test.md
@@ -37,6 +37,7 @@ melange test [flags]
       --env-file string               file to use for preloaded environment variables
       --guest-dir string              directory used for the build environment guest
   -h, --help                          help for test
+      --ignore-signatures             ignore repository signature verification
   -i, --interactive                   when enabled, attaches stdin with a tty to the pod on failure
   -k, --keyring-append strings        path to extra keys to include in the build environment keyring
       --overlay-binsh string          use specified file as /bin/sh overlay in build environment

--- a/pkg/build/test.go
+++ b/pkg/build/test.go
@@ -148,6 +148,7 @@ func (t *Test) BuildGuest(ctx context.Context, imgConfig apko_types.ImageConfigu
 		apko_build.WithExtraKeys(t.ExtraKeys),
 		apko_build.WithExtraBuildRepos(t.ExtraRepos),
 		apko_build.WithExtraPackages(t.ExtraTestPackages),
+		apko_build.WithIgnoreSignatures(t.IgnoreSignatures),
 		apko_build.WithCache(t.ApkCacheDir, false, apk.NewCache(true)),
 		apko_build.WithTempDir(tmp))
 	if err != nil {

--- a/pkg/build/test_options.go
+++ b/pkg/build/test_options.go
@@ -204,3 +204,12 @@ func WithTestRemove(c bool) TestOption {
 		return nil
 	}
 }
+
+// WithIgnoreSignatures indicates whether to ignore signatures when
+// installing packages.
+func WithTestIgnoreSignatures(ignore bool) TestOption {
+	return func(t *Test) error {
+		t.IgnoreSignatures = ignore
+		return nil
+	}
+}

--- a/pkg/cli/test.go
+++ b/pkg/cli/test.go
@@ -49,6 +49,7 @@ func test() *cobra.Command {
 	var runner string
 	var extraTestPackages []string
 	var remove bool
+	var ignoreSignatures bool
 
 	cmd := &cobra.Command{
 		Use:     "test",
@@ -80,6 +81,7 @@ func test() *cobra.Command {
 				build.WithTestDebugRunner(debugRunner),
 				build.WithTestInteractive(interactive),
 				build.WithTestRemove(remove),
+				build.WithTestIgnoreSignatures(ignoreSignatures),
 			}
 
 			if len(args) > 0 {
@@ -132,6 +134,7 @@ func test() *cobra.Command {
 	cmd.Flags().StringSliceVarP(&extraRepos, "repository-append", "r", []string{}, "path to extra repositories to include in the build environment")
 	cmd.Flags().StringSliceVar(&extraTestPackages, "test-package-append", []string{}, "extra packages to install for each of the test environments")
 	cmd.Flags().BoolVar(&remove, "rm", true, "clean up intermediate artifacts (e.g. container images, temp dirs)")
+	cmd.Flags().BoolVar(&ignoreSignatures, "ignore-signatures", false, "ignore repository signature verification")
 
 	return cmd
 }


### PR DESCRIPTION
This flag seems to have been forgotten while implementing `melange test`. There's already a field for it in `type Test struct` but it's not populated or read.

This adds `--ignore-signatures` to `melange test`, and passes it through to the apko build to produce the test environment.