### PR TITLE
experiment: on the fly disk for melange QEMU runner

### DIFF
--- a/.github/workflows/wolfi-presubmit.yaml
+++ b/.github/workflows/wolfi-presubmit.yaml
@@ -68,7 +68,7 @@ jobs:
           - guac
           - mdbook
           - s3cmd
-          - db  # Uses license-path
+          - py3-pyelftools  # Uses license-path
           - cadvisor  # uses cgroups
           - fping  # uses get/setcaps
           - perl-yaml-syck

--- a/.github/workflows/wolfi-presubmit.yaml
+++ b/.github/workflows/wolfi-presubmit.yaml
@@ -68,7 +68,10 @@ jobs:
           - guac
           - mdbook
           - s3cmd
-          - db # Uses license-path
+          - db  # Uses license-path
+          - cadvisor  # uses cgroups
+          - dotnet-9  # huge workspace size 3+gb
+          - fping  # uses get/setcaps
           - perl-yaml-syck
           - ncurses
           - fping

--- a/.github/workflows/wolfi-presubmit.yaml
+++ b/.github/workflows/wolfi-presubmit.yaml
@@ -70,7 +70,6 @@ jobs:
           - s3cmd
           - db  # Uses license-path
           - cadvisor  # uses cgroups
-          - dotnet-9  # huge workspace size 3+gb
           - fping  # uses get/setcaps
           - perl-yaml-syck
           - ncurses
@@ -156,8 +155,8 @@ jobs:
         run: |
           make SHELL="/bin/bash" MELANGE="sudo melange" test/${{ matrix.package }}
 
-      - name: Run tests to verify xattrs with QEMU runner
-        if: matrix.runner == 'qemu' && matrix.package == 'fping'
+      - name: Run tests with QEMU runner
+        if: matrix.runner == 'qemu'
         run: |
           make \
             SHELL="/bin/bash" \

--- a/.github/workflows/wolfi-presubmit.yaml
+++ b/.github/workflows/wolfi-presubmit.yaml
@@ -71,6 +71,7 @@ jobs:
           - py3-pyelftools  # Uses license-path
           - cadvisor  # uses cgroups
           - fping  # uses get/setcaps
+          - memcached  # uses a diff test user
           - perl-yaml-syck
           - ncurses
           - subversion

--- a/.github/workflows/wolfi-presubmit.yaml
+++ b/.github/workflows/wolfi-presubmit.yaml
@@ -74,7 +74,6 @@ jobs:
           - fping  # uses get/setcaps
           - perl-yaml-syck
           - ncurses
-          - fping
           - subversion
           - sudo
           - py3-supported-python

--- a/.github/workflows/wolfi-presubmit.yaml
+++ b/.github/workflows/wolfi-presubmit.yaml
@@ -157,6 +157,17 @@ jobs:
         run: |
           make SHELL="/bin/bash" MELANGE="sudo melange" test/${{ matrix.package }}
 
+      - name: Run tests to verify xattrs with QEMU runner
+        if: matrix.runner == 'qemu' && matrix.package == 'fping'
+        run: |
+          make \
+            SHELL="/bin/bash" \
+            QEMU_KERNEL_IMAGE=/tmp/kernel/boot/vmlinuz-virt \
+            QEMU_KERNEL_MODULES=/tmp/kernel/lib/modules/ \
+            MELANGE="/usr/bin/melange" \
+            MELANGE_EXTRA_OPTS="--runner qemu" \
+            test/${{ matrix.package }}
+
       - name: Check package ${{ matrix.package }} xattrs for QEMU-built package
         if: matrix.runner == 'qemu' && matrix.package == 'fping'
         run: |

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -310,7 +310,6 @@ func (b *Build) buildGuest(ctx context.Context, imgConfig apko_types.ImageConfig
 
 	if b.Runner.Name() == container.QemuName {
 		b.ExtraPackages = append(b.ExtraPackages, []string{
-			"melange-microvm-init",
 			"gnutar",
 			"attr",
 		}...)

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -308,6 +308,10 @@ func (b *Build) buildGuest(ctx context.Context, imgConfig apko_types.ImageConfig
 	defer os.RemoveAll(tmp)
 
 	if b.Runner.Name() == container.QemuName {
+		/*
+		 * here we need to inject gnutar+attr in order to syphon back
+		 * the workspace from the VM preserving extended attributes.
+		 */
 		b.ExtraPackages = append(b.ExtraPackages, []string{
 			"gnutar",
 			"attr",

--- a/pkg/build/test.go
+++ b/pkg/build/test.go
@@ -278,13 +278,6 @@ func (t *Test) TestPackage(ctx context.Context) error {
 		return fmt.Errorf("compiling %s tests: %w", t.ConfigFile, err)
 	}
 
-	if t.Runner.Name() == container.QemuName {
-		t.ExtraTestPackages = append(t.ExtraTestPackages, []string{
-			"melange-microvm-init",
-			"gnutar",
-		}...)
-	}
-
 	// Filter out any subpackages with false If conditions.
 	t.Configuration.Subpackages = slices.DeleteFunc(t.Configuration.Subpackages, func(sp config.Subpackage) bool {
 		result, err := shouldRun(sp.If)

--- a/pkg/build/test.go
+++ b/pkg/build/test.go
@@ -494,7 +494,8 @@ func (t *Test) buildWorkspaceConfig(ctx context.Context, imgRef, pkgName string,
 		Capabilities: caps,
 		WorkspaceDir: t.WorkspaceDir,
 		Environment:  map[string]string{},
-		RunAs:        imgcfg.Accounts.RunAs,
+		RunAsUID:     runAsUID(imgcfg.Accounts),
+		RunAs:        runAs(imgcfg.Accounts),
 	}
 	if t.Configuration.Capabilities.Add != nil {
 		cfg.Capabilities.Add = t.Configuration.Capabilities.Add

--- a/pkg/container/bubblewrap_runner.go
+++ b/pkg/container/bubblewrap_runner.go
@@ -226,7 +226,7 @@ func (bw *bubblewrap) TerminatePod(ctx context.Context, cfg *Config) error {
 
 // WorkspaceTar implements Runner
 // This is a noop for Bubblewrap, which uses bind-mounts to manage the workspace
-func (bw *bubblewrap) WorkspaceTar(ctx context.Context, cfg *Config) (io.ReadCloser, error) {
+func (bw *bubblewrap) WorkspaceTar(ctx context.Context, cfg *Config, extraFiles []string) (io.ReadCloser, error) {
 	return nil, nil
 }
 

--- a/pkg/container/bubblewrap_runner.go
+++ b/pkg/container/bubblewrap_runner.go
@@ -116,10 +116,10 @@ func (bw *bubblewrap) cmd(ctx context.Context, cfg *Config, debug bool, envOverr
 		"--clearenv")
 
 	// If we need to run as an user, we run as that user.
-	if cfg.RunAs != "" {
+	if cfg.RunAsUID != "" {
 		baseargs = append(baseargs, "--unshare-user")
-		baseargs = append(baseargs, "--uid", cfg.RunAs)
-		baseargs = append(baseargs, "--gid", cfg.RunAs)
+		baseargs = append(baseargs, "--uid", cfg.RunAsUID)
+		baseargs = append(baseargs, "--gid", cfg.RunAsUID)
 		// Else if we're not using melange as root, we force the use of the
 		// Apko build user. This avoids problems on machines where default
 		// regular user is NOT 1000.

--- a/pkg/container/bubblewrap_runner_test.go
+++ b/pkg/container/bubblewrap_runner_test.go
@@ -35,7 +35,7 @@ func TestBubblewrapCmd(t *testing.T) {
 		},
 		{
 			name:         "With config RunAs",
-			config:       &Config{RunAs: "65535"},
+			config:       &Config{RunAsUID: "65535"},
 			expectedArgs: fmt.Sprintf("--unshare-user --uid %s --gid %s", "65535", "65535"),
 		},
 	}

--- a/pkg/container/config.go
+++ b/pkg/container/config.go
@@ -52,6 +52,7 @@ type Config struct {
 	ImgRef                string
 	PodID                 string
 	Arch                  apko_types.Architecture
+	RunAsUID              string
 	RunAs                 string
 	WorkspaceDir          string
 	CPU, CPUModel, Memory string

--- a/pkg/container/docker/docker_runner.go
+++ b/pkg/container/docker/docker_runner.go
@@ -358,7 +358,7 @@ func (dk *docker) Debug(ctx context.Context, cfg *mcontainer.Config, envOverride
 
 // WorkspaceTar implements Runner
 // This is a noop for Docker, which uses bind-mounts to manage the workspace
-func (dk *docker) WorkspaceTar(ctx context.Context, cfg *mcontainer.Config) (io.ReadCloser, error) {
+func (dk *docker) WorkspaceTar(ctx context.Context, cfg *mcontainer.Config, extraFiles []string) (io.ReadCloser, error) {
 	return nil, nil
 }
 

--- a/pkg/container/docker/docker_runner.go
+++ b/pkg/container/docker/docker_runner.go
@@ -220,7 +220,7 @@ func (dk *docker) Run(ctx context.Context, cfg *mcontainer.Config, envOverride m
 	}
 
 	taskIDResp, err := dk.cli.ContainerExecCreate(ctx, cfg.PodID, container.ExecOptions{
-		User:         cfg.RunAs,
+		User:         cfg.RunAsUID,
 		Cmd:          args,
 		WorkingDir:   runnerWorkdir,
 		Env:          environ,

--- a/pkg/container/qemu_runner.go
+++ b/pkg/container/qemu_runner.go
@@ -1127,6 +1127,15 @@ func generateCpio(ctx context.Context) (string, error) {
 	}
 
 	clog.FromContext(ctx).Info("qemu: generating initramfs")
+
+	err := os.MkdirAll(filepath.Join(
+		"kernel",
+		apko_types.Architecture(runtime.GOARCH).ToAPK()),
+		os.ModePerm)
+	if err != nil {
+		return "", fmt.Errorf("unable to dest directory: %w", err)
+	}
+
 	spec := apko_types.ImageConfiguration{
 		Contents: apko_types.ImageContents{
 			RuntimeRepositories: []string{

--- a/pkg/container/qemu_runner.go
+++ b/pkg/container/qemu_runner.go
@@ -1141,11 +1141,8 @@ func generateCpio(ctx context.Context) (string, error) {
 
 	spec := apko_types.ImageConfiguration{
 		Contents: apko_types.ImageContents{
-			RuntimeRepositories: []string{
-				"https://packages.wolfi.dev/os",
-			},
-			Keyring: []string{
-				"https://packages.wolfi.dev/os/wolfi-signing.rsa.pub",
+			BuildRepositories: []string{
+				"https://apk.cgr.dev/chainguard",
 			},
 			Packages: []string{
 				"microvm-init",

--- a/pkg/container/qemu_runner.go
+++ b/pkg/container/qemu_runner.go
@@ -158,7 +158,7 @@ func (bw *qemu) Debug(ctx context.Context, cfg *Config, envOverride map[string]s
 			ssh.PublicKeys(signer),
 		},
 		Config: ssh.Config{
-			Ciphers: []string{"aes128-ctr", "aes256-gcm@openssh.com"},
+			Ciphers: []string{"aes128-gcm@openssh.com"},
 		},
 		HostKeyCallback: hostKeyCallback,
 	}
@@ -845,7 +845,7 @@ func getHostKey(ctx context.Context, cfg *Config) error {
 			ssh.PublicKeys(signer),
 		},
 		Config: ssh.Config{
-			Ciphers: []string{"aes128-ctr", "aes256-gcm@openssh.com"},
+			Ciphers: []string{"aes128-gcm@openssh.com"},
 		},
 		HostKeyCallback: func(hostname string, remote net.Addr, key ssh.PublicKey) error {
 			hostKey = key
@@ -906,7 +906,7 @@ func sendSSHCommand(ctx context.Context, user, address string,
 			ssh.PublicKeys(signer),
 		},
 		Config: ssh.Config{
-			Ciphers: []string{"aes128-ctr", "aes256-gcm@openssh.com"},
+			Ciphers: []string{"aes128-gcm@openssh.com"},
 		},
 		HostKeyCallback: hostKeyCallback,
 	}

--- a/pkg/container/runner.go
+++ b/pkg/container/runner.go
@@ -43,7 +43,7 @@ type Runner interface {
 	// WorkspaceTar returns an io.ReadCloser that can be used to read the status of the workspace.
 	// The io.ReadCloser itself is a tar stream, which can be written to an io.Writer as is,
 	// or passed to an fs.FS processor
-	WorkspaceTar(ctx context.Context, cfg *Config) (io.ReadCloser, error)
+	WorkspaceTar(ctx context.Context, cfg *Config, extraFiles []string) (io.ReadCloser, error)
 }
 
 type Loader interface {


### PR DESCRIPTION
With this we adapt to the equivalent branch of 89luca89/os this way we use this minimal initramfs to unpack the rootfs.tar.gz mounted to /dev/vdb into /mount, and then use SSHD's ChrootDirectory to chroot into it

This solves the following problem:

- multiple compression/decompression cycle of the rootfs, hence a big performance improvement
  - we now use `layer.Uncompressed()` which is the same as bubblewrap runner now.
- removes the ~2gb limit for the initramfs as now we're using the disk
- cpio initramfs is now cache-able, so for local development things are also faster
- removes need of SSHD inside the build environment
- migrates to use SSHD's `ChrootDirectory` to enter the build environment (avoid access at build time to vmlinuz modules sshd binary etc)
- removes extra files in the build environment (eg: ssh keys, authorized keys) thus solving issues with "approved licence" file scanners

Generally speaking with this PR we improve performance but also reliability and make the build environment less "tainted"

Depends on:
- [x] https://github.com/chainguard-dev/enterprise-packages/pull/23129
- [x] https://github.com/wolfi-dev/os/pull/52911
- [x] https://github.com/wolfi-dev/os/pull/52948
