### PR TITLE
license-check: fix running checks for builds using qemu

### DIFF
--- a/pkg/container/qemu_runner.go
+++ b/pkg/container/qemu_runner.go
@@ -45,6 +45,7 @@ import (
 	apko_types "chainguard.dev/apko/pkg/build/types"
 	apko_cpio "chainguard.dev/apko/pkg/cpio"
 	"chainguard.dev/melange/internal/logwriter"
+	"chainguard.dev/melange/pkg/license"
 	"github.com/chainguard-dev/clog"
 	"github.com/charmbracelet/log"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
@@ -387,6 +388,17 @@ func (bw *qemu) WorkspaceTar(ctx context.Context, cfg *Config, extraFiles []stri
 	if cfg.SSHKey == nil {
 		return nil, nil
 	}
+
+	// For qemu, we also want to get all the detected license files for the
+	// license checking that will be done later.
+	// First, get the list of all files from the remote workspace.
+	licenseFiles, err := getWorkspaceLicenseFiles(ctx, cfg)
+	if err != nil {
+		clog.FromContext(ctx).Errorf("failed to extract list of files for licensing: %v", err)
+		return nil, err
+	}
+	// Now, append those files to the extraFiles list.
+	extraFiles = append(extraFiles, licenseFiles...)
 
 	outFile, err := os.Create(filepath.Join(cfg.WorkspaceDir, "melange-out.tar"))
 	if err != nil {
@@ -772,6 +784,52 @@ func createMicroVM(ctx context.Context, cfg *Config) error {
 		false,
 		[]string{"sh", "-c", "find /mnt/ -mindepth 1 -maxdepth 1 -exec cp -a {} /home/build/ \\;"},
 	)
+}
+
+// getWorkspaceLicenseFiles returns a list of possible license files from the
+// workspace
+func getWorkspaceLicenseFiles(ctx context.Context, cfg *Config) ([]string, error) {
+	// default to root user, unless a different user is specified
+	user := "root"
+	if cfg.RunAs != "" {
+		user = cfg.RunAs
+	}
+
+	// let's create a string writer so that the SSH command can write
+	// the list of files to it
+	var buf bytes.Buffer
+	bufWriter := bufio.NewWriter(&buf)
+	defer bufWriter.Flush()
+	err := sendSSHCommand(ctx,
+		user,
+		cfg.SSHWorkspaceAddress,
+		cfg,
+		nil,
+		nil,
+		nil,
+		bufWriter,
+		false,
+		[]string{"sh", "-c", "cd /mount/home/build && find . -type f -print"},
+	)
+
+	if err != nil {
+		clog.FromContext(ctx).Errorf("failed to extract list of files for licensing: %v", buf.String())
+		return nil, err
+	}
+
+	// Now, we can read the list of files from the string writer.
+	licenseFiles := []string{}
+	foundFiles := strings.SplitSeq(buf.String(), "\n")
+	for f := range foundFiles {
+		if strings.Contains(f, "melange-out") {
+			continue
+		}
+		if is, _ := license.IsLicenseFile(filepath.Base(f)); is {
+			licenseFiles = append(licenseFiles, f)
+		}
+	}
+
+	return licenseFiles, nil
 }
 
 func getKernelPath(ctx context.Context, cfg *Config) (string, error) {

--- a/pkg/license/license.go
+++ b/pkg/license/license.go
@@ -20,6 +20,7 @@ import (
 	"io/fs"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"sort"
 	"strings"
 
@@ -172,8 +173,10 @@ func FindLicenseFiles(fsys fs.FS) ([]LicenseFile, error) {
 }
 
 // IsLicenseFile checks if a file is a license file based on its name.
+// Returns true/fals if the file is a license file, and the weight value
+// associated with the match, as some matches are potentially more relevant.
 func IsLicenseFile(filename string) (bool, float64) {
-	var ignore bool
+	filenameExt := filepath.Ext(filename)
 	// Check if the file matches any of the license-related regex patterns
 	for regex, weight := range filenameRegexes {
 		if !regex.MatchString(filename) {
@@ -181,12 +184,7 @@ func IsLicenseFile(filename string) (bool, float64) {
 		}
 		// licensee does this check as part of the regex, but in go we don't have
 		// the same regex capabilities
-		for _, ext := range ignoredExt {
-			if ignore = filepath.Ext(filename) == ext; ignore {
-				break
-			}
-		}
-		if ignore {
+		if slices.Contains(ignoredExt, filenameExt) {
 			continue
 		}
 		return true, weight

--- a/pkg/license/license.go
+++ b/pkg/license/license.go
@@ -129,7 +129,6 @@ func (c *melangeClassifier) Identify(fsys fs.FS, licensePath string) ([]License,
 func FindLicenseFiles(fsys fs.FS) ([]LicenseFile, error) {
 	// This file is using regular expressions defined in the regexp.go file
 	var licenseFiles []LicenseFile
-	var ignore bool
 	err := fs.WalkDir(fsys, ".", func(filePath string, info fs.DirEntry, err error) error {
 		if err != nil {
 			return err
@@ -143,22 +142,8 @@ func FindLicenseFiles(fsys fs.FS) ([]LicenseFile, error) {
 			return nil
 		}
 
-		// Check if the file matches any of the license-related regex patterns
-		for regex, weight := range filenameRegexes {
-			if !regex.MatchString(info.Name()) {
-				continue
-			}
-			// licensee does this check as part of the regex, but in go we don't have
-			// the same regex capabilities
-			for _, ext := range ignoredExt {
-				if ignore = filepath.Ext(info.Name()) == ext; ignore {
-					break
-				}
-			}
-			if ignore {
-				continue
-			}
-
+		is, weight := IsLicenseFile(info.Name())
+		if is {
 			// Licenses in the top level directory have a higher weight so that they
 			// always appear first
 			if filepath.Dir(filePath) == "." {
@@ -169,7 +154,6 @@ func FindLicenseFiles(fsys fs.FS) ([]LicenseFile, error) {
 				Path:   filePath,
 				Weight: weight,
 			})
-			break
 		}
 
 		return nil
@@ -185,6 +169,29 @@ func FindLicenseFiles(fsys fs.FS) ([]LicenseFile, error) {
 	})
 
 	return licenseFiles, nil
+}
+
+// IsLicenseFile checks if a file is a license file based on its name.
+func IsLicenseFile(filename string) (bool, float64) {
+	var ignore bool
+	// Check if the file matches any of the license-related regex patterns
+	for regex, weight := range filenameRegexes {
+		if !regex.MatchString(filename) {
+			continue
+		}
+		// licensee does this check as part of the regex, but in go we don't have
+		// the same regex capabilities
+		for _, ext := range ignoredExt {
+			if ignore = filepath.Ext(filename) == ext; ignore {
+				break
+			}
+		}
+		if ignore {
+			continue
+		}
+		return true, weight
+	}
+	return false, 0.0
 }
 
 // CollectLicenseInfo collects license information from the given filesystem.

--- a/pkg/license/license_test.go
+++ b/pkg/license/license_test.go
@@ -117,6 +117,7 @@ func TestIdentify(t *testing.T) {
 		"LICENSE-BSD-modified": "BSD-3-Clause",
 		"LICENSE-GPLv2":        "GPL-2.0",
 		"LICENSE-GPLv3":        "GPL-3.0",
+		"COPYRIGHT":            "NOASSERTION",
 	}
 
 	testDataDir := "testdata"


### PR DESCRIPTION
We have recently added license-checking to the build pipeline, running our license identification against the build workspace to come up with what licenses are present in the source.

This works fine for bubblewrap as the workspace directory operates via bind mounts, but for qemu, the workspace is on the qemu disk and we only get the artifacts via `retrieveWorkspace()` - which only syncs the `melange-out/` dir + any other files we explicitly ask for. So licensing checks can't run properly, as they need the source from the workspace for analysis.
Modify the qemu runner to fetch all the license related files and copy them over as part of `retrieveWorkspace()`.