### PR TITLE
fix: ensure we don't create random mount points

### DIFF
--- a/pkg/container/qemu_runner.go
+++ b/pkg/container/qemu_runner.go
@@ -794,10 +794,10 @@ func createMicroVM(ctx context.Context, cfg *Config) error {
 		setupMountCommand := fmt.Sprintf(
 			"mkdir -p %s %s /mount/upper /mount/work && mount -t 9p melange_cache %s && "+
 				"mount -t overlay overlay -o lowerdir=%s,upperdir=/mount/upper,workdir=/mount/work %s",
-			cfg.CacheDir,
+			DefaultCacheDir,
 			filepath.Join("/mount", DefaultCacheDir),
-			cfg.CacheDir,
-			cfg.CacheDir,
+			DefaultCacheDir,
+			DefaultCacheDir,
 			filepath.Join("/mount", DefaultCacheDir),
 		)
 		if setupMountCommand != ": " {


### PR DESCRIPTION
cfg.CacheDir can be foregin paths and might be a problem to use them as-is in the qemu vm
so let's use DefaultCacheDir instead