### PR TITLE
manpages.yaml: Move directory contents to avoid errors and clean up a…

### DIFF
--- a/pkg/build/pipelines/split/manpages.yaml
+++ b/pkg/build/pipelines/split/manpages.yaml
@@ -27,7 +27,8 @@ pipeline:
         "$PACKAGE_DIR/usr/man"; do
 
         if [ -d "$mandir" ]; then
-          mkdir -p "${{targets.contextdir}}/usr/share"
-          mv "$mandir" "${{targets.contextdir}}/usr/share/"
+          mkdir -p "${{targets.contextdir}}/usr/share/man"
+          mv "$mandir"/* "${{targets.contextdir}}/usr/share/man/"
+          rmdir --parents --ignore-fail-on-non-empty "$mandir"
         fi
       done


### PR DESCRIPTION
Updated the script to move only the contents of detected man directories into the target, avoiding directory conflicts. Also added cleanup to remove empty source directories after relocation.