### PR TITLE
license-check: fix --format=simple

### DIFF
--- a/pkg/renovate/copyright/copyright.go
+++ b/pkg/renovate/copyright/copyright.go
@@ -207,9 +207,26 @@ func populateSimpleCopyright(ctx context.Context, copyrightNode *yaml.Node, lice
 	slices.Sort(ls)
 	combined := strings.Join(ls, " AND ")
 
-	copyrightNode.Kind = yaml.ScalarNode
-	copyrightNode.Value = combined
-	copyrightNode.Tag = "!!str"
+	// Create a single license entry with the combined license string
+	licenseNode := &yaml.Node{
+		Kind:    yaml.MappingNode,
+		Style:   yaml.FlowStyle,
+		Content: []*yaml.Node{},
+	}
+
+	licenseNode.Content = append(licenseNode.Content, &yaml.Node{
+		Kind:  yaml.ScalarNode,
+		Value: "license",
+		Tag:   "!!str",
+		Style: yaml.FlowStyle,
+	}, &yaml.Node{
+		Kind:  yaml.ScalarNode,
+		Value: combined,
+		Tag:   "!!str",
+		Style: yaml.FlowStyle,
+	})
+
+	copyrightNode.Content = append(copyrightNode.Content, licenseNode)
 
 	return nil
 }

--- a/pkg/renovate/copyright/copyright_test.go
+++ b/pkg/renovate/copyright/copyright_test.go
@@ -182,10 +182,9 @@ func TestCopyright_updateSimple(t *testing.T) {
 	resultData, err := os.ReadFile(testFile)
 	assert.NoError(t, err)
 
-	// The copyright field should be a single string with both licenses joined by " AND "
+	// The copyright field should contain a single license entry with both licenses joined by " AND "
 	result := string(resultData)
-	assert.Contains(t, result, "Apache-2.0 AND MIT")
+	assert.Contains(t, result, "license: Apache-2.0 AND MIT")
 	assert.NotContains(t, result, "GPL-3.0")
 	assert.NotContains(t, result, "NOASSERTION")
-	assert.NotContains(t, result, "license:")
 }


### PR DESCRIPTION
The recently added `melange license-check --fix --format=simple` was not doing what it was supposed to: the generated license string was not properly added as a `license:` field. This PR fixes that.