### PR TITLE
test(e2e/pipelines): run tests on qemu runner

### DIFF
--- a/.github/workflows/melange-test-pipelines.yaml
+++ b/.github/workflows/melange-test-pipelines.yaml
@@ -40,7 +40,7 @@ jobs:
     name: Test packages
     needs:
       - build-melange
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-8-core
 
     permissions:
       contents: read
@@ -74,6 +74,27 @@ jobs:
           go-version-file: './go.mod'
           check-latest: true
 
+      - name: Download kernel for VMs
+        run: |
+          KERNEL_PKG="$(curl -sL https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/APKINDEX.tar.gz | tar -Oxz APKINDEX | awk -F':' '$1 == "P" {printf "%s-", $2} $1 == "V" {printf "%s.apk\n", $2}' | grep "linux-virt" | grep -v dev)"
+          curl -LSo linux-virt.apk "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/$KERNEL_PKG"
+          mkdir -p /tmp/kernel
+          tar -xf ./linux-virt.apk -C /tmp/kernel/
+
+      - name: Install QEMU/KVM
+        run: |
+          sudo apt-get update
+          sudo apt-get -y install qemu-system-x86-64 qemu-kvm
+
+      - name: Enable KVM group perms
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
       - name: Run e2e-tests
         run: |
-          make test-e2e
+          make \
+            QEMU_KERNEL_IMAGE=/tmp/kernel/boot/vmlinuz-virt \
+            QEMU_KERNEL_MODULES=/tmp/kernel/lib/modules/ \
+            test-e2e

--- a/e2e-tests/capabilities-add-drop-build.yaml
+++ b/e2e-tests/capabilities-add-drop-build.yaml
@@ -20,18 +20,18 @@ environment:
 pipeline:
   - name: Test default effective capability
     runs: |
-      # Skip test if on QEMU runner, since the runner does not support process capabilities Melange feature.
+      # Skip test if on QEMU runner, since the runner does not support process capabilities add/drop Melange feature.
       { test -f /sys/class/dmi/id/sys_vendor && grep -E "^QEMU$" /sys/class/dmi/id/sys_vendor && exit 0; } || true
       capsh --decode=$(grep CapEff /proc/self/status | cut -d ':' -f2 | xargs) | grep -i cap_dac_override
 
   - name: Test added non-default effective capability
     runs: |
-      # Skip test if on QEMU runner, since the runner does not support process capabilities Melange feature.
+      # Skip test if on QEMU runner, since the runner does not support process capabilities add/drop Melange feature.
       { test -f /sys/class/dmi/id/sys_vendor && grep -E "^QEMU$" /sys/class/dmi/id/sys_vendor && exit 0; } || true
       capsh --decode=$(grep CapEff /proc/self/status | cut -d ':' -f2 | xargs) | grep -i cap_net_admin
 
   - name: Test dropped default effective capability
     runs: |
-      # Skip test if on QEMU runner, since the runner does not support process capabilities Melange feature.
+      # Skip test if on QEMU runner, since the runner does not support process capabilities add/drop Melange feature.
       { test -f /sys/class/dmi/id/sys_vendor && grep -E "^QEMU$" /sys/class/dmi/id/sys_vendor && exit 0; } || true
       capsh --decode=$(grep CapEff /proc/self/status | cut -d ':' -f2 | xargs) | grep -vi cap_sys_chroot

--- a/e2e-tests/capabilities-add-drop-build.yaml
+++ b/e2e-tests/capabilities-add-drop-build.yaml
@@ -20,12 +20,18 @@ environment:
 pipeline:
   - name: Test default effective capability
     runs: |
+      # Skip test if on QEMU runner, since the runner does not support process capabilities Melange feature.
+      { test -f /sys/class/dmi/id/sys_vendor && grep -E "^QEMU$" /sys/class/dmi/id/sys_vendor && exit 0; } || true
       capsh --decode=$(grep CapEff /proc/self/status | cut -d ':' -f2 | xargs) | grep -i cap_dac_override
 
   - name: Test added non-default effective capability
     runs: |
+      # Skip test if on QEMU runner, since the runner does not support process capabilities Melange feature.
+      { test -f /sys/class/dmi/id/sys_vendor && grep -E "^QEMU$" /sys/class/dmi/id/sys_vendor && exit 0; } || true
       capsh --decode=$(grep CapEff /proc/self/status | cut -d ':' -f2 | xargs) | grep -i cap_net_admin
 
   - name: Test dropped default effective capability
     runs: |
+      # Skip test if on QEMU runner, since the runner does not support process capabilities Melange feature.
+      { test -f /sys/class/dmi/id/sys_vendor && grep -E "^QEMU$" /sys/class/dmi/id/sys_vendor && exit 0; } || true
       capsh --decode=$(grep CapEff /proc/self/status | cut -d ':' -f2 | xargs) | grep -vi cap_sys_chroot

--- a/e2e-tests/capabilities-add-drop-nopkg-test.yaml
+++ b/e2e-tests/capabilities-add-drop-nopkg-test.yaml
@@ -22,18 +22,18 @@ test:
   pipeline:
     - name: Test default effective capability
       runs: |
-        # Skip test if on QEMU runner, since the runner does not support process capabilities Melange feature.
+        # Skip test if on QEMU runner, since the runner does not support process capabilities add/drop Melange feature.
         { test -f /sys/class/dmi/id/sys_vendor && grep -E "^QEMU$" /sys/class/dmi/id/sys_vendor && exit 0; } || true
         capsh --decode=$(grep CapEff /proc/self/status | cut -d ':' -f2 | xargs) | grep -i cap_dac_override
 
     - name: Test added non-default effective capability
       runs: |
-        # Skip test if on QEMU runner, since the runner does not support process capabilities Melange feature.
+        # Skip test if on QEMU runner, since the runner does not support process capabilities add/drop Melange feature.
         { test -f /sys/class/dmi/id/sys_vendor && grep -E "^QEMU$" /sys/class/dmi/id/sys_vendor && exit 0; } || true
         capsh --decode=$(grep CapEff /proc/self/status | cut -d ':' -f2 | xargs) | grep -i cap_net_admin
 
     - name: Test dropped default effective capability
       runs: |
-        # Skip test if on QEMU runner, since the runner does not support process capabilities Melange feature.
+        # Skip test if on QEMU runner, since the runner does not support process capabilities add/drop Melange feature.
         { test -f /sys/class/dmi/id/sys_vendor && grep -E "^QEMU$" /sys/class/dmi/id/sys_vendor && exit 0; } || true
         capsh --decode=$(grep CapEff /proc/self/status | cut -d ':' -f2 | xargs) | grep -vi cap_sys_chroot

--- a/e2e-tests/capabilities-add-drop-nopkg-test.yaml
+++ b/e2e-tests/capabilities-add-drop-nopkg-test.yaml
@@ -22,12 +22,18 @@ test:
   pipeline:
     - name: Test default effective capability
       runs: |
+        # Skip test if on QEMU runner, since the runner does not support process capabilities Melange feature.
+        { test -f /sys/class/dmi/id/sys_vendor && grep -E "^QEMU$" /sys/class/dmi/id/sys_vendor && exit 0; } || true
         capsh --decode=$(grep CapEff /proc/self/status | cut -d ':' -f2 | xargs) | grep -i cap_dac_override
 
     - name: Test added non-default effective capability
       runs: |
+        # Skip test if on QEMU runner, since the runner does not support process capabilities Melange feature.
+        { test -f /sys/class/dmi/id/sys_vendor && grep -E "^QEMU$" /sys/class/dmi/id/sys_vendor && exit 0; } || true
         capsh --decode=$(grep CapEff /proc/self/status | cut -d ':' -f2 | xargs) | grep -i cap_net_admin
 
     - name: Test dropped default effective capability
       runs: |
+        # Skip test if on QEMU runner, since the runner does not support process capabilities Melange feature.
+        { test -f /sys/class/dmi/id/sys_vendor && grep -E "^QEMU$" /sys/class/dmi/id/sys_vendor && exit 0; } || true
         capsh --decode=$(grep CapEff /proc/self/status | cut -d ':' -f2 | xargs) | grep -vi cap_sys_chroot

--- a/e2e-tests/git-checkout-build.yaml
+++ b/e2e-tests/git-checkout-build.yaml
@@ -271,14 +271,16 @@ pipeline:
       else
         # Ownership of existing files is not changed.
         expected_runner=42
-        expected_melange=6
+        expected_melange=1
       fi
       exclude_args="! -regex ^\.\/\.ssh.*$ ! -regex ^./.gitconfig$"
       found_runner=$(find . -user $runner_user $exclude_args | wc -l)
       mismatch=""
       if [[ $found_runner != $expected_runner ]]; then
-        echo "Expected $expected_runner files owned by $runner_user, found $found_runner"
+        echo "Expected $expected_runner files owned by the runner user $runner_user, found $found_runner"
         find . -user $runner_user $exclude_args
+        echo "files owned by Melange user $melange_user:"
+        find . -user $melange_user $exclude_args
         mismatch=true
       fi
       if [[ $melange_user != $runner_user ]]; then

--- a/e2e-tests/greeter-build-test.yaml
+++ b/e2e-tests/greeter-build-test.yaml
@@ -16,7 +16,7 @@ package:
   epoch: 0
   dependencies:
     runtime:
-      - dash-binsh
+      - busybox
 
 environment:
   contents:

--- a/e2e-tests/run-tests
+++ b/e2e-tests/run-tests
@@ -67,6 +67,7 @@ for yaml in "$@"; do
     vrc "Testing $base from $yaml for $op" \
       ${MELANGE} "$op" \
         --arch=x86_64 --source-dir=./test-fixtures \
+        --runner=qemu \
         "$yaml" \
         ${args} $opargs \
         "--keyring-append=$PWD/$key.pub" \


### PR DESCRIPTION
This PR sets the QEMU runner as the default runner for e2e tests for pipelines.
It uses the Alpine kernel, the same way we do for the Wolfi presubmit CI workflow.

## Melange Pull Request Template

### Functional Changes

- [ ] This change can build all of Wolfi without errors (describe results in notes)

Notes:

### SCA Changes

- [ ] Examining several representative APKs show no regression / the desired effect (details in notes)

Notes:

### Linter

- [ ] The new check is clean across Wolfi
- [ ] The new check is opt-in or a warning

Notes: