### PR TITLE
feat(sbom): Include the distro qualifier as part of the APK PURL

### DIFF
--- a/examples/go-install.yaml
+++ b/examples/go-install.yaml
@@ -11,7 +11,7 @@
 # please see go-install.yaml in this directory.
 package:
   name: hello
-  version: v0.0.1
+  version: 0.0.1
   epoch: 0
   description: "A project that will greet the world infinitely"
 
@@ -26,4 +26,4 @@ pipeline:
   - uses: go/install
     with:
       package: github.com/puerco/hello
-      version: ${{package.version}}
+      version: v${{package.version}}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -264,6 +264,10 @@ func newAPKPackageURL(distro, name, version, arch string) *purl.PackageURL {
 		Namespace: distro,
 		Name:      name,
 		Version:   version,
+		Qualifiers: []purl.Qualifier{{
+			Key:   "distro",
+			Value: distro,
+		}},
 	}
 
 	if arch != "" {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1270,3 +1270,102 @@ func TestSetCapability(t *testing.T) {
 		})
 	}
 }
+
+func TestPackageURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		pkg      Package
+		distro   string
+		arch     string
+		expected string
+	}{
+		{
+			name: "basic package URL",
+			pkg: Package{
+				Name:    "test-package",
+				Version: "1.0.0",
+				Epoch:   0,
+			},
+			distro:   "alpine",
+			arch:     "x86_64",
+			expected: "pkg:apk/alpine/test-package@1.0.0-r0?arch=x86_64&distro=alpine",
+		},
+		{
+			name: "package with epoch",
+			pkg: Package{
+				Name:    "test-package",
+				Version: "2.1.3",
+				Epoch:   5,
+			},
+			distro:   "wolfi",
+			arch:     "aarch64",
+			expected: "pkg:apk/wolfi/test-package@2.1.3-r5?arch=aarch64&distro=wolfi",
+		},
+		{
+			name: "package without architecture",
+			pkg: Package{
+				Name:    "test-package",
+				Version: "1.0.0",
+				Epoch:   0,
+			},
+			distro:   "alpine",
+			arch:     "",
+			expected: "pkg:apk/alpine/test-package@1.0.0-r0?distro=alpine",
+		},
+		{
+			name: "package with complex version",
+			pkg: Package{
+				Name:    "complex-package",
+				Version: "1.2.3-alpha.1",
+				Epoch:   10,
+			},
+			distro:   "chainguard",
+			arch:     "x86_64",
+			expected: "pkg:apk/chainguard/complex-package@1.2.3-alpha.1-r10?arch=x86_64&distro=chainguard",
+		},
+		{
+			name: "package with special characters in name",
+			pkg: Package{
+				Name:    "lib-test_package.so",
+				Version: "0.1.0",
+				Epoch:   1,
+			},
+			distro:   "alpine",
+			arch:     "arm64",
+			expected: "pkg:apk/alpine/lib-test_package.so@0.1.0-r1?arch=arm64&distro=alpine",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			packageURL := tt.pkg.PackageURL(tt.distro, tt.arch)
+			require.NotNil(t, packageURL)
+
+			actualURL := packageURL.String()
+			require.Equal(t, tt.expected, actualURL, "PackageURL string representation should match expected format")
+
+			// Verify the PackageURL can be parsed back
+			parsed, err := purl.FromString(actualURL)
+			require.NoError(t, err, "Generated PackageURL should be parseable")
+
+			// Verify components
+			require.Equal(t, purlTypeAPK, parsed.Type)
+			require.Equal(t, tt.distro, parsed.Namespace)
+			require.Equal(t, tt.pkg.Name, parsed.Name)
+			require.Equal(t, tt.pkg.FullVersion(), parsed.Version)
+
+			// Verify qualifiers
+			expectedQualifiers := purl.Qualifiers{
+				{Key: "distro", Value: tt.distro},
+			}
+			if tt.arch != "" {
+				// arch qualifier comes first alphabetically
+				expectedQualifiers = purl.Qualifiers{
+					{Key: "arch", Value: tt.arch},
+					{Key: "distro", Value: tt.distro},
+				}
+			}
+			require.Equal(t, expectedQualifiers, parsed.Qualifiers)
+		})
+	}
+}


### PR DESCRIPTION
This change is altering the PURL generated for an APK. We are keeping track of the distro (`wolfi` or `chainguard`, generally) inside the namespace identifier. However, some scanners are expect the `distro` qualifier to be set on APKs identifying our APKs.

The real question is - was there a reason not to set the `distro` qualifier previously, or is this a safe change?

### Functional Changes

- [ ] Updates the PURL of an APK to include `distro=${distro}`.

Notes:

### SCA Changes

- [ ] I've confirmed the change changes the SBOM as desired

Notes:

### Linter

- [ ] The new check is clean across Wolfi
- [ ] The new check is opt-in or a warning
