### PR TITLE
fix: make checkout expected-commit bump less greedy

### DIFF
--- a/docs/VAR-TRANSFORMS.md
+++ b/docs/VAR-TRANSFORMS.md
@@ -46,6 +46,21 @@ pipeline:
       uri: https://github.com/openjdk/jdk17u/archive/refs/tags/jdk-${{vars.mangled-package-version}}.tar.gz
 ```
 
+`mangled-package-version` can also be used with `git-checkout`:
+
+```yaml
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/openjdk/jdk12u
+      tag: ${{vars.mangled-package-version}}
+      expected-commit: 5018cdd1904357c04c9c41e0f8fe8994916cb638
+```
+
+
+Note: If `melange bump` is run, it will attempt to update the `expected-commit` value.
+
+
 Other example:
 
 In some case, you need to join two or more regex match subgroups with `_`. Here you must use `${1}` instead of `$1`. More information [here](https://github.com/golang/go/issues/32885#issuecomment-507477621)

--- a/pkg/renovate/bump/bump.go
+++ b/pkg/renovate/bump/bump.go
@@ -225,8 +225,7 @@ func updateGitCheckout(ctx context.Context, node *yaml.Node, expectedGitSha stri
 	if err != nil {
 		log.Infof("git-checkout node does not contain a tag, assume we need to update the expected-commit sha")
 	} else {
-		versionPattern := regexp.MustCompile(`\${{vars\..+}}`)
-		if !strings.Contains(tag.Value, "${{package.version}}") && !versionPattern.MatchString(tag.Value) {
+		if !strings.Contains(tag.Value, "${{package.version}}") && !strings.Contains(tag.Value, "${{vars.mangled-package-version}}") {
 			log.Infof("Skipping git-checkout node as it does not contain a version substitution so assuming it is not the main checkout")
 			return nil
 		}

--- a/pkg/renovate/bump/bump.go
+++ b/pkg/renovate/bump/bump.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"regexp"
 	"strconv"
 	"strings"
 

--- a/pkg/renovate/bump/bump.go
+++ b/pkg/renovate/bump/bump.go
@@ -236,7 +236,7 @@ func updateGitCheckout(ctx context.Context, node *yaml.Node, expectedGitSha stri
 	if expectedGitSha != "" {
 		// Update expected hash nodes.
 		nodeCommit, err := renovate.NodeFromMapping(withNode, "expected-commit")
-		if err == nil {
+		if err == nil && !strings.Contains(nodeCommit.Value, "${{") {
 			nodeCommit.Value = expectedGitSha
 			log.Infof("  expected-commit: %s", expectedGitSha)
 		}


### PR DESCRIPTION
## Melange Pull Request Template

Prior to this commit, bumps updated `expected-commit` for any git checkout node who's `tag` attribute matched the regular expression `\${{vars\..+}}` (i.e. anything which used a variable).

This made the logic very greedy, clobbering values for unrelated checkouts (for example [here](https://github.com/wolfi-dev/os/pull/52449/commits/4bc6632241cd0487b22349344dcea4c25647ef7d))

We only want bumps to update those where `tag` matches either `package.version` or `vars.mangled-package-version`. 

Currently we use the following vars in `tag` attributes:
```
ben@cosmos:~/Repos/os$ grep -h 'tag: ${' *.yaml | grep -v 'package\.version' | cut -d: -f2 | sort | uniq
 ${{vars.docker-machine-tag}}
 ${{vars.exporter-tag}}
 ${{vars.mangled-package-version}}
```

It also adds a check to ensure that `expected-commit` does not contain a variable (i.e. `${{`) before overwriting it's value

