### PR TITLE
Delete named pipes instead of broadly excluding fifo files

### DIFF
--- a/.github/workflows/wolfi-presubmit.yaml
+++ b/.github/workflows/wolfi-presubmit.yaml
@@ -67,6 +67,7 @@ jobs:
           - dpkg
           #- gdk-pixbuf # Looks like this is broken again, see: https://gitlab.gnome.org/GNOME/gobject-introspection/-/issues/515
           - gitsign
+          - grafana-image-renderer
           - guac
           - mdbook
           - s3cmd

--- a/pkg/container/qemu_runner.go
+++ b/pkg/container/qemu_runner.go
@@ -425,7 +425,7 @@ func (bw *qemu) WorkspaceTar(ctx context.Context, cfg *Config, extraFiles []stri
 	// We could just cp -a to /mnt as it is our shared workspace directory, but
 	// this will lose some file metadata like hardlinks, owners and so on.
 	// Example of package that won't work when using "cp -a" is glibc.
-	retrieveCommand := "cd /mount/home/build && tar cvpf - --xattrs --acls --exclude='*fifo*' melange-out"
+	retrieveCommand := "cd /mount/home/build && find melange-out -type p -delete 2>/dev/null || true && tar cvpf - --xattrs --acls melange-out"
 	// we append also all the necessary files that we might need, for example Licenses
 	// for license checks
 	for _, v := range extraFiles {


### PR DESCRIPTION
We're currently excluding `fifo` files by name which is preventing certain legitimate files and directories that are needed in the emitted APK.

This PR deletes any named pipe files before we try to archive the workspace instead of potentially excluding valid directories or files.