### PR TITLE
Drop the `MkdirAll` for all runners.

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -725,10 +725,6 @@ func (b *Build) BuildPackage(ctx context.Context) error {
 		}
 	}
 
-	if err := os.MkdirAll(filepath.Join(b.WorkspaceDir, melangeOutputDirName, b.Configuration.Package.Name), 0o755); err != nil {
-		return err
-	}
-
 	linterQueue := []linterTarget{}
 	cfg := b.workspaceConfig(ctx)
 
@@ -799,9 +795,6 @@ func (b *Build) BuildPackage(ctx context.Context) error {
 	// run any pipelines for subpackages
 	for _, sp := range b.Configuration.Subpackages {
 		sp := sp
-		if err := os.MkdirAll(filepath.Join(b.WorkspaceDir, melangeOutputDirName, sp.Name), 0o755); err != nil {
-			return err
-		}
 
 		if !b.isBuildLess() {
 			log.Infof("running pipeline for subpackage %s", sp.Name)


### PR DESCRIPTION
This change drops the `mkdir` we were performing before, which doesn't work properly if the working directory isn't a live volume mount into the melange process.

I expect this to cause some packages to fail, but they should be failing with QEMU already today and this will help us force flush them out.
