### PR TITLE
Avoid running cachedir mount commands via script

### DIFF
--- a/pkg/container/qemu_runner.go
+++ b/pkg/container/qemu_runner.go
@@ -59,6 +59,8 @@ import (
 
 var _ Debugger = (*qemu)(nil)
 
+var setupMountCommand string
+
 const QemuName = "qemu"
 
 const (
@@ -843,7 +845,7 @@ func createMicroVM(ctx context.Context, cfg *Config) error {
 
 	if cfg.CacheDir != "" {
 		clog.FromContext(ctx).Infof("qemu: setting up melange cachedir: %s", cfg.CacheDir)
-		setupMountCommand := fmt.Sprintf(
+		setupMountCommand = fmt.Sprintf(
 			"mkdir -p %s %s /mount/upper /mount/work && mount -t 9p melange_cache %s && "+
 				"mount -t overlay overlay -o lowerdir=%s,upperdir=/mount/upper,workdir=/mount/work %s",
 			DefaultCacheDir,
@@ -1220,7 +1222,8 @@ func sendSSHCommand(ctx context.Context, client *ssh.Client,
 	// Tests expect to be able to put processes in background between steps.
 	// using `script` will avoid ssh hangs for open fds, and will allow to
 	// leave background processes running for the whole duration of the test.
-	if cfg.TestRun {
+	// Don't run the cache dir mount commands through `script` on boot since it will not work
+	if cfg.TestRun && !strings.Contains(cmd, setupMountCommand) {
 		cmd = shellquote.Join(append([]string{
 			"script", "-f", "-q",
 			"--log-in", "/dev/null",


### PR DESCRIPTION
We currently run all QEMU commands via `script` when running tests. This does not work for the cache directory mount commands:
```
2025/07/07 16:46:49 INFO qemu: setting up melange cachedir: /tmp/melange-cache
2025/07/07 16:46:49 WARN ash: script: not found
2025/07/07 16:46:49 ERRO Failed to run command "script -f -q --log-in /dev/null --log-out /dev/null -e -c 'sh -c '\\''mkdir -p /var/cache/melange /mount/var/cache/melange /mount/upper /mount/work && mount -t 9p melange_cache /var/cache/melange && mount -t overlay overlay -o lowerdir=/var/cache/melange,upperdir=/mount/upper,workdir=/mount/work /mount/var/cache/melange'\\'": Process exited with status 127
```

This PR avoids running the initial cache directory mount commands via `script` for tests while allowing for all other commands.