### PR TITLE
e2e-tests/run-tests: Invoke melange using `$MELANGE`

### DIFF
--- a/e2e-tests/run-tests
+++ b/e2e-tests/run-tests
@@ -27,7 +27,7 @@ key="local-melange.rsa"
 if [ -f "$key" -a -f "$key.pub" ]; then
     echo "using existing $key"
 else
-    melange keygen "$key" ||
+    $MELANGE keygen "$key" ||
         { echo "failed to create local-melange signing key"; exit 1; }
 fi
 


### PR DESCRIPTION
When `melange` is not in `PATH`, but you still invoke `make test-e2e` passing `MELANGE` and pointing to a proper `melange` binary, the `run-tests` script will currently fail because it tries to invoke the system's `melange` to generate the keys.  Fix this by always making sure to invoke `$MELANGE`.