### PR TITLE
linter: usrmerge add trailing '/' to denote directory for prefix check

### DIFF
--- a/pkg/linter/linter.go
+++ b/pkg/linter/linter.go
@@ -807,7 +807,7 @@ func usrmergeLinter(ctx context.Context, _ *config.Configuration, _ string, fsys
 			}
 		}
 
-		if strings.HasPrefix(path, "sbin/") || strings.HasPrefix(path, "bin/") || strings.HasPrefix(path, "usr/sbin") {
+		if strings.HasPrefix(path, "sbin/") || strings.HasPrefix(path, "bin/") || strings.HasPrefix(path, "usr/sbin/") {
 			paths = append(paths, path)
 		}
 


### PR DESCRIPTION
Not sure why it was missed on usr/sbin/ but not the others. Without this usr/sbin is checked twice, once to see if it's a directory or regular file and again when assembling a list on non compliant files. We only want to check for files inside usr/sbin/ not recheck usr/sbin.

Before:
```
❯ ./melange lint wolfi-baselayout-20230201-r20.apk
2025/05/29 11:09:28 INFO Required checks: [dev infodir tempdir usrmerge varempty]
2025/05/29 11:09:28 INFO Warning checks: [lddcheck object opt pkgconf python/docs python/multiple python/test setuidgid srv strip usrlocal worldwrite]
2025/05/29 11:09:28 INFO linting apk: wolfi-baselayout (size: 13 kB)
2025/05/29 11:09:28 WARN linter "usrlocal" failed on package "wolfi-baselayout": /usr/local path found in non-compat package: usr/local/lib64; suggest: This package should be a -compat package
2025/05/29 11:09:28 ERRO linter "usrmerge" failed on package "wolfi-baselayout": Package contains paths in violation of usrmerge:
usr/sbin
; suggest: Move binary to /usr/bin
```

After:
```
❯ ./melange lint wolfi-baselayout-20230201-r20.apk
2025/05/29 11:09:12 INFO Required checks: [dev infodir tempdir usrmerge varempty]
2025/05/29 11:09:12 INFO Warning checks: [lddcheck object opt pkgconf python/docs python/multiple python/test setuidgid srv strip usrlocal worldwrite]
2025/05/29 11:09:12 INFO linting apk: wolfi-baselayout (size: 13 kB)
2025/05/29 11:09:12 WARN linter "usrlocal" failed on package "wolfi-baselayout": /usr/local path found in non-compat package: usr/local/lib64; suggest: This package should be a -compat package
```

What the path looks like:

```
❯ tar tvf ./wolfi-baselayout-20230201-r20.apk | grep 'usr/sbin'
lrwxrwxrwx  0 root   root        0 Mar 31 06:08 usr/sbin -> bin
```

## Melange Pull Request Template

<!--
*** PULL REQUEST CHECKLIST: PLEASE START HERE ***

The single most important feature of melange is that we can build Wolfi.

Many changes to melange introduce a risk of breaking the build, and sometimes
these are not flushed out until a package is changed (much) later.  This
pertains to basic execution, SCA changes, linter changes, and more.
-->

### Functional Changes

- [ ] This change can build all of Wolfi without errors (describe results in notes)

Notes:

### SCA Changes

- [ ] Examining several representative APKs show no regression / the desired effect (details in notes)

Notes:

### Linter

- [ ] The new check is clean across Wolfi
- [ ] The new check is opt-in or a warning

Notes:
