### PR TITLE
fix: ensure make parent dirs when unpacking files from workspace

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -1211,6 +1211,10 @@ func (b *Build) retrieveWorkspace(ctx context.Context, fs apkofs.FullFS) error {
 			}
 
 		case tar.TypeReg:
+			parentDir := filepath.Dir(hdr.Name)
+			if err := fs.MkdirAll(parentDir, 0o755); err != nil {
+				return fmt.Errorf("unable to create directory %s: %w", hdr.Name, err)
+			}
 			f, err := fs.OpenFile(hdr.Name, os.O_CREATE|os.O_WRONLY, hdr.FileInfo().Mode())
 			if err != nil {
 				return fmt.Errorf("unable to open file %s: %w", hdr.Name, err)

--- a/pkg/container/qemu_runner.go
+++ b/pkg/container/qemu_runner.go
@@ -405,18 +405,24 @@ func (bw *qemu) WorkspaceTar(ctx context.Context, cfg *Config, extraFiles []stri
 		user = cfg.RunAs
 	}
 
+	log := clog.FromContext(ctx)
+	stderr := logwriter.New(log.Debug)
 	err = sendSSHCommand(ctx,
 		user,
 		cfg.SSHWorkspaceAddress,
 		cfg,
 		nil,
 		nil,
-		nil,
+		stderr,
 		outFile,
 		false,
 		[]string{"sh", "-c", retrieveCommand},
 	)
+
 	if err != nil {
+		var buf bytes.Buffer
+		io.Copy(&buf, outFile)
+		clog.FromContext(ctx).Errorf("failed to tar workspace: %v", buf.String())
 		return nil, err
 	}
 

--- a/pkg/container/qemu_runner.go
+++ b/pkg/container/qemu_runner.go
@@ -421,7 +421,11 @@ func (bw *qemu) WorkspaceTar(ctx context.Context, cfg *Config, extraFiles []stri
 
 	if err != nil {
 		var buf bytes.Buffer
-		io.Copy(&buf, outFile)
+		_, cerr := io.Copy(&buf, outFile)
+		if cerr != nil {
+			clog.FromContext(ctx).Errorf("failed to tar workspace: %v", cerr)
+			return nil, cerr
+		}
 		clog.FromContext(ctx).Errorf("failed to tar workspace: %v", buf.String())
 		return nil, err
 	}


### PR DESCRIPTION
Add some output to tar generation
Make sure that parent directory of unpacked files exists 