### PR TITLE
Use os.DirFS over apkofs.DirFS

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -687,7 +687,7 @@ func (b *Build) BuildPackage(ctx context.Context) error {
 			return fmt.Errorf("mkdir -p %s: %w", b.WorkspaceDir, err)
 		}
 
-		fs := apkofs.DirFS(b.SourceDir)
+		fs := os.DirFS(b.SourceDir)
 		if fs != nil {
 			log.Infof("populating workspace %s from %s", b.WorkspaceDir, b.SourceDir)
 			if err := b.populateWorkspace(ctx, fs); err != nil {

--- a/pkg/build/test.go
+++ b/pkg/build/test.go
@@ -208,11 +208,22 @@ func (t *Test) PopulateWorkspace(ctx context.Context, src fs.FS) error {
 
 	log.Infof("populating workspace %s from %s", t.WorkspaceDir, t.SourceDir)
 
-	fsys := apkofs.DirFS(t.SourceDir, apkofs.WithCreateDir())
-
-	if fsys == nil {
-		return fmt.Errorf("unable to create/use directory %s", t.SourceDir)
+	fi, err := os.Stat(t.SourceDir)
+	switch {
+	case err != nil && !os.IsNotExist(err):
+		log.Warn("error checking dir", "error", err)
+		return nil
+	case err != nil && os.IsNotExist(err):
+		if err := os.MkdirAll(t.SourceDir, 0o700); err != nil {
+			log.Warn("error creating dir", "dir", t.SourceDir, "error", err)
+			return nil
+		}
+	case !fi.IsDir():
+		log.Warn("not a directory", "dir", t.SourceDir)
+		return nil
 	}
+
+	fsys := os.DirFS(t.SourceDir)
 
 	return fs.WalkDir(fsys, ".", func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
@@ -295,7 +306,7 @@ func (t *Test) TestPackage(ctx context.Context) error {
 			return fmt.Errorf("mkdir -p %s: %w", t.WorkspaceDir, err)
 		}
 
-		if err := t.PopulateWorkspace(ctx, apkofs.DirFS(t.SourceDir)); err != nil {
+		if err := t.PopulateWorkspace(ctx, os.DirFS(t.SourceDir)); err != nil {
 			return fmt.Errorf("unable to populate workspace: %w", err)
 		}
 	}

--- a/pkg/build/test.go
+++ b/pkg/build/test.go
@@ -211,16 +211,13 @@ func (t *Test) PopulateWorkspace(ctx context.Context, src fs.FS) error {
 	fi, err := os.Stat(t.SourceDir)
 	switch {
 	case err != nil && !os.IsNotExist(err):
-		log.Warn("error checking dir", "error", err)
-		return nil
+		return fmt.Errorf("stating dir %s: %w", t.SourceDir, err)
 	case err != nil && os.IsNotExist(err):
 		if err := os.MkdirAll(t.SourceDir, 0o700); err != nil {
-			log.Warn("error creating dir", "dir", t.SourceDir, "error", err)
-			return nil
+			return fmt.Errorf("creating dir %s: %w", t.SourceDir, err)
 		}
 	case !fi.IsDir():
-		log.Warn("not a directory", "dir", t.SourceDir)
-		return nil
+		return fmt.Errorf("not a directory: %s", t.SourceDir)
 	}
 
 	fsys := os.DirFS(t.SourceDir)

--- a/pkg/cli/license_check.go
+++ b/pkg/cli/license_check.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	apkofs "chainguard.dev/apko/pkg/apk/fs"
 	"chainguard.dev/melange/pkg/config"
 	"chainguard.dev/melange/pkg/license"
 	"chainguard.dev/melange/pkg/renovate"
@@ -69,7 +68,7 @@ func licenseCheck() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("failed to get absolute path for source directory: %w", err)
 			}
-			sourceFS := apkofs.DirFS(sourceDir)
+			sourceFS := os.DirFS(sourceDir)
 			detectedLicenses, diffs, err := license.LicenseCheck(ctx, cfg, sourceFS)
 			if err != nil {
 				return err

--- a/pkg/license/license_test.go
+++ b/pkg/license/license_test.go
@@ -23,7 +23,6 @@ import (
 	"strings"
 	"testing"
 
-	apkofs "chainguard.dev/apko/pkg/apk/fs"
 	"chainguard.dev/melange/pkg/config"
 	"github.com/chainguard-dev/clog"
 )
@@ -59,7 +58,7 @@ func TestFindLicenseFiles(t *testing.T) {
 		fp.Close()
 	}
 
-	tmpFS := apkofs.DirFS(tmpDir)
+	tmpFS := os.DirFS(tmpDir)
 
 	// Call function under test
 	licenseFiles, err := FindLicenseFiles(tmpFS)
@@ -135,7 +134,7 @@ func TestFindLicenseFiles(t *testing.T) {
 		fp.Close()
 	}
 
-	tmpFS = apkofs.DirFS(tmpDir)
+	tmpFS = os.DirFS(tmpDir)
 
 	// Call function under test
 	licenseFiles, err = FindLicenseFiles(tmpFS)
@@ -165,7 +164,7 @@ func TestIdentify(t *testing.T) {
 	}
 
 	testDataDir := "testdata"
-	dataFS := apkofs.DirFS(testDataDir)
+	dataFS := os.DirFS(testDataDir)
 	err = fs.WalkDir(dataFS, ".", func(path string, info fs.DirEntry, err error) error {
 		if err != nil {
 			t.Errorf("Error walking through testdata directory: %v", err)
@@ -217,7 +216,7 @@ func TestLicenseCheck(t *testing.T) {
 	}
 
 	testDataDir := "testdata"
-	dataFS := apkofs.DirFS(testDataDir)
+	dataFS := os.DirFS(testDataDir)
 
 	// Create a buffer to capture log output
 	var logBuf strings.Builder
@@ -293,7 +292,7 @@ func TestLicenseCheck_withOverrides(t *testing.T) {
 	}
 
 	testDataDir := "testdata"
-	dataFS := apkofs.DirFS(testDataDir)
+	dataFS := os.DirFS(testDataDir)
 
 	// Call function under test
 	_, diffs, err := LicenseCheck(context.Background(), cfg, dataFS)

--- a/pkg/linter/linter.go
+++ b/pkg/linter/linter.go
@@ -29,7 +29,6 @@ import (
 	"slices"
 	"strings"
 
-	apkofs "chainguard.dev/apko/pkg/apk/fs"
 	"github.com/chainguard-dev/clog"
 	"github.com/dustin/go-humanize"
 	"golang.org/x/exp/maps"
@@ -684,7 +683,7 @@ func LintBuild(ctx context.Context, cfg *config.Configuration, packageName strin
 	}
 
 	log := clog.FromContext(ctx)
-	fsys := apkofs.DirFS(path)
+	fsys := os.DirFS(path)
 
 	if err := lintPackageFS(ctx, cfg, packageName, fsys, warn); err != nil {
 		log.Warn(err.Error())


### PR DESCRIPTION
We don't need this anymore, and the signature changed to require a context.Context, so I'm just dropping it rather than dealing with that.