### PR TITLE
Error if a package version is not parseable by apk.ParseVersion

### DIFF
--- a/pkg/build/testdata/build_configs/bogus-version.yaml
+++ b/pkg/build/testdata/build_configs/bogus-version.yaml
@@ -1,0 +1,54 @@
+# this package should be valid except it has an invalid version.
+package:
+  name: bogus-version
+  version: 1.0.0_b6
+  epoch: 0
+  description: A package with a invalid version.
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - busybox
+
+environment:
+  contents:
+    packages:
+      - busybox
+      - apk-tools
+
+pipeline:
+  - name: Ask apk version what it thinks about package.version
+    runs: |
+      ver="${{package.version}}"
+      validity="valid"
+      apk version -c "$ver" >/dev/null || validity="invalid"
+      echo "'apk version -c $ver' says '$ver' is $validity"
+
+  - name: build a package
+    runs: |
+      bd="${{target.destdir}}/usr/bin/"
+      fpath="$bd/bogus-version"
+      ver="${{package.version}}"
+
+      mkdir -p "$bd"
+      cat >"$fpath" <<EOF
+      #!/bin/sh
+      echo "Bogus! version is $ver.
+      EOF
+      chmod 755 "$fpath"
+
+update:
+  enabled: false
+
+test:
+  pipeline:
+    - name: run bogus-version
+      runs: |
+        fail() { echo "FAIL:" "$@"; exit 1; }
+        ver="${{package.version}}"
+        out=$(bogus-version) || fail "bogus-version exited $?"
+        echo "$out" | grep -i bogus ||
+          fail "bogus-version output did not have 'bogus'"
+        echo "$out" | grep -F "$ver" ||
+          fail "bogus-version output did not have '$ver'"
+        echo "PASS: tested bogus-version"

--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 	"time"
 
+	"chainguard.dev/apko/pkg/apk/apk"
 	apko_types "chainguard.dev/apko/pkg/build/types"
 	"chainguard.dev/melange/pkg/build"
 	"chainguard.dev/melange/pkg/container"
@@ -338,7 +339,13 @@ func BuildCmd(ctx context.Context, archs []apko_types.Architecture, baseOpts ...
 		} else if err != nil {
 			return err
 		}
+
 		defer bc.Close(ctx)
+
+		ver := bc.Configuration.Package.Version
+		if _, err := apk.ParseVersion(ver); err != nil {
+			return fmt.Errorf("Unable to parse version '%s' for %s: %v", ver, bc.ConfigFile, err)
+		}
 
 		bcs = append(bcs, bc)
 	}


### PR DESCRIPTION
As described in https://github.com/chainguard-dev/apko/issues/1704 , There are some packages that have gotten into the archive with versions that apko cannot parse.

This change makes melange error if it sees a version that cannot be parsed.