### PR TITLE
feat: use user's SSH keys to talk to QEMU runner

### DIFF
--- a/pkg/container/config.go
+++ b/pkg/container/config.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	apko_types "chainguard.dev/apko/pkg/build/types"
+	"golang.org/x/crypto/ssh"
 )
 
 const (
@@ -56,7 +57,7 @@ type Config struct {
 	RunAs                 string
 	WorkspaceDir          string
 	CPU, CPUModel, Memory string
-	SSHKey                []byte
+	SSHKey                ssh.Signer
 	SSHAddress            string
 	SSHWorkspaceAddress   string
 	SSHHostKey            string


### PR DESCRIPTION
This makes debugging a lot easier, so people can easily enter a debug shell when building with `melange build --debug`

If no SSH Keys are present, they'll be generated on the spot like before.