### PR TITLE
licensing: default to concatenating with AND, add simple mode  for license-check --fix

### DIFF
--- a/docs/md/melange_license-check.md
+++ b/docs/md/melange_license-check.md
@@ -30,6 +30,7 @@ melange license-check file [flags]
 ```
       --fix              fix license issues in the melange yaml file
   -h, --help             help for license-check
+      --simple           use a simple copyright format with all detected licenses joined together
       --workdir string   path to the working directory, e.g. where the source will be extracted to
 ```
 

--- a/pkg/cli/license_check.go
+++ b/pkg/cli/license_check.go
@@ -32,6 +32,7 @@ import (
 func licenseCheck() *cobra.Command {
 	var workDir string
 	var fix bool
+	var simple bool
 	cmd := &cobra.Command{
 		Use:     "license-check file",
 		Short:   "Gather and check licensing data",
@@ -81,6 +82,7 @@ func licenseCheck() *cobra.Command {
 					ctx,
 					copyright.WithLicenses(detectedLicenses),
 					copyright.WithDiffs(diffs),
+					copyright.WithSimple(simple),
 				)
 				err = rc.Renovate(cmd.Context(), copyrightRenovator)
 			}
@@ -91,6 +93,7 @@ func licenseCheck() *cobra.Command {
 
 	cmd.Flags().StringVar(&workDir, "workdir", "", "path to the working directory, e.g. where the source will be extracted to")
 	cmd.Flags().BoolVar(&fix, "fix", false, "fix license issues in the melange yaml file")
+	cmd.Flags().BoolVar(&simple, "simple", false, "use a simple copyright format with all detected licenses joined together")
 
 	return cmd
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -432,7 +432,7 @@ func (p Package) LicenseExpression() string {
 	}
 	for _, cp := range p.Copyright {
 		if licenseExpression != "" {
-			licenseExpression += " OR "
+			licenseExpression += " AND "
 		}
 		licenseExpression += cp.License
 	}

--- a/pkg/renovate/copyright/copyright.go
+++ b/pkg/renovate/copyright/copyright.go
@@ -17,6 +17,9 @@ package copyright
 import (
 	"context"
 	"fmt"
+	"maps"
+	"slices"
+	"strings"
 
 	"github.com/chainguard-dev/clog"
 
@@ -30,6 +33,7 @@ import (
 type CopyrightConfig struct {
 	Licenses []license.License
 	Diffs    []license.LicenseDiff
+	Simple   bool
 }
 
 // Option sets a config option on a CopyrightConfig.
@@ -49,6 +53,16 @@ func WithLicenses(licenses []license.License) Option {
 func WithDiffs(diffs []license.LicenseDiff) Option {
 	return func(cfg *CopyrightConfig) error {
 		cfg.Diffs = diffs
+		return nil
+	}
+}
+
+// WithSimple sets whether the copyright should be populated with a single
+// node containing all detected licenses joined together, or with multiple
+// nodes, one per license.
+func WithSimple(simple bool) Option {
+	return func(cfg *CopyrightConfig) error {
+		cfg.Simple = simple
 		return nil
 	}
 }
@@ -104,46 +118,98 @@ func New(ctx context.Context, opts ...Option) renovate.Renovator {
 		copyrightNode.Content = nil
 
 		// Repopulate the copyrightNode with detected licenses
-		for _, l := range ccfg.Licenses {
-			// Skip licenses we don't have full confidence in.
-			if !license.IsLicenseMatchConfident(l) {
-				log.Infof("skipping unconfident license %s", l.Source)
-				continue
+		if ccfg.Simple {
+			// Make the copyright field a single node with all licenses joined together
+			if err = populateSimpleCopyright(ctx, copyrightNode, ccfg.Licenses); err != nil {
+				return err
 			}
-
-			licenseNode := &yaml.Node{
-				Kind:    yaml.MappingNode,
-				Style:   yaml.FlowStyle,
-				Content: []*yaml.Node{},
+		} else {
+			// Use flat license listing (original behavior)
+			if err = populateCopyright(ctx, copyrightNode, ccfg.Licenses); err != nil {
+				return err
 			}
-
-			licenseNode.Content = append(licenseNode.Content, &yaml.Node{
-				Kind:  yaml.ScalarNode,
-				Value: "license",
-				Tag:   "!!str",
-				Style: yaml.FlowStyle,
-			}, &yaml.Node{
-				Kind:  yaml.ScalarNode,
-				Value: l.Name,
-				Tag:   "!!str",
-				Style: yaml.FlowStyle,
-			})
-
-			licenseNode.Content = append(licenseNode.Content, &yaml.Node{
-				Kind:  yaml.ScalarNode,
-				Value: "license-path",
-				Tag:   "!!str",
-				Style: yaml.FlowStyle,
-			}, &yaml.Node{
-				Kind:  yaml.ScalarNode,
-				Value: l.Source,
-				Tag:   "!!str",
-				Style: yaml.FlowStyle,
-			})
-
-			copyrightNode.Content = append(copyrightNode.Content, licenseNode)
 		}
 
 		return nil
 	}
+}
+
+// populateCopyright populates the copyright node with the detected licenses,
+// one entry per license.
+func populateCopyright(ctx context.Context, copyrightNode *yaml.Node, licenses []license.License) error {
+	log := clog.FromContext(ctx)
+
+	for _, l := range licenses {
+		// Skip licenses we don't have full confidence in.
+		if !license.IsLicenseMatchConfident(l) {
+			log.Infof("skipping unconfident license %s", l.Source)
+			continue
+		}
+
+		licenseNode := &yaml.Node{
+			Kind:    yaml.MappingNode,
+			Style:   yaml.FlowStyle,
+			Content: []*yaml.Node{},
+		}
+
+		licenseNode.Content = append(licenseNode.Content, &yaml.Node{
+			Kind:  yaml.ScalarNode,
+			Value: "license",
+			Tag:   "!!str",
+			Style: yaml.FlowStyle,
+		}, &yaml.Node{
+			Kind:  yaml.ScalarNode,
+			Value: l.Name,
+			Tag:   "!!str",
+			Style: yaml.FlowStyle,
+		})
+
+		licenseNode.Content = append(licenseNode.Content, &yaml.Node{
+			Kind:  yaml.ScalarNode,
+			Value: "license-path",
+			Tag:   "!!str",
+			Style: yaml.FlowStyle,
+		}, &yaml.Node{
+			Kind:  yaml.ScalarNode,
+			Value: l.Source,
+			Tag:   "!!str",
+			Style: yaml.FlowStyle,
+		})
+
+		copyrightNode.Content = append(copyrightNode.Content, licenseNode)
+	}
+
+	return nil
+}
+
+// populateSimpleCopyright populates the copyright field with a single node
+// with all detected licenses joined together.
+func populateSimpleCopyright(ctx context.Context, copyrightNode *yaml.Node, licenses []license.License) error {
+	log := clog.FromContext(ctx)
+
+	// Gather all the license names and concatenate them with AND statements
+	licenseMap := make(map[string]struct{})
+	for _, l := range licenses {
+		if !license.IsLicenseMatchConfident(l) {
+			log.Infof("skipping unconfident license %s", l.Source)
+			continue
+		}
+		licenseMap[l.Name] = struct{}{}
+	}
+
+	if len(licenseMap) == 0 {
+		log.Infof("no confident licenses found to populate copyright")
+		return nil
+	}
+
+	// Join the license names with " AND ", sorting them first for consistency
+	ls := slices.Collect(maps.Keys(licenseMap))
+	slices.Sort(ls)
+	combined := strings.Join(ls, " AND ")
+
+	copyrightNode.Kind = yaml.ScalarNode
+	copyrightNode.Value = combined
+	copyrightNode.Tag = "!!str"
+
+	return nil
 }

--- a/pkg/renovate/copyright/copyright_test.go
+++ b/pkg/renovate/copyright/copyright_test.go
@@ -126,3 +126,66 @@ func TestCopyright_noDiffs(t *testing.T) {
 	assert.Contains(t, string(resultData), "license: Not-Applicable")
 	assert.NotContains(t, string(resultData), "license: Invalid")
 }
+
+func TestCopyright_updateSimple(t *testing.T) {
+	dir := t.TempDir()
+	ctx := slogtest.Context(t)
+
+	detectedLicenses := []license.License{
+		{
+			Name:       "Apache-2.0",
+			Source:     "LICENSE",
+			Confidence: 1.0,
+		},
+		{
+			Name:       "MIT",
+			Source:     "internal/COPYING",
+			Confidence: 1.0,
+		},
+		{
+			Name:       "Apache-2.0",
+			Source:     "vendor/foo/LICENSE",
+			Confidence: 1.0,
+		},
+		{
+			Name:       "GPL-3.0",
+			Source:     "internal/LICENSE",
+			Confidence: 0.2,
+		},
+	}
+
+	diffs := []license.LicenseDiff{
+		{
+			Path:   "LICENSE",
+			Is:     "GPL-2.0",
+			Should: "Apache-2.0",
+		},
+	}
+
+	// Copy the test data file to the temp directory
+	src := filepath.Join("testdata", "nolicense.yaml")
+	testFile := filepath.Join(dir, "nolicense.yaml")
+	input, err := os.ReadFile(src)
+	assert.NoError(t, err)
+
+	err = os.WriteFile(testFile, input, 0644)
+	assert.NoError(t, err)
+
+	rctx, err := renovate.New(renovate.WithConfig(testFile))
+	assert.NoError(t, err)
+
+	copyrightRenovator := New(ctx, WithLicenses(detectedLicenses), WithDiffs(diffs), WithSimple(true))
+
+	err = rctx.Renovate(slogtest.Context(t), copyrightRenovator)
+	assert.NoError(t, err)
+
+	resultData, err := os.ReadFile(testFile)
+	assert.NoError(t, err)
+
+	// The copyright field should be a single string with both licenses joined by " AND "
+	result := string(resultData)
+	assert.Contains(t, result, "Apache-2.0 AND MIT")
+	assert.NotContains(t, result, "GPL-3.0")
+	assert.NotContains(t, result, "NOASSERTION")
+	assert.NotContains(t, result, "license:")
+}


### PR DESCRIPTION
Rationale: even with our current license checking mechanism, listing out all the licenses properly will end up concatenating them in the package with an OR statement. This is bad. Think of GPL software containing some vendored MIT code - its SBOM will end up with a license string of "GPLv3 OR MIT", which is untrue and potentially dangerous as the code cannot be redistributed with a less restrictive license. Defaulting to AND is a safer bet.

There is an ongoing design and implementation effort to add ability to express relations to licensing: https://github.com/chainguard-dev/melange/pull/2050 . But this is a big change and needs an actual design doc I'm afraid.

In the meantime, switching to AND seems a good bet, and I added a renovate `--simple` option for the `--fix` mode that doesn't list all the licenses individually (with links to files) but simply deals with listing out just the licenses in one string. It's something we'll want to modify and do properly (listing all the files), but before we do, this is the only safe way of ensuring the person working on the licensing bits has power over relationships between the licenses listed out. `--fix` just gives a guideline, nothing more.