### PR TITLE
fix: manually setting release version to fix blocked pipeline

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -50,6 +50,7 @@ jobs:
         if: steps.check.outputs.need_release == 'yes' && steps.check.outputs.existing_tag == ''
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          custom_tag: "v0.26.4"
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         if: steps.check.outputs.need_release == 'yes'


### PR DESCRIPTION
### Functional Changes

- [x] This change can build all of Wolfi without errors (describe results in notes)

Notes:
* This is simply a workaround to a tagging issue for the GHA
* Alternative to this PR we could get an admin to delete the previous failed tags
