### PR TITLE
fix: improve QEMU resource limits handling

### DIFF
--- a/.github/workflows/wolfi-presubmit.yaml
+++ b/.github/workflows/wolfi-presubmit.yaml
@@ -71,7 +71,7 @@ jobs:
           - py3-pyelftools  # Uses license-path
           - cadvisor  # uses cgroups
           - fping  # uses get/setcaps
-          - memcached  # uses a diff test user
+          - sonarqube-10  # uses a diff test user
           - perl-yaml-syck
           - ncurses
           - subversion


### PR DESCRIPTION
Default to use 85% or available memory and all CPU cores. If a resource snippet is declared, it will be treated as an upbound limit for resources.

Fixes: https://github.com/chainguard-dev/prodsec/issues/143