### PR TITLE
SCA: Generate `depends` for shlibs ending in `.so`

### DIFF
--- a/.github/workflows/wolfi-presubmit.yaml
+++ b/.github/workflows/wolfi-presubmit.yaml
@@ -211,6 +211,9 @@ jobs:
             docker run --rm -v $(pwd):/work --workdir /work cgr.dev/chainguard/wolfi-base /bin/sh -c "sed 's|=.*||' -i /etc/apk/world; apk add --allow-untrusted -X ./packages/ packages/x86_64/${{ matrix.package }}-*.apk; ls -hal /usr/bin/sudo"
           elif [[ "${{ matrix.package }}" == "postfix" ]]; then
             docker run --rm -v $(pwd):/work --workdir /work cgr.dev/chainguard/wolfi-base /bin/sh -c "sed 's|=.*||' -i /etc/apk/world; apk add --allow-untrusted -X ./packages/ packages/x86_64/${{ matrix.package }}-*.apk; ls -hal /var/spool/postfix; ls -hal /var/lib/postfix"
+            # Test https://github.com/chainguard-dev/melange/pull/2072
+            PKGVER=$(tar -Oxf ./packages/x86_64/${{ matrix.package }}-stone-*.apk .PKGINFO | grep '^pkgver' | cut -d' ' -f3)
+            tar -Oxf ./packages/x86_64/${{ matrix.package }}-stone-*.apk .PKGINFO | grep "^depend = ${{ matrix.package }}=${PKGVER}"
           else
             docker run --rm -v $(pwd):/work --workdir /work cgr.dev/chainguard/wolfi-base /bin/sh -c "sed 's|=.*||' -i /etc/apk/world; apk add --allow-untrusted -X ./packages/ packages/x86_64/${{ matrix.package }}-*.apk"
           fi

--- a/docs/BUILD-FILE.md
+++ b/docs/BUILD-FILE.md
@@ -218,6 +218,16 @@ options:
   no-versioned-shlib-deps: true
 ```
 
+`no-vendored-cross-package-deps` - When a subpackage `X` ships a
+vendored shared library that's used by subpackage `Y`, melange won't
+generate a `depends` from `Y -> X`.  By default, melange will generate
+a `depends` for `X=version`.
+
+```
+options:
+  no-vendored-cross-package-deps: true
+```
+
 ### scriptlets
 List of executable scripts that run at various stages of the package lifecycle,
 triggered by configurable events. These are useful to handle tasks that only

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -92,6 +92,10 @@ type PackageOption struct {
 	NoCommands bool `json:"no-commands,omitempty" yaml:"no-commands,omitempty"`
 	// Optional: Don't generate versioned depends for shared libraries
 	NoVersionedShlibDeps bool `json:"no-versioned-shlib-deps,omitempty" yaml:"no-versioned-shlib-deps,omitempty"`
+	// Optional: Don't generate inter-package depends when one
+	// subpackage depends on a vendored shared library shipped by
+	// another.
+	NoVendoredCrossPackageDeps bool `json:"no-vendored-cross-package-deps,omitempty" yaml:"no-vendored-cross-package-deps,omitempty"`
 }
 
 type Checks struct {

--- a/pkg/sca/e2e_test.go
+++ b/pkg/sca/e2e_test.go
@@ -73,6 +73,7 @@ func TestAnalyze(t *testing.T) {
 				"so:liblcms2-e69eef39.so.2.0.16",
 				"so:liblzma-13fa198c.so.5.4.5",
 				"so:libm.so.6",
+				"so:libopenblas64_p-r0-0cf96a72.3.23.dev.so",
 				"so:libopenjp2-eca49203.so.2.5.0",
 				"so:libpng16-78d422d5.so.16.40.0",
 				"so:libpthread.so.0",
@@ -149,6 +150,17 @@ func TestAnalyze(t *testing.T) {
 				"so:libm.so.6",
 				"so:libmount.so.1",
 				"so:libssl.so.3",
+				// libsystemd-core-256.so and
+				// libsystemd-shared-256.so are
+				// false-positives that get added to
+				// runtime deps because systemd links
+				// against these vendored libraries,
+				// but melange doesn't have enough
+				// context to determine that they are
+				// vendored because they're shipped by
+				// another subpackage.
+				"so:libsystemd-core-256.so",
+				"so:libsystemd-shared-256.so",
 				"so:libudev.so.1",
 			},
 			Provides: []string{

--- a/pkg/sca/sca.go
+++ b/pkg/sca/sca.go
@@ -84,10 +84,20 @@ type SCAHandle interface {
 	PkgResolver() *apk.PkgResolver
 }
 
+type GeneratorArgs struct {
+	// Extra directories where libraries can be found.  This is
+	// filled by getLdSoConfDLibPaths.
+	extraLibDirs []string
+
+	// A map of vendored shlib -> package name.  This is filled by
+	// getAllVendoredShlibs.
+	allVendoredShlibs map[string]string
+}
+
 // DependencyGenerator takes an SCAHandle, config.Dependencies pointer
-// and a list of paths to be appended to libDirs and returns findings
+// and a GeneratorArgs struct with extra arguments and returns findings
 // based on analysis.
-type DependencyGenerator func(context.Context, SCAHandle, *config.Dependencies, []string) error
+type DependencyGenerator func(context.Context, SCAHandle, *config.Dependencies, *GeneratorArgs) error
 
 func isInDir(path string, dirs []string) bool {
 	mydir := filepath.Dir(path)
@@ -175,7 +185,7 @@ func getLdSoConfDLibPaths(ctx context.Context, hdl SCAHandle) ([]string, error) 
 	return extraLibPaths, nil
 }
 
-func generateCmdProviders(ctx context.Context, hdl SCAHandle, generated *config.Dependencies, extraLibDirs []string) error {
+func generateCmdProviders(ctx context.Context, hdl SCAHandle, generated *config.Dependencies, args *GeneratorArgs) error {
 	log := clog.FromContext(ctx)
 
 	log.Info("scanning for commands...")
@@ -238,7 +248,7 @@ func findInterpreter(bin *elf.File) (string, error) {
 
 // dereferenceCrossPackageSymlink attempts to dereference a symlink across multiple package
 // directories.
-func dereferenceCrossPackageSymlink(hdl SCAHandle, path string, extraLibDirs []string) (string, string, error) {
+func dereferenceCrossPackageSymlink(hdl SCAHandle, path string, args *GeneratorArgs) (string, string, error) {
 	targetPackageNames := hdl.RelativeNames()
 
 	pkgFS, err := hdl.Filesystem()
@@ -253,7 +263,7 @@ func dereferenceCrossPackageSymlink(hdl SCAHandle, path string, extraLibDirs []s
 
 	realPath = filepath.Base(realPath)
 
-	expandedLibDirs := append(libDirs, extraLibDirs...)
+	expandedLibDirs := append(libDirs, args.extraLibDirs...)
 
 	for _, pkgName := range targetPackageNames {
 		baseFS, err := hdl.FilesystemForRelative(pkgName)
@@ -448,13 +458,13 @@ func determineShlibVersion(ctx context.Context, hdl SCAHandle, shlib string) (st
 	return "", nil
 }
 
-func processSymlinkSo(ctx context.Context, hdl SCAHandle, path string, generated *config.Dependencies, extraLibDirs []string) error {
+func processSymlinkSo(ctx context.Context, hdl SCAHandle, path string, generated *config.Dependencies, args *GeneratorArgs) error {
 	log := clog.FromContext(ctx)
 	if !strings.Contains(path, ".so") {
 		return nil
 	}
 
-	targetPkg, realPath, err := dereferenceCrossPackageSymlink(hdl, path, extraLibDirs)
+	targetPkg, realPath, err := dereferenceCrossPackageSymlink(hdl, path, args)
 	if err != nil {
 		return nil
 	}
@@ -507,7 +517,62 @@ func processSymlinkSo(ctx context.Context, hdl SCAHandle, path string, generated
 	return nil
 }
 
-func generateSharedObjectNameDeps(ctx context.Context, hdl SCAHandle, generated *config.Dependencies, extraLibDirs []string) error {
+func getAllVendoredShlibs(ctx context.Context, hdl SCAHandle, extraLibDirs []string) (map[string]string, error) {
+	log := clog.FromContext(ctx)
+
+	log.Info("gathering list of vendored shlibs...")
+
+	targetPackageNames := hdl.RelativeNames()
+
+	expandedLibDirs := append(libDirs, extraLibDirs...)
+
+	allVendoredShlibs := make(map[string]string)
+
+	for _, pkgName := range targetPackageNames {
+		fsys, err := hdl.FilesystemForRelative(pkgName)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := fs.WalkDir(fsys, "/", func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				if errors.Is(err, fs.ErrNotExist) {
+					return fs.SkipAll
+				}
+				return err
+			}
+
+			if !strings.Contains(path, ".so.") && !strings.HasSuffix(path, ".so") {
+				return nil
+			}
+
+			fi, err := d.Info()
+			if err != nil {
+				return err
+			}
+
+			mode := fi.Mode()
+			if !mode.IsRegular() && mode & os.ModeSymlink != os.ModeSymlink {
+				return nil
+			}
+
+			dirPath := filepath.Dir(path)
+			if !isInDir(dirPath, expandedLibDirs) {
+				libName := filepath.Base(path)
+				log.Infof("   found vendored lib %s for package %s", libName, pkgName)
+				allVendoredShlibs[libName] = pkgName
+			}
+
+			return nil
+		}); err != nil {
+			return nil, err
+		}
+	}
+
+	return allVendoredShlibs, nil
+}
+
+func generateSharedObjectNameDeps(ctx context.Context, hdl SCAHandle, generated *config.Dependencies, args *GeneratorArgs) error {
 	log := clog.FromContext(ctx)
 	log.Infof("scanning for shared object dependencies...")
 
@@ -516,7 +581,7 @@ func generateSharedObjectNameDeps(ctx context.Context, hdl SCAHandle, generated 
 		return err
 	}
 
-	expandedLibDirs := append(libDirs, extraLibDirs...)
+	expandedLibDirs := append(libDirs, args.extraLibDirs...)
 
 	if err := fs.WalkDir(fsys, ".", func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
@@ -534,7 +599,7 @@ func generateSharedObjectNameDeps(ctx context.Context, hdl SCAHandle, generated 
 		isLink := mode.Type()&fs.ModeSymlink == fs.ModeSymlink
 
 		if isLink {
-			if err := processSymlinkSo(ctx, hdl, path, generated, extraLibDirs); err != nil {
+			if err := processSymlinkSo(ctx, hdl, path, generated, args); err != nil {
 				return err
 			}
 		}
@@ -594,9 +659,36 @@ func generateSharedObjectNameDeps(ctx context.Context, hdl SCAHandle, generated 
 			if lib == "libcuda.so.1" {
 				continue
 			}
-			if strings.Contains(lib, ".so.") {
-				log.Infof("  found lib %s for %s", lib, path)
-				generated.Runtime = append(generated.Runtime, fmt.Sprintf("so:%s", lib))
+			if strings.Contains(lib, ".so.") || strings.HasSuffix(lib, ".so") {
+				pkgName, isVendoredDep := args.allVendoredShlibs[lib]
+
+				// There are corner cases when we have
+				// a vendored shared library in a
+				// subpackage X and a binary linked
+				// against it in another subpackage Y
+				// (e.g. see postfix and
+				// postfix-stone).  In this case, we
+				// want to generate a depends
+				// relationship from Y -> X.
+				if isVendoredDep {
+					// Vendored dependency.
+					if pkgName == hdl.PackageName() {
+						log.Infof("  found vendored lib %s", lib)
+						continue
+					}
+
+					if !hdl.Options().NoVendoredCrossPackageDeps {
+						log.Infof("  found vendored lib %s from package %s; depending on %s=%s", lib, pkgName, pkgName, hdl.Version())
+						generated.Runtime = append(generated.Runtime, fmt.Sprintf("%s=%s", pkgName, hdl.Version()))
+					} else {
+						log.Infof("  found vendored lib %s; not generating any depends", lib)
+						continue
+					}
+				} else {
+					// Regular library dependency.
+					log.Infof("  found lib %s for %s", lib, path)
+					generated.Runtime = append(generated.Runtime, fmt.Sprintf("so:%s", lib))
+				}
 
 				shlibVer, err := determineShlibVersion(ctx, hdl, lib)
 				if err != nil {
@@ -687,7 +779,7 @@ var generateRuntimePkgConfigDeps = true
 
 // generatePkgConfigDeps generates a list of provided pkg-config package names and versions,
 // as well as dependency relationships.
-func generatePkgConfigDeps(ctx context.Context, hdl SCAHandle, generated *config.Dependencies, extraLibDirs []string) error {
+func generatePkgConfigDeps(ctx context.Context, hdl SCAHandle, generated *config.Dependencies, args *GeneratorArgs) error {
 	log := clog.FromContext(ctx)
 	log.Infof("scanning for pkg-config data...")
 
@@ -777,7 +869,7 @@ func generatePkgConfigDeps(ctx context.Context, hdl SCAHandle, generated *config
 
 // generatePythonDeps generates a python-3.X-base dependency for packages which ship
 // Python modules.
-func generatePythonDeps(ctx context.Context, hdl SCAHandle, generated *config.Dependencies, extraLibDirs []string) error {
+func generatePythonDeps(ctx context.Context, hdl SCAHandle, generated *config.Dependencies, args *GeneratorArgs) error {
 	log := clog.FromContext(ctx)
 	log.Infof("scanning for python modules...")
 
@@ -841,7 +933,7 @@ func generatePythonDeps(ctx context.Context, hdl SCAHandle, generated *config.De
 
 // generateRubyDeps generates a ruby-X.Y dependency for packages which ship
 // Ruby gems.
-func generateRubyDeps(ctx context.Context, hdl SCAHandle, generated *config.Dependencies, extraLibDirs []string) error {
+func generateRubyDeps(ctx context.Context, hdl SCAHandle, generated *config.Dependencies, args *GeneratorArgs) error {
 	log := clog.FromContext(ctx)
 	log.Infof("scanning for ruby gems...")
 
@@ -888,7 +980,7 @@ func generateRubyDeps(ctx context.Context, hdl SCAHandle, generated *config.Depe
 }
 
 // For a documentation package add a dependency on man-db and / or texinfo as appropriate
-func generateDocDeps(ctx context.Context, hdl SCAHandle, generated *config.Dependencies, extraLibDirs []string) error {
+func generateDocDeps(ctx context.Context, hdl SCAHandle, generated *config.Dependencies, args *GeneratorArgs) error {
 	log := clog.FromContext(ctx)
 	log.Infof("scanning for -doc package...")
 	if !strings.HasSuffix(hdl.PackageName(), "-doc") {
@@ -1011,7 +1103,7 @@ func getShbang(fp io.Reader) (string, error) {
 	return bin, nil
 }
 
-func generateShbangDeps(ctx context.Context, hdl SCAHandle, generated *config.Dependencies, extraLibDirs []string) error {
+func generateShbangDeps(ctx context.Context, hdl SCAHandle, generated *config.Dependencies, args *GeneratorArgs) error {
 	log := clog.FromContext(ctx)
 	log.Infof("scanning for shbang deps...")
 
@@ -1072,6 +1164,16 @@ func Analyze(ctx context.Context, hdl SCAHandle, generated *config.Dependencies)
 		return err
 	}
 
+	allVendoredShlibs, err := getAllVendoredShlibs(ctx, hdl, extraLibDirs)
+	if err != nil {
+		return err
+	}
+
+	args := GeneratorArgs{
+		extraLibDirs,
+		allVendoredShlibs,
+	}
+
 	generators := []DependencyGenerator{
 		generateSharedObjectNameDeps,
 		generateCmdProviders,
@@ -1083,7 +1185,7 @@ func Analyze(ctx context.Context, hdl SCAHandle, generated *config.Dependencies)
 	}
 
 	for _, gen := range generators {
-		if err := gen(ctx, hdl, generated, extraLibDirs); err != nil {
+		if err := gen(ctx, hdl, generated, &args); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
It turns out that this feature uncovered another bug in melange, which
is also being addressed by this commit.

When a package X ships a vendored shared library, and a subpackage Y
links against said library, melange fails to detect that the shlib is
vendored and generates a "depends" for it on Y, which is wrong because
X will never have a "provides" for said library.  I believe we hadn't
come accross this problem before because vendored libraries tend not
to be versioned (i.e., their names end in ".so"), which melange
happily ignored until now.  The underlying cause of this problem is
the fact that melange performs SCA for each (sub)package
independently, without taking into consideration everything that's
being built by the package.

I implemented a way to detect vendored libraries on the package and
all of its subpackages during SCA, and if melange detects that a
subpackage Y depends on a vendored library provided by its parent
package X, then a "depends" will be generated (in the form
"X=<version").  It is possible to disable this feature by setting the
"no-vendored-cross-package-deps" option to true.

Fixes: https://github.com/chainguard-dev/internal-dev/issues/7609