### PR TITLE
fix: add ignore paths to license files

### DIFF
--- a/pkg/container/qemu_runner.go
+++ b/pkg/container/qemu_runner.go
@@ -439,7 +439,7 @@ func (bw *qemu) WorkspaceTar(ctx context.Context, cfg *Config, extraFiles []stri
 	// we append also all the necessary files that we might need, for example Licenses
 	// for license checks
 	for _, v := range extraFiles {
-		retrieveCommand = retrieveCommand + " " + v
+		retrieveCommand = fmt.Sprintf("%s %q", retrieveCommand, v)
 	}
 
 	// default to root user, unless a different user is specified
@@ -855,7 +855,7 @@ func getWorkspaceLicenseFiles(ctx context.Context, cfg *Config, extraFiles []str
 		if strings.Contains(f, "melange-out") {
 			continue
 		}
-		if is, _ := license.IsLicenseFile(filepath.Base(f)); is {
+		if is, _ := license.IsLicenseFile(f); is {
 			licenseFiles = append(licenseFiles, f)
 		}
 	}

--- a/pkg/license/license.go
+++ b/pkg/license/license.go
@@ -184,7 +184,7 @@ func IsLicenseFile(filename string) (bool, float64) {
 		"venv",
 	}
 	for _, i := range ignoredPaths {
-		if strings.Contains(filepath.Dir(filename), i) {
+		if slices.Contains(strings.Split(filename, string(filepath.Separator)), i) {
 			return false, 0.0
 		}
 	}

--- a/pkg/license/license.go
+++ b/pkg/license/license.go
@@ -143,7 +143,7 @@ func FindLicenseFiles(fsys fs.FS) ([]LicenseFile, error) {
 			return nil
 		}
 
-		is, weight := IsLicenseFile(info.Name())
+		is, weight := IsLicenseFile(filePath)
 		if is {
 			// Licenses in the top level directory have a higher weight so that they
 			// always appear first
@@ -176,6 +176,22 @@ func FindLicenseFiles(fsys fs.FS) ([]LicenseFile, error) {
 // Returns true/fals if the file is a license file, and the weight value
 // associated with the match, as some matches are potentially more relevant.
 func IsLicenseFile(filename string) (bool, float64) {
+	// Ignore files in these paths
+	ignoredPaths := []string{
+		".virtualenv",
+		"env",
+		"node_modules",
+		"venv",
+	}
+	for _, i := range ignoredPaths {
+		if strings.Contains(filepath.Dir(filename), i) {
+			return false, 0.0
+		}
+	}
+
+	// normalize to file name only
+	filename = filepath.Base(filename)
+
 	filenameExt := filepath.Ext(filename)
 	// Check if the file matches any of the license-related regex patterns
 	for regex, weight := range filenameRegexes {

--- a/pkg/license/license_test.go
+++ b/pkg/license/license_test.go
@@ -122,7 +122,10 @@ func TestFindLicenseFiles(t *testing.T) {
 	tmpDir = t.TempDir()
 	for _, name := range testInoreFiles {
 		filePath := filepath.Join(tmpDir, name)
-		os.MkdirAll(filepath.Join(tmpDir, filepath.Dir(name)), os.ModePerm)
+		err := os.MkdirAll(filepath.Join(tmpDir, filepath.Dir(name)), os.ModePerm)
+		if err != nil {
+			t.Fatalf("Failed to create test file %s: %v", name, err)
+		}
 		fp, err := os.OpenFile(filePath, os.O_RDONLY|os.O_CREATE, 0666)
 		if err != nil {
 			t.Fatalf("Failed to create test file %s: %v", name, err)
@@ -136,6 +139,9 @@ func TestFindLicenseFiles(t *testing.T) {
 	licenseFiles, err = FindLicenseFiles(tmpFS)
 	if len(licenseFiles) > 0 {
 		t.Fatalf("Failed to test ignored files")
+	}
+	if err != nil {
+		t.Fatalf("FindLicenseFiles returned an error: %v", err)
 	}
 
 }

--- a/pkg/license/license_test.go
+++ b/pkg/license/license_test.go
@@ -101,6 +101,43 @@ func TestFindLicenseFiles(t *testing.T) {
 			t.Errorf("Expected license file %s not found", expected)
 		}
 	}
+
+	testInoreFiles := []string{
+		"node_modules/LICENSE",
+		"node_modules/LICENSE.md",
+		"venv/COPYING",
+		"venv/COPYING.txt",
+		"venv/random.txt",
+		"env/LICENSE-MIT.md",
+		"env/README.md",
+		"env/LICENSE-APACHE",
+		".virtualenv/LICENSE.gemspec",
+		".virtualenv/COPYRIGHT",
+		".virtualenv/MIT-COPYING",
+		"node_modules/copyme",
+		"node_modules/COPY",
+		"node_modules/LICENSE.txt",
+	}
+
+	tmpDir = t.TempDir()
+	for _, name := range testInoreFiles {
+		filePath := filepath.Join(tmpDir, name)
+		os.MkdirAll(filepath.Join(tmpDir, filepath.Dir(name)), os.ModePerm)
+		fp, err := os.OpenFile(filePath, os.O_RDONLY|os.O_CREATE, 0666)
+		if err != nil {
+			t.Fatalf("Failed to create test file %s: %v", name, err)
+		}
+		fp.Close()
+	}
+
+	tmpFS = apkofs.DirFS(tmpDir)
+
+	// Call function under test
+	licenseFiles, err = FindLicenseFiles(tmpFS)
+	if len(licenseFiles) > 0 {
+		t.Fatalf("Failed to test ignored files")
+	}
+
 }
 
 func TestIdentify(t *testing.T) {


### PR DESCRIPTION
This way we ignore huge number of files that are not actually part of the source

Fixes: https://github.com/chainguard-dev/prodsec/issues/156