### PR TITLE
license-check: allow relative paths for extracted-source paths

### DIFF
--- a/pkg/cli/license_check.go
+++ b/pkg/cli/license_check.go
@@ -63,6 +63,11 @@ func licenseCheck() *cobra.Command {
 				sourceDir = workDir
 			}
 
+			// Turn sourceDir to an absolute path
+			sourceDir, err = filepath.Abs(sourceDir)
+			if err != nil {
+				return fmt.Errorf("failed to get absolute path for source directory: %w", err)
+			}
 			sourceFS := apkofs.DirFS(sourceDir)
 			detectedLicenses, diffs, err := license.LicenseCheck(ctx, cfg, sourceFS)
 			if err != nil {


### PR DESCRIPTION
A really small bugfix - currently if you run `melange license-check ./` when in a source directory, for instance, the command will fail. It's fine for yaml and apk files, but not source directories. This fixes it.