### PR TITLE
fix: improve SSH command handling

### DIFF
--- a/.github/workflows/wolfi-presubmit.yaml
+++ b/.github/workflows/wolfi-presubmit.yaml
@@ -71,7 +71,7 @@ jobs:
           - py3-pyelftools  # Uses license-path
           - cadvisor  # uses cgroups
           - fping  # uses get/setcaps
-          - sonarqube-10  # uses a diff test user
+          - logstash-8  # uses a diff test user
           - perl-yaml-syck
           - ncurses
           - subversion

--- a/pkg/container/config.go
+++ b/pkg/container/config.go
@@ -63,4 +63,7 @@ type Config struct {
 	SSHHostKey            string
 	Disk                  string
 	Timeout               time.Duration
+	SSHClient             *ssh.Client
+	WorkspaceClient       *ssh.Client
+	QemuPID               int
 }

--- a/pkg/container/qemu_runner.go
+++ b/pkg/container/qemu_runner.go
@@ -674,6 +674,7 @@ func createMicroVM(ctx context.Context, cfg *Config) error {
 
 	// qemu-system-x86_64 or qemu-system-aarch64...
 	qemuCmd := exec.CommandContext(ctx, fmt.Sprintf("qemu-system-%s", cfg.Arch.ToAPK()), baseargs...)
+	clog.FromContext(ctx).Info("qemu: starting VM")
 	clog.FromContext(ctx).Debugf("qemu: executing - %s", strings.Join(qemuCmd.Args, " "))
 
 	outRead, outWrite := io.Pipe()
@@ -725,6 +726,7 @@ func createMicroVM(ctx context.Context, cfg *Config) error {
 
 	started := make(chan struct{})
 
+	clog.FromContext(ctx).Info("qemu: waiting for SSH")
 	go func() {
 		// one-hour timeout with a 500ms sleep
 		retries := 7200


### PR DESCRIPTION
Instead of using session.Run() we use session.Shell() and use session.Stdin to "write" the command in it.

Also, deduplicate clients, and only keep them as singletons.

Makes it more resilient to random EOFs

Avoid leaking qemu processes, kill by pid if things go wrong

Fix: https://github.com/chainguard-dev/prodsec/issues/170