### PR TITLE
cli: Implement new `compare-versions` command

### DIFF
--- a/docs/md/melange.md
+++ b/docs/md/melange.md
@@ -22,6 +22,7 @@ toc: true
 
 * [melange build](/docs/md/melange_build.md)	 - Build a package from a YAML configuration file
 * [melange bump](/docs/md/melange_bump.md)	 - Update a Melange YAML file to reflect a new package version
+* [melange compare-versions](/docs/md/melange_compare-versions.md)	 - Compare two package versions
 * [melange compile](/docs/md/melange_compile.md)	 - Compile a YAML configuration file
 * [melange completion](/docs/md/melange_completion.md)	 - Generate completion script
 * [melange convert](/docs/md/melange_convert.md)	 - EXPERIMENTAL COMMAND - Attempts to convert packages/gems/apkbuild files into melange configuration files

--- a/docs/md/melange_compare-versions.md
+++ b/docs/md/melange_compare-versions.md
@@ -1,0 +1,48 @@
+---
+title: "melange compare-versions"
+slug: melange_compare-versions
+url: /docs/md/melange_compare-versions.md
+draft: false
+images: []
+type: "article"
+toc: true
+---
+## melange compare-versions
+
+Compare two package versions
+
+### Synopsis
+
+Compare two package versions according to a specified operator.
+
+The operator can be: eq (equal), ne (not-equal),
+                     lt (less-than), le (less-than or equal),
+                     gt (greater-than), ge (greater-than or equal)
+
+```
+melange compare-versions [flags]
+```
+
+### Examples
+
+```
+melange compare-versions version1 operator version2
+```
+
+### Options
+
+```
+  -h, --help     help for compare-versions
+  -s, --silent   don't print anything; use the return code ($?) to signal whether the comparison is true or false
+```
+
+### Options inherited from parent commands
+
+```
+      --log-level string   log level (e.g. debug, info, warn, error) (default "INFO")
+```
+
+### SEE ALSO
+
+* [melange](/docs/md/melange.md)	 - 
+

--- a/pkg/cli/commands.go
+++ b/pkg/cli/commands.go
@@ -53,6 +53,7 @@ func New() *cobra.Command {
 
 	cmd.AddCommand(buildCmd())
 	cmd.AddCommand(bumpCmd())
+	cmd.AddCommand(compareVersions())
 	cmd.AddCommand(completion())
 	cmd.AddCommand(compile())
 	cmd.AddCommand(convert())

--- a/pkg/cli/compareversions.go
+++ b/pkg/cli/compareversions.go
@@ -1,0 +1,103 @@
+// Copyright 2025 Chainguard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"chainguard.dev/apko/pkg/apk/apk"
+	"github.com/spf13/cobra"
+)
+
+func compareVersions() *cobra.Command {
+	var silent bool
+
+	cmd := &cobra.Command {
+		Use:     "compare-versions",
+		Short:   "Compare two package versions",
+		Long:    `Compare two package versions according to a specified operator.
+
+The operator can be: eq (equal), ne (not-equal),
+                     lt (less-than), le (less-than or equal),
+                     gt (greater-than), ge (greater-than or equal)`,
+		Example: `melange compare-versions version1 operator version2`,
+		Args:    cobra.ExactArgs(3),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return compareVersionsCli(cmd.Context(), args[0], args[1], args[2], silent)
+		},
+	}
+
+	cmd.Flags().BoolVarP(&silent, "silent", "s", false, "don't print anything; use the return code ($?) to signal whether the comparison is true or false")
+
+	return cmd
+}
+
+func compareVersionsCli(_ context.Context, version1 string, operator string, version2 string, silent bool) error {
+	pkgversion1, err := apk.ParseVersion(version1)
+	if err != nil {
+		return err
+	}
+
+	pkgversion2, err := apk.ParseVersion(version2)
+	if err != nil {
+		return err
+	}
+
+	r := apk.CompareVersions(pkgversion1, pkgversion2)
+
+	var succeeded bool
+	var operatorStr string
+
+	switch operator {
+	case "eq":
+		succeeded = r == 0
+		operatorStr = "equal to"
+	case "lt":
+		succeeded = r < 0
+		operatorStr = "less than"
+	case "le":
+		succeeded = r <= 0
+		operatorStr = "less than or equal to"
+	case "gt":
+		succeeded = r > 0
+		operatorStr = "greater than"
+	case "ge":
+		succeeded = r >= 0
+		operatorStr = "greater than or equal to"
+	case "ne":
+		succeeded = r != 0
+		operatorStr = "different than"
+	default:
+		return fmt.Errorf("invalid operator %q", operator)
+	}
+
+	if succeeded {
+		if silent {
+			os.Exit(0)
+		} else {
+			fmt.Printf("%q is %s %q\n", version1, operatorStr, version2)
+		}
+	} else {
+		if silent {
+			os.Exit(1)
+		} else {
+			fmt.Printf("%q is NOT %s %q\n", version1, operatorStr, version2)
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
Sometimes it's useful to check how two versions relate to one another. Inspired by Debian's `dpkg --compare-versions`, I decided to implement our very own version comparison CLI.