### PR TITLE
sbom: generate downloadLocations for unknown gits

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"testing"
 
-	"chainguard.dev/apko/pkg/sbom/generator/spdx"
 	"chainguard.dev/melange/pkg/sbom"
 	"github.com/chainguard-dev/clog/slogtest"
 	purl "github.com/package-url/packageurl-go"
@@ -779,7 +778,7 @@ func TestGetGitSBOMPackage(t *testing.T) {
 					Version:    "v3.2.1",
 					Qualifiers: purl.QualifiersFromMap(map[string]string{"vcs_url": "git+https://git.example.com/custom-org/custom-project"}),
 				},
-				DownloadLocation: spdx.NOASSERTION,
+				DownloadLocation: "https://tarballs.chainguard.dev/608a605d8d2ab7139ece3614ed66e9d8f26207ea-v3.2.1.tar.gz",
 			},
 			expectError: false,
 		},
@@ -802,7 +801,7 @@ func TestGetGitSBOMPackage(t *testing.T) {
 					Version:    "abcdef0123456789abcdef0123456789abcdef01",
 					Qualifiers: purl.QualifiersFromMap(map[string]string{"vcs_url": "git+https://git.example.com/custom-org/custom-project@abcdef0123456789abcdef0123456789abcdef01"}),
 				},
-				DownloadLocation: spdx.NOASSERTION,
+				DownloadLocation: "https://tarballs.chainguard.dev/608a605d8d2ab7139ece3614ed66e9d8f26207ea-abcdef0123456789abcdef0123456789abcdef01.tar.gz",
 			},
 			expectError: false,
 		},
@@ -825,7 +824,7 @@ func TestGetGitSBOMPackage(t *testing.T) {
 					Version:    "v3.2.1",
 					Qualifiers: purl.QualifiersFromMap(map[string]string{"vcs_url": "git+https://git.example.com/custom-org/custom-project@abcdef0123456789abcdef0123456789abcdef01"}),
 				},
-				DownloadLocation: spdx.NOASSERTION,
+				DownloadLocation: "https://tarballs.chainguard.dev/608a605d8d2ab7139ece3614ed66e9d8f26207ea-abcdef0123456789abcdef0123456789abcdef01.tar.gz",
 			},
 			expectError: false,
 		},
@@ -848,7 +847,7 @@ func TestGetGitSBOMPackage(t *testing.T) {
 					Version:    "v3.2.1",
 					Qualifiers: purl.QualifiersFromMap(map[string]string{"vcs_url": "git://git.example.com/custom-project@abcdef0123456789abcdef0123456789abcdef01"}),
 				},
-				DownloadLocation: spdx.NOASSERTION,
+				DownloadLocation: "https://tarballs.chainguard.dev/b081ce6d3d60edf8fb56381229094a3cffc2d6da-abcdef0123456789abcdef0123456789abcdef01.tar.gz",
 			},
 			expectError: false,
 		},


### PR DESCRIPTION
Use tarballs.chainguard.dev for the downloadLocation for git sources
which are not github or gitlab based; these will be populated
automatically by a post commit job that generates and uploads the
tarballs to the detailed location.
