### PR TITLE
scan: Return an error instead of os.Exit(1)

### DIFF
--- a/pkg/cli/scan.go
+++ b/pkg/cli/scan.go
@@ -328,7 +328,7 @@ func scanCmd(ctx context.Context, file string, sc *scanConfig) error {
 	}
 
 	if sawDiff {
-		os.Exit(1)
+		return fmt.Errorf("saw diff for %s", file)
 	}
 
 	return nil


### PR DESCRIPTION
We defer a bunch of Close() calls to clean up temporary directories, but defers aren't executed if you call os.Exit, so these were leaking when using the --diff flag.

Instead, just return an error, which will still exit with an error code of 1, but only after running the clean up defers.