### PR TITLE
qemu runner: fix embedded authorized key when debugging

### DIFF
--- a/pkg/container/qemu_runner.go
+++ b/pkg/container/qemu_runner.go
@@ -124,7 +124,7 @@ func (bw *qemu) Debug(ctx context.Context, cfg *Config, envOverride map[string]s
 		log.Warn("qemu: could not get user ssh key pair, using ephemeral ones")
 	}
 	if pubKey != nil {
-		command := fmt.Sprintf("echo %q | tee -a /root/.ssh/authorized_keys /home/*/.ssh/authorized_keys", string(pubKey))
+		command := fmt.Sprintf("echo %q | tee -a /root/.ssh/authorized_keys /home/*/.ssh/authorized_keys", strings.TrimSpace(string(pubKey)))
 		err := sendSSHCommand(ctx,
 			cfg.WorkspaceClient,
 			cfg,


### PR DESCRIPTION
When using the qemu runner with the debug build option, the user's public ssh key is supposed to get appended to the guests authorized_keys files, but attempts to use this were failing with:

```
  root@localhost: Permission denied (publickey,keyboard-interactive).
```

Examining what melange was injecting into the guest's authorized keys file, the user's public key contained a trailing newline character; e.g.:

```
  wolfi-vm:~# cat .ssh/authorized_keys
  ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBDhcpdU0le62vuZ5K6MSe+ywqZBUY6FFcIA6iklvUFwRVfXh7Gh7zDYRSMc5JydcCju9oSxml4YocCWbddOF7m8=
  ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEMVW0YujhFd5iaIf15QAdQv8YeS3v/F+P+pN10qi4Fg\n
```

Fix this by trimming space/newlines on the stringified public key before injecting it into the guest.

Fixes: https://github.com/chainguard-dev/prodsec/issues/217