### PR TITLE
sbom: pass SHA512 not SHA256 when in use.

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -549,7 +549,7 @@ func (p Pipeline) SBOMPackageForUpstreamSource(licenseDeclared, supplier string,
 		expectedSHA512 := with["expected-sha512"]
 		if len(expectedSHA512) > 0 {
 			args["checksum"] = "sha512:" + expectedSHA512
-			checksums["SHA512"] = expectedSHA256
+			checksums["SHA512"] = expectedSHA512
 		}
 
 		// These get defaulted correctly from within the fetch pipeline definition


### PR DESCRIPTION
Ensure the correct checksum is used when generating downloadLocation checksums.