### PR TITLE
Avoid external cache for QEMU

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -1113,10 +1113,14 @@ func (b *Build) buildWorkspaceConfig(ctx context.Context) *container.Config {
 			WorkspaceDir: b.WorkspaceDir,
 		}
 	}
-
 	mounts := []container.BindMount{
 		{Source: b.WorkspaceDir, Destination: container.DefaultWorkspaceDir},
 		{Source: "/etc/resolv.conf", Destination: container.DefaultResolvConfPath},
+	}
+
+	// Mounting /var/cache/melange via 9p is orders of magnitude slower
+	if b.Runner.Name() == container.QemuName {
+		b.CacheDir = "/home/build/.melange-cache"
 	}
 
 	if b.CacheDir != "" {


### PR DESCRIPTION
Using `/var/cache/melange` within QEMU over `9p` (at least on macOS?) has sizable performance implications. For instance, I spent 20 minutes downloading Go packages and still did not manage to move onto a build.

For QEMU, we can use a local directory in `/home/build` to avoid the performance hit unless there's a better way to do this. This also improves the isolation story since we aren't sharing a cache between builds.

Edit: `cadvisor` builds in ~90 seconds in CI with this code and it previously took ~5 minutes.