### PR TITLE
SCA: Generate `provides` for shlibs ending with ".so"

### DIFF
--- a/pkg/sca/sca.go
+++ b/pkg/sca/sca.go
@@ -622,7 +622,7 @@ func generateSharedObjectNameDeps(ctx context.Context, hdl SCAHandle, generated 
 		//
 		// As a rough heuristic, we assume that if the filename contains ".so.",
 		// it is meant to be used as a shared object.
-		if interp == "" || strings.Contains(basename, ".so.") {
+		if interp == "" || strings.Contains(basename, ".so.") || strings.HasSuffix(basename, ".so") {
 			sonames, err := ef.DynString(elf.DT_SONAME)
 			// most likely SONAME is not set on this object
 			if err != nil {


### PR DESCRIPTION
This is the first step to implement support for `depends` generation.

I plan to implement the support for `depends` soon, but it will require more thought because we can't generate `depends` statements for packages that don't have `provides` yet.

Relates: https://github.com/chainguard-dev/internal-dev/issues/7609