### PR TITLE
Improve TestUsability for qemu to be arch aware.

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -254,7 +254,7 @@ func New(ctx context.Context, opts ...Option) (*Build, error) {
 	b.SBOMGroup.SetCreatedTime(b.SourceDateEpoch)
 
 	// Check that we actually can run things in containers.
-	if b.Runner != nil && !b.Runner.TestUsability(ctx) {
+	if b.Runner != nil && !b.Runner.TestUsability(ctx, b.containerConfig) {
 		return nil, fmt.Errorf("unable to run containers using %s, specify --runner and one of %s", b.Runner.Name(), GetAllRunners())
 	}
 

--- a/pkg/build/build_integration_test.go
+++ b/pkg/build/build_integration_test.go
@@ -11,10 +11,12 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"io"
 
+	apko_types "chainguard.dev/apko/pkg/build/types"
 	"chainguard.dev/apko/pkg/sbom/generator/spdx"
 	"chainguard.dev/melange/pkg/container"
 	"chainguard.dev/melange/pkg/container/docker"
@@ -147,7 +149,8 @@ func TestBuild_BuildPackage(t *testing.T) {
 func getRunner(ctx context.Context, t *testing.T) container.Runner {
 	t.Helper()
 
-	if r := container.BubblewrapRunner(true); r.TestUsability(ctx) {
+	cfg := Configuration{Architecture: apko_types.ParseArchitecture(runtime.GOARCH)}
+	if r := container.BubblewrapRunner(true); r.TestUsability(ctx, &cfg) {
 		return r
 	}
 

--- a/pkg/build/test.go
+++ b/pkg/build/test.go
@@ -115,8 +115,11 @@ func NewTest(ctx context.Context, opts ...TestOption) (*Test, error) {
 
 	t.Configuration = *parsedCfg
 
+	cfg := container.Config{
+		Arch: apko_types.ParseArchitecture(runtime.GOARCH),
+	}
 	// Check that we actually can run things in containers.
-	if !t.Runner.TestUsability(ctx) {
+	if !t.Runner.TestUsability(ctx, &cfg) {
 		return nil, fmt.Errorf("unable to run containers using %s, specify --runner and one of %s", t.Runner.Name(), GetAllRunners())
 	}
 

--- a/pkg/container/bubblewrap_runner.go
+++ b/pkg/container/bubblewrap_runner.go
@@ -183,7 +183,7 @@ func (bw *bubblewrap) Debug(ctx context.Context, cfg *Config, envOverride map[st
 
 // TestUsability determines if the Bubblewrap runner can be used
 // as a container runner.
-func (bw *bubblewrap) TestUsability(ctx context.Context) bool {
+func (bw *bubblewrap) TestUsability(ctx context.Context, cfg *Config) bool {
 	log := clog.FromContext(ctx)
 	if _, err := exec.LookPath("bwrap"); err != nil {
 		log.Warnf("cannot use bubblewrap for containers: bwrap not found on $PATH")

--- a/pkg/container/docker/docker_runner.go
+++ b/pkg/container/docker/docker_runner.go
@@ -161,7 +161,7 @@ func (dk *docker) TerminatePod(ctx context.Context, cfg *mcontainer.Config) erro
 
 // TestUsability determines if the Docker runner can be used
 // as a container runner.
-func (dk *docker) TestUsability(ctx context.Context) bool {
+func (dk *docker) TestUsability(ctx context.Context, cfg *mcontainer.Config) bool {
 	log := clog.FromContext(ctx)
 	if _, err := dk.cli.Ping(ctx); err != nil {
 		log.Errorf("cannot use docker for containers: %v", err)

--- a/pkg/container/qemu_runner.go
+++ b/pkg/container/qemu_runner.go
@@ -305,10 +305,10 @@ func (bw *qemu) Debug(ctx context.Context, cfg *Config, envOverride map[string]s
 
 // TestUsability determines if the Qemu runner can be used
 // as a microvm runner.
-func (bw *qemu) TestUsability(ctx context.Context) bool {
+func (bw *qemu) TestUsability(ctx context.Context, cfg *Config) bool {
 	log := clog.FromContext(ctx)
 
-	arch := apko_types.Architecture(runtime.GOARCH)
+	arch := cfg.Arch
 	if _, err := exec.LookPath(fmt.Sprintf("qemu-system-%s", arch.ToAPK())); err != nil {
 		log.Warnf("cannot use qemu for microvms: qemu-system-%s not found on $PATH", arch.ToAPK())
 		return false

--- a/pkg/container/runner.go
+++ b/pkg/container/runner.go
@@ -30,7 +30,7 @@ type Debugger interface {
 type Runner interface {
 	Close() error
 	Name() string
-	TestUsability(ctx context.Context) bool
+	TestUsability(ctx context.Context, cfg *Config) bool
 	// OCIImageLoader returns a Loader that will load an OCI image from a stream.
 	// It should return the Loader, which will be used to load the provided image
 	// as a tar stream into the Loader. That image will be used as the root when StartPod() the container.


### PR DESCRIPTION
Qemu runner would complain that it wasn't usable if `qemu-system-<arch> was not available, when <arch>` was the system runtime arch.  If you're "cross" building then you need `qemu-system-<target-arch>` where arch is the target arch.
