### PR TITLE
Fix typo in license reporting re: ignored results.

### DIFF
--- a/pkg/license/license.go
+++ b/pkg/license/license.go
@@ -240,7 +240,7 @@ func LicenseCheck(ctx context.Context, cfg *config.Configuration, fsys fs.FS) ([
 	for _, dl := range detectedLicenses {
 		s := ""
 		// This is heuristics, but we want to ignore licenses with a confidence lower than a threshold
-		if isLicenseMatchConfident(dl) {
+		if !isLicenseMatchConfident(dl) {
 			s = " ignored"
 		}
 		log.Infof("  %s: %s (%f%s) (%s)", dl.Source, dl.Name, dl.Confidence, s, dl.Type)


### PR DESCRIPTION
Currently `melange license-check` will report that there's a lot of ignored licenses, due to a typo in code. Let's fix that and add a test for this particular case.