### PR TITLE
sbom: Populate downloadLocation and checksums

### DIFF
--- a/pkg/build/testdata/goldenfiles/sboms/7zip-two-fetches-2301-r3.spdx.json
+++ b/pkg/build/testdata/goldenfiles/sboms/7zip-two-fetches-2301-r3.spdx.json
@@ -60,9 +60,15 @@
       "filesAnalyzed": false,
       "licenseConcluded": "NOASSERTION",
       "licenseDeclared": "NOASSERTION",
-      "downloadLocation": "NOASSERTION",
+      "downloadLocation": "https://7-zip.org/a/7z2301-src.tar.xz",
       "originator": "Organization: Wolfi",
       "supplier": "Organization: Wolfi",
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "e39f660c023aa65e55388be225b5591fe2a5c9138693f3c9107e2eb4ce97fafde118d3375e01ada99d29de9633f56221b5b3d640c982178884670cd84c8aa986"
+        }
+      ],
       "externalRefs": [
         {
           "referenceCategory": "PACKAGE-MANAGER",
@@ -78,9 +84,15 @@
       "filesAnalyzed": false,
       "licenseConcluded": "NOASSERTION",
       "licenseDeclared": "NOASSERTION",
-      "downloadLocation": "NOASSERTION",
+      "downloadLocation": "https://7-zip.org/a/7z2301-src.tar.xz",
       "originator": "Organization: Wolfi",
       "supplier": "Organization: Wolfi",
+      "checksums": [
+        {
+          "algorithm": "SHA512",
+          "checksumValue": "e39f660c023aa65e55388be225b5591fe2a5c9138693f3c9107e2eb4ce97fafde118d3375e01ada99d29de9633f56221b5b3d640c982178884670cd84c8aa986"
+        }
+      ],
       "externalRefs": [
         {
           "referenceCategory": "PACKAGE-MANAGER",

--- a/pkg/build/testdata/goldenfiles/sboms/crane-0.20.2-r1.spdx.json
+++ b/pkg/build/testdata/goldenfiles/sboms/crane-0.20.2-r1.spdx.json
@@ -60,9 +60,15 @@
       "filesAnalyzed": false,
       "licenseConcluded": "NOASSERTION",
       "licenseDeclared": "Apache-2.0",
-      "downloadLocation": "NOASSERTION",
+      "downloadLocation": "git+https://github.com/google/go-containerregistry@v0.20.2",
       "originator": "Organization: Google",
       "supplier": "Organization: Google",
+      "checksums": [
+        {
+          "algorithm": "SHA1",
+          "checksumValue": "c195f151efe3369874c72662cd69ad43ee485128"
+        }
+      ],
       "externalRefs": [
         {
           "referenceCategory": "PACKAGE-MANAGER",

--- a/pkg/build/testdata/goldenfiles/sboms/crane-0.20.2-r1.spdx.json
+++ b/pkg/build/testdata/goldenfiles/sboms/crane-0.20.2-r1.spdx.json
@@ -63,12 +63,6 @@
       "downloadLocation": "git+https://github.com/google/go-containerregistry@v0.20.2",
       "originator": "Organization: Google",
       "supplier": "Organization: Google",
-      "checksums": [
-        {
-          "algorithm": "SHA1",
-          "checksumValue": "c195f151efe3369874c72662cd69ad43ee485128"
-        }
-      ],
       "externalRefs": [
         {
           "referenceCategory": "PACKAGE-MANAGER",

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -588,8 +588,6 @@ func (p Pipeline) SBOMPackageForUpstreamSource(licenseDeclared, supplier string,
 		tag := with["tag"]
 		expectedCommit := with["expected-commit"]
 		downloadLocation := "git+" + repo
-		checksums := make(map[string]string)
-		checksums["SHA1"] = expectedCommit
 
 		// We'll use all available data to ensure our SBOM's package ID is unique, even
 		// when the same repo is git-checked out multiple times.
@@ -643,7 +641,6 @@ func (p Pipeline) SBOMPackageForUpstreamSource(licenseDeclared, supplier string,
 					Version:          v,
 					LicenseDeclared:  licenseDeclared,
 					Namespace:        namespace,
-					Checksums:        checksums,
 					PURL:             pu,
 					DownloadLocation: downloadLocation,
 				}, nil
@@ -697,7 +694,6 @@ func (p Pipeline) SBOMPackageForUpstreamSource(licenseDeclared, supplier string,
 			Version:          version,
 			LicenseDeclared:  licenseDeclared,
 			Namespace:        supplier,
-			Checksums:        checksums,
 			PURL:             &pu,
 			DownloadLocation: downloadLocation,
 		}, nil

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -539,14 +539,17 @@ func (p Pipeline) SBOMPackageForUpstreamSource(licenseDeclared, supplier string,
 	case "fetch":
 		args := make(map[string]string)
 		args["download_url"] = with["uri"]
+		checksums := make(map[string]string)
 
 		expectedSHA256 := with["expected-sha256"]
 		if len(expectedSHA256) > 0 {
 			args["checksum"] = "sha256:" + expectedSHA256
+			checksums["SHA256"] = expectedSHA256
 		}
 		expectedSHA512 := with["expected-sha512"]
 		if len(expectedSHA512) > 0 {
 			args["checksum"] = "sha512:" + expectedSHA512
+			checksums["SHA512"] = expectedSHA256
 		}
 
 		// These get defaulted correctly from within the fetch pipeline definition
@@ -570,11 +573,13 @@ func (p Pipeline) SBOMPackageForUpstreamSource(licenseDeclared, supplier string,
 		}
 
 		return &sbom.Package{
-			IDComponents: idComponents,
-			Name:         pkgName,
-			Version:      pkgVersion,
-			Namespace:    supplier,
-			PURL:         pu,
+			IDComponents:     idComponents,
+			Name:             pkgName,
+			Version:          pkgVersion,
+			Namespace:        supplier,
+			Checksums:        checksums,
+			PURL:             pu,
+			DownloadLocation: args["download_url"],
 		}, nil
 
 	case "git-checkout":
@@ -582,6 +587,9 @@ func (p Pipeline) SBOMPackageForUpstreamSource(licenseDeclared, supplier string,
 		branch := with["branch"]
 		tag := with["tag"]
 		expectedCommit := with["expected-commit"]
+		downloadLocation := "git+" + repo
+		checksums := make(map[string]string)
+		checksums["SHA1"] = expectedCommit
 
 		// We'll use all available data to ensure our SBOM's package ID is unique, even
 		// when the same repo is git-checked out multiple times.
@@ -615,6 +623,10 @@ func (p Pipeline) SBOMPackageForUpstreamSource(licenseDeclared, supplier string,
 					continue
 				}
 
+				// URI format supports use of commit or tag as suffix
+				// the commit is also passed in the checksums list.
+				downloadLocation += "@" + v
+
 				pu := &purl.PackageURL{
 					Type:      purl.TypeGithub,
 					Namespace: namespace,
@@ -626,12 +638,14 @@ func (p Pipeline) SBOMPackageForUpstreamSource(licenseDeclared, supplier string,
 				}
 
 				return &sbom.Package{
-					IDComponents:    idComponents,
-					Name:            name,
-					Version:         v,
-					LicenseDeclared: licenseDeclared,
-					Namespace:       namespace,
-					PURL:            pu,
+					IDComponents:     idComponents,
+					Name:             name,
+					Version:          v,
+					LicenseDeclared:  licenseDeclared,
+					Namespace:        namespace,
+					Checksums:        checksums,
+					PURL:             pu,
+					DownloadLocation: downloadLocation,
 				}, nil
 			}
 
@@ -648,6 +662,14 @@ func (p Pipeline) SBOMPackageForUpstreamSource(licenseDeclared, supplier string,
 
 		// Encode vcs_url with git+ prefix and @commit suffix
 		vcsUrl := "git+" + repo
+
+		if len(tag) > 0 {
+			downloadLocation += "@" + tag
+		} else {
+			if len(expectedCommit) > 0 {
+				downloadLocation += "@" + expectedCommit
+			}
+		}
 
 		if len(expectedCommit) > 0 {
 			vcsUrl += "@" + expectedCommit
@@ -670,12 +692,14 @@ func (p Pipeline) SBOMPackageForUpstreamSource(licenseDeclared, supplier string,
 		}
 
 		return &sbom.Package{
-			IDComponents:    idComponents,
-			Name:            name,
-			Version:         version,
-			LicenseDeclared: licenseDeclared,
-			Namespace:       supplier,
-			PURL:            &pu,
+			IDComponents:     idComponents,
+			Name:             name,
+			Version:          version,
+			LicenseDeclared:  licenseDeclared,
+			Namespace:        supplier,
+			Checksums:        checksums,
+			PURL:             &pu,
+			DownloadLocation: downloadLocation,
 		}, nil
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -662,10 +662,8 @@ func (p Pipeline) SBOMPackageForUpstreamSource(licenseDeclared, supplier string,
 
 		if len(tag) > 0 {
 			downloadLocation += "@" + tag
-		} else {
-			if len(expectedCommit) > 0 {
-				downloadLocation += "@" + expectedCommit
-			}
+		} else if len(expectedCommit) > 0 {
+			downloadLocation += "@" + expectedCommit
 		}
 
 		if len(expectedCommit) > 0 {

--- a/pkg/sbom/package.go
+++ b/pkg/sbom/package.go
@@ -74,14 +74,18 @@ type Package struct {
 
 	// Checksums of the package. The keys are the checksum algorithms (e.g. "SHA-256"),
 	// and the values are the checksums.
-	//
-	// TODO: We're not currently using this field, consider removing it.
 	Checksums map[string]string
 
 	// The Package URL for this package, if any. If set, it will be added as the
 	// only ExternalRef of type "purl" to the SPDX package. (A package
 	// should have only one PURL external ref.)
 	PURL *purl.PackageURL
+
+	// The Download Location for this package, if any; It set this is generated
+	// alongside the PackageURL from fetch/git-checkout pipelines for upstream
+	// source locations; Leaving this empty will result in NOASSERTION being
+	// used as its value.
+	DownloadLocation string
 }
 
 // ToSPDX returns the Package converted to its SPDX representation.
@@ -98,6 +102,10 @@ func (p Package) ToSPDX(ctx context.Context) spdx.Package {
 		}
 	}
 
+	if p.DownloadLocation == "" {
+		p.DownloadLocation = spdx.NOASSERTION
+	}
+
 	sp := spdx.Package{
 		ID:               p.ID(),
 		Name:             p.Name,
@@ -105,7 +113,7 @@ func (p Package) ToSPDX(ctx context.Context) spdx.Package {
 		FilesAnalyzed:    false,
 		LicenseConcluded: spdx.NOASSERTION,
 		LicenseDeclared:  p.LicenseDeclared,
-		DownloadLocation: spdx.NOASSERTION,
+		DownloadLocation: p.DownloadLocation,
 		CopyrightText:    p.Copyright,
 		Checksums:        p.getChecksums(),
 		ExternalRefs:     p.getExternalRefs(),


### PR DESCRIPTION
 For packages that related to fetch and git-checkout actions in build pipelines populate the downloadLocation and checksums fields alongside the purl's that are already present in externalRefs.

Download location is either a URL or a Vcs reference as defined in the SPDX specification.  Checksums are provided for both types.

[SPDX reference for examples](https://spdx.github.io/spdx-spec/v2.3/package-information/#773-examples)