### PR TITLE
license-check: tweaks to license display and renovate

### DIFF
--- a/pkg/license/license_test.go
+++ b/pkg/license/license_test.go
@@ -215,21 +215,21 @@ func TestLicenseCheck(t *testing.T) {
 		}
 	}
 
-	// Now also check the log output and make sure that "ignored" is present only for the low-confidence license,
-	// LICENSE-BSD-modified.
+	// Now also check the log output and make sure that "low-confidence" is present only for the low-confidence
+	// licenses: LICENSE-BSD-modified and COPYRIGHT (the latter is not a valid license)
 	found := false
 	lines := strings.Split(logBuf.String(), "\n")
 	for _, line := range lines {
-		if strings.Contains(line, "ignored") {
-			// Check if the line contains the expected license
-			if !strings.Contains(line, "LICENSE-BSD-modified") {
-				t.Errorf("Unexpected log line with 'ignored': %s", line)
+		if strings.Contains(line, "low-confidence") {
+			// Check if the line contains one of the expected licenses
+			if !strings.Contains(line, "LICENSE-BSD-modified") && !strings.Contains(line, "COPYRIGHT") {
+				t.Errorf("Unexpected log line with 'low-confidence': %s", line)
 			}
 			found = true
 		}
 	}
 	if !found {
-		t.Error("Expected log line with 'ignored' not found")
+		t.Error("Expected log line with 'low-confidence' not found")
 	}
 }
 

--- a/pkg/renovate/copyright/copyright_test.go
+++ b/pkg/renovate/copyright/copyright_test.go
@@ -41,6 +41,16 @@ func TestCopyright_update(t *testing.T) {
 			Source:     "internal/COPYING",
 			Confidence: 1.0,
 		},
+		{
+			Name:       "GPL-3.0",
+			Source:     "internal/LICENSE",
+			Confidence: 0.2,
+		},
+		{
+			Name:       "NOASSERTION",
+			Source:     "docs/COPYING",
+			Confidence: 0.0,
+		},
 	}
 
 	// Copy the test data file to the temp directory
@@ -65,4 +75,6 @@ func TestCopyright_update(t *testing.T) {
 	assert.Contains(t, string(resultData), "license: Apache-2.0")
 	assert.Contains(t, string(resultData), "license: MIT")
 	assert.NotContains(t, string(resultData), "license: Not-Applicable")
+	assert.NotContains(t, string(resultData), "license: GPL-3.0")
+	assert.NotContains(t, string(resultData), "license: NOASSERTION")
 }


### PR DESCRIPTION
More tweaks to the license checking logic:

- List out all licenses that could not be detected properly and mark them as NOASSERTION
- Print out all the low-confidence licenses as a separate list and urge the developers to look at those
- Fix renovate to ignore low-confidence licenses (as we can't really vouch for those)
- Fix renovate not to clear out license information when there are no valid licenses detected