### PR TITLE
Fix absolute path handling.

### DIFF
--- a/pkg/build/pipeline.go
+++ b/pkg/build/pipeline.go
@@ -216,7 +216,11 @@ func (r *pipelineRunner) runPipeline(ctx context.Context, pipeline *config.Pipel
 
 	workdir := WorkDir
 	if pipeline.WorkDir != "" {
-		workdir = filepath.Join(WorkDir, pipeline.WorkDir)
+		if filepath.IsAbs(pipeline.WorkDir) {
+			workdir = pipeline.WorkDir
+		} else {
+			workdir = filepath.Join(WorkDir, pipeline.WorkDir)
+		}
 	}
 
 	// We might have called signal.Ignore(os.Interrupt) as part of a previous debug step,


### PR DESCRIPTION
`filepath.Join` doesn't behave as I, or Gemini, thought.  This adds an explicit check to properly handle when the working directory is absolute.
