### PR TITLE
fix: exclude fifos in WorkspaceTar

### DIFF
--- a/.github/workflows/wolfi-presubmit.yaml
+++ b/.github/workflows/wolfi-presubmit.yaml
@@ -62,6 +62,7 @@ jobs:
           - tini
           - lzo
           - bubblewrap
+          - dpkg
           #- gdk-pixbuf # Looks like this is broken again, see: https://gitlab.gnome.org/GNOME/gobject-introspection/-/issues/515
           - gitsign
           - guac

--- a/pkg/container/qemu_runner.go
+++ b/pkg/container/qemu_runner.go
@@ -402,7 +402,7 @@ func (bw *qemu) WorkspaceTar(ctx context.Context, cfg *Config) (io.ReadCloser, e
 		nil,
 		outFile,
 		false,
-		[]string{"sh", "-c", "cd /home/build && tar cvpzf - --xattrs --acls *"},
+		[]string{"sh", "-c", "cd /home/build && tar cvpzf - --xattrs --acls --exclude='*fifo*' *"},
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Fifos when compressed/extracted won't work anyway and they are usually problematic (see dpkg package)