### PR TITLE
wolfi-presubmit: configure MELANGE_RUNNER for bubblewrap builds.

### DIFF
--- a/.github/workflows/wolfi-presubmit.yaml
+++ b/.github/workflows/wolfi-presubmit.yaml
@@ -117,7 +117,7 @@ jobs:
         uses: ./melange-src/.github/actions/setup-bubblewrap
       - if: matrix.runner == 'bubblewrap'
         run: |
-          make SHELL="/bin/bash" MELANGE="sudo melange" package/${{ matrix.package }}
+          make MELANGE_RUNNER="bubblewrap" SHELL="/bin/bash" MELANGE="sudo melange" package/${{ matrix.package }}
 
       - name: Download kernel for VMs
         if: matrix.runner == 'qemu'

--- a/.github/workflows/wolfi-presubmit.yaml
+++ b/.github/workflows/wolfi-presubmit.yaml
@@ -154,7 +154,7 @@ jobs:
       - name: Run tests to verify xattrs with bubblewrap runner
         if: matrix.runner == 'bubblewrap' && matrix.package == 'fping'
         run: |
-          make SHELL="/bin/bash" MELANGE="sudo melange" test/${{ matrix.package }}
+          make MELANGE_RUNNER="bubblewrap" SHELL="/bin/bash" MELANGE="sudo melange" test/${{ matrix.package }}
 
       - name: Run tests with QEMU runner
         if: matrix.runner == 'qemu'


### PR DESCRIPTION
wolfi now defaults to using qemu; set MELANGE_RUNNER for bubblewrap build tests.