### PR TITLE
Use ftpmirror.gnu.org whenever applicable

### DIFF
--- a/examples/conditional.yaml
+++ b/examples/conditional.yaml
@@ -44,7 +44,7 @@ pipeline:
   - uses: fetch
     if: ${{package.name}} != 'hello'
     with:
-      uri: https://ftp.gnu.org/gnu/hello/hello-${{package.version}}.tar.gz
+      uri: https://ftpmirror.gnu.org/gnu/hello/hello-${{package.version}}.tar.gz
       expected-sha256: cf04af86dc085268c5f4470fbae49b18afbc221b78096aab842d934a76bad0ab
 
   - runs: |

--- a/examples/gnu-hello.yaml
+++ b/examples/gnu-hello.yaml
@@ -25,7 +25,7 @@ environment:
 pipeline:
   - uses: fetch
     with:
-      uri: https://ftp.gnu.org/gnu/hello/hello-${{package.version}}.tar.gz
+      uri: https://ftpmirror.gnu.org/gnu/hello/hello-${{package.version}}.tar.gz
       expected-sha256: cf04af86dc085268c5f4470fbae49b18afbc221b78096aab842d934a76bad0ab
 
   - uses: autoconf/configure


### PR DESCRIPTION
We should use ftpmirror.gnu.org instead of ftp.gnu.org whenever applicable.