### PR TITLE
Fix issues introduced by the qemu_runner changes to os-release

### DIFF
--- a/pkg/container/qemu_runner.go
+++ b/pkg/container/qemu_runner.go
@@ -493,7 +493,6 @@ func (bw *qemu) GetReleaseData(ctx context.Context, cfg *Config) (*apko_build.Re
 		nil,
 		nil,
 		bufWriter,
-		false,
 		[]string{"sh", "-c", "cat /etc/os-release"},
 	)
 
@@ -1223,7 +1222,7 @@ func sendSSHCommand(ctx context.Context, client *ssh.Client,
 	// Tests expect to be able to put processes in background between steps.
 	// using `script` will avoid ssh hangs for open fds, and will allow to
 	// leave background processes running for the whole duration of the test.
-	if cfg.TestRun{
+	if cfg.TestRun {
 		cmd = shellquote.Join(append([]string{
 			"script", "-f", "-q",
 			"--log-in", "/dev/null",


### PR DESCRIPTION
Latest PR broke melange PRs, not sure how the tests were passing before. Maybe some stuff got merged before that changed the qemu run commands!