### PR TITLE
feat: avoid adding additional packages on QEMU runners

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -307,17 +307,6 @@ func (b *Build) buildGuest(ctx context.Context, imgConfig apko_types.ImageConfig
 	}
 	defer os.RemoveAll(tmp)
 
-	if b.Runner.Name() == container.QemuName {
-		/*
-		 * here we need to inject gnutar+attr in order to syphon back
-		 * the workspace from the VM preserving extended attributes.
-		 */
-		b.ExtraPackages = append(b.ExtraPackages, []string{
-			"gnutar",
-			"attr",
-		}...)
-	}
-
 	// Work around LockImageConfiguration assuming multi-arch.
 	imgConfig.Archs = []apko_types.Architecture{b.Arch}
 

--- a/pkg/container/config.go
+++ b/pkg/container/config.go
@@ -58,6 +58,7 @@ type Config struct {
 	CPU, CPUModel, Memory string
 	SSHKey                []byte
 	SSHAddress            string
+	SSHWorkspaceAddress   string
 	SSHHostKey            string
 	Disk                  string
 	Timeout               time.Duration

--- a/pkg/container/qemu_runner.go
+++ b/pkg/container/qemu_runner.go
@@ -1160,10 +1160,6 @@ func generateCpio(ctx context.Context) (string, error) {
 		Contents: apko_types.ImageContents{
 			BuildRepositories: []string{
 				"https://apk.cgr.dev/chainguard",
-				"/home/luca-linux/Projects/chainguard/wolfi-os/packages/",
-			},
-			Keyring: []string{
-				"/home/luca-linux/Projects/chainguard/wolfi-os/local-melange.rsa.pub",
 			},
 			Packages: []string{
 				"microvm-init",

--- a/pkg/container/qemu_runner.go
+++ b/pkg/container/qemu_runner.go
@@ -392,7 +392,7 @@ func (bw *qemu) WorkspaceTar(ctx context.Context, cfg *Config, extraFiles []stri
 	// We could just cp -a to /mnt as it is our shared workspace directory, but
 	// this will lose some file metadata like hardlinks, owners and so on.
 	// Example of package that won't work when using "cp -a" is glibc.
-	retrieveCommand := "cd /home/build && tar cvpf - --xattrs --acls --exclude='*fifo*' melange-out"
+	retrieveCommand := "cd /mount/home/build && tar cvpf - --xattrs --acls --exclude='*fifo*' melange-out"
 	// we append also all the necessary files that we might need, for example Licenses
 	// for license checks
 	for _, v := range extraFiles {


### PR DESCRIPTION
When using QEMU runners we were forced to add gnutar/attr packages to the build environment in order to copy back the workspace outputs.

With the new version of the microvm init, we can instead use the alternative SSHD port, that avoid chrooting into the build environment.

This will let us use the initramfs packages instead of injecting them into the build environment.

Depends on:

- [ ] https://github.com/wolfi-dev/os/pull/53169