### PR TITLE
qemu runner: define static mount tag for mount_cache

### DIFF
--- a/pkg/container/qemu_runner.go
+++ b/pkg/container/qemu_runner.go
@@ -635,7 +635,7 @@ func createMicroVM(ctx context.Context, cfg *Config) error {
 
 	if cfg.CacheDir != "" {
 		baseargs = append(baseargs, "-fsdev", "local,security_model=mapped,id=fsdev101,path="+cfg.CacheDir)
-		baseargs = append(baseargs, "-device", "virtio-9p-pci,id=fs101,fsdev=fsdev101,mount_tag="+cfg.CacheDir)
+		baseargs = append(baseargs, "-device", "virtio-9p-pci,id=fs101,fsdev=fsdev101,mount_tag=melange_cache")
 	}
 
 	// if no size is specified, let's go for a default
@@ -792,11 +792,10 @@ func createMicroVM(ctx context.Context, cfg *Config) error {
 	if cfg.CacheDir != "" {
 		clog.FromContext(ctx).Infof("qemu: setting up melange cachedir: %s", cfg.CacheDir)
 		setupMountCommand := fmt.Sprintf(
-			"mkdir -p %s %s /mount/upper /mount/work && mount -t 9p %s %s && "+
+			"mkdir -p %s %s /mount/upper /mount/work && mount -t 9p melange_cache %s && "+
 				"mount -t overlay overlay -o lowerdir=%s,upperdir=/mount/upper,workdir=/mount/work %s",
 			cfg.CacheDir,
 			filepath.Join("/mount", DefaultCacheDir),
-			cfg.CacheDir,
 			cfg.CacheDir,
 			cfg.CacheDir,
 			filepath.Join("/mount", DefaultCacheDir),


### PR DESCRIPTION
In 2c1640e ("fix: handle CACHEDIR properly (#2021)"), the qemu runner was changed to mount the host's melange-cache into the vm as a disk based overlayfs. However, when it does this, it set the mount_tag that the 9p client in the guest uses to identify what to mount as the path in the host system, based on $TMPDIR. Unfortunately, the mount_tag has a limit of 31 characters, so if $TMPDIR is set to not /tmp, this can cause failures, like it did for me:

```
WARN qemu: qemu-system-x86_64: -device virtio-9p-pci,id=fs101,fsdev=fsdev101,mount_tag=/home/sbeattie/tmp/melange-cache: mount tag '/home/sbeattie/tmp/melange-cache' (32 bytes) is longer than maximum (31 bytes)
ERRO failed to build package: unable to start pod: qemu: VM exited unexpectedly: exit status 1

```

To fix this, convert the mount_tag for the melange cache in the qemu invocation to a static tag called "melange_cache", and pass that in the 9p mount invocation.
