### PR TITLE
Add rust-src directories to ignoredPaths

### DIFF
--- a/.github/workflows/wolfi-presubmit.yaml
+++ b/.github/workflows/wolfi-presubmit.yaml
@@ -68,15 +68,16 @@ jobs:
           - guac
           - mdbook
           - s3cmd
-          - py3-pyelftools  # Uses license-path
-          - cadvisor  # uses cgroups
-          - fping  # uses get/setcaps
-          - logstash-8  # uses a diff test user
+          - py3-pyelftools # Uses license-path
+          - cadvisor # uses cgroups
+          - fping # uses get/setcaps
+          - logstash-8 # uses a diff test user
           - perl-yaml-syck
           - ncurses
           - subversion
           - sudo
           - py3-supported-python
+          - rust-1.86
           # TODO: https://github.com/wolfi-dev/os/issues/26442
           #- xmlto
 

--- a/pkg/license/license.go
+++ b/pkg/license/license.go
@@ -177,10 +177,18 @@ func FindLicenseFiles(fsys fs.FS) ([]LicenseFile, error) {
 // associated with the match, as some matches are potentially more relevant.
 func IsLicenseFile(filename string) (bool, float64) {
 	// Ignore files in these paths
+
+	// Packages like Rust embed the semver in certain paths, so replace the segment with `-`
+	// rust-1.86.0-src -> rust-src
+	re := regexp.MustCompile(`\-\d+\.\d+\.\d+\-`)
+	filename = re.ReplaceAllString(filename, "-")
+
 	ignoredPaths := []string{
 		".virtualenv",
 		"env",
 		"node_modules",
+		"rust-src",
+		"rustc-src",
 		"venv",
 	}
 	for _, i := range ignoredPaths {

--- a/pkg/license/license_test.go
+++ b/pkg/license/license_test.go
@@ -117,6 +117,8 @@ func TestFindLicenseFiles(t *testing.T) {
 		"node_modules/copyme",
 		"node_modules/COPY",
 		"node_modules/LICENSE.txt",
+		"rust-src-1.86.0/rust-src/foo/LICENSE-MIT",
+		"rustc-src-1.86.0/rust-src/foo/LICENSE-MIT",
 	}
 
 	tmpDir = t.TempDir()


### PR DESCRIPTION
Rust exhibits a similar behavior to packages that have `node_modules` directories. This PR adds a bit of regex parsing to ensure we have a consistent string to ignore. I built `rust-1.86` locally and it worked whereas previously it failed when encountering `rust-x.y.z/` LICENSE files.