### PR TITLE
fix: avoid fetching hardlinks in licenses

### DIFF
--- a/pkg/container/qemu_runner.go
+++ b/pkg/container/qemu_runner.go
@@ -925,7 +925,7 @@ func getWorkspaceLicenseFiles(ctx context.Context, cfg *Config, extraFiles []str
 		nil,
 		bufWriter,
 		false,
-		[]string{"sh", "-c", "cd /mount/home/build && find . -type f -print"},
+		[]string{"sh", "-c", "cd /mount/home/build && find . -type f -links 1 -print"},
 	)
 
 	if err != nil {


### PR DESCRIPTION
Hardlinks will not behave well when uncompressing the fetched archive on the host, so we avoid them, they're duplicate files anyway