### PR TITLE
scan: Add namespace flag

### DIFF
--- a/docs/md/melange_scan.md
+++ b/docs/md/melange_scan.md
@@ -29,6 +29,7 @@ melange scan bash.yaml
       --diff                       show diff output
   -h, --help                       help for scan
   -k, --keyring-append string      path to key to include in the build environment keyring (default "local-melange.rsa.pub")
+      --namespace string           namespace to use in package URLs in SBOM (eg wolfi, alpine) (default "unknown")
   -p, --package string             which package's .PKGINFO to print (if there are subpackages)
   -r, --repository-append string   path to repository to include in the build environment (default "./packages")
 ```

--- a/pkg/cli/scan.go
+++ b/pkg/cli/scan.go
@@ -45,6 +45,8 @@ type scanConfig struct {
 	archs    []string
 	diff     bool
 	comments bool
+
+	purlNamespace string
 }
 
 func scan() *cobra.Command {
@@ -68,6 +70,8 @@ func scan() *cobra.Command {
 	cmd.Flags().StringSliceVar(&sc.archs, "arch", []string{}, "architectures to scan (default is x86_64)")
 	cmd.Flags().BoolVar(&sc.diff, "diff", false, "show diff output")
 	cmd.Flags().BoolVar(&sc.comments, "comments", false, "include comments in .PKGINFO diff")
+
+	cmd.Flags().StringVar(&sc.purlNamespace, "namespace", "unknown", "namespace to use in package URLs in SBOM (eg wolfi, alpine)")
 
 	return cmd
 }
@@ -151,6 +155,7 @@ func scanCmd(ctx context.Context, file string, sc *scanConfig) error {
 			WorkspaceDir:    dir,
 			SourceDateEpoch: time.Unix(0, 0),
 			Configuration:   cfg,
+			Namespace:       sc.purlNamespace,
 		}
 
 		pb := build.PackageBuild{


### PR DESCRIPTION
This gets plumbed into the maintainer field, which we started setting at some point, so it would cause spurious diffs.