### PR TITLE
Include top-level environment variables in tests

### DIFF
--- a/e2e-tests/env-vars-build-test.yaml
+++ b/e2e-tests/env-vars-build-test.yaml
@@ -10,22 +10,22 @@ environment:
       - busybox
   environment:
     FOO: bar
-    TEST_FILE: /var/test
+    TEST_DIR: /var/test
 
 pipeline:
   - runs: |
-      mkdir -p "${{targets.contextdir}}${TEST_FILE}"
-      touch "${{targets.contextdir}}${TEST_FILE}/foo.txt"
-      echo $FOO > "${{targets.contextdir}}${TEST_FILE}/foo.txt"
+      mkdir -p "${{targets.contextdir}}${TEST_DIR}"
+      touch "${{targets.contextdir}}${TEST_DIR}/foo.txt"
+      echo $FOO > "${{targets.contextdir}}${TEST_DIR}/foo.txt"
 
 subpackages:
   - name: env-vars-subpkg-test
     description: Test that top-level environment variables are accessible for sub-package tests
     pipeline:
       - runs: |
-          mkdir -p "${{targets.contextdir}}${TEST_FILE}"
-          touch "${{targets.contextdir}}${TEST_FILE}/foo.txt"
-          echo $FOO > "${{targets.contextdir}}${TEST_FILE}/foo.txt"
+          mkdir -p "${{targets.contextdir}}${TEST_DIR}"
+          touch "${{targets.contextdir}}${TEST_DIR}/foo.txt"
+          echo $FOO > "${{targets.contextdir}}${TEST_DIR}/foo.txt"
     test:
       environment:
         contents:
@@ -34,7 +34,7 @@ subpackages:
       pipeline:
         - runs: |
             set -e
-            testdata=$(cat "${TEST_FILE}/foo.txt")
+            testdata=$(cat "${TEST_DIR}/foo.txt")
             [ "$FOO" == "$testdata" ]
 
 test:
@@ -45,5 +45,5 @@ test:
   pipeline:
     - runs: |
         set -e
-        testdata=$(cat "${TEST_FILE}/foo.txt")
+        testdata=$(cat "${TEST_DIR}/foo.txt")
         [ "$FOO" == "$testdata" ]

--- a/e2e-tests/env-vars-build-test.yaml
+++ b/e2e-tests/env-vars-build-test.yaml
@@ -1,0 +1,49 @@
+package:
+  name: env-vars-test
+  description: Test that top-level environment variables are accessible for tests
+  version: 0.1.0
+  epoch: 0
+
+environment:
+  contents:
+    packages:
+      - busybox
+  environment:
+    FOO: bar
+    TEST_FILE: /var/test
+
+pipeline:
+  - runs: |
+      mkdir -p "${{targets.contextdir}}${TEST_FILE}"
+      touch "${{targets.contextdir}}${TEST_FILE}/foo.txt"
+      echo $FOO > "${{targets.contextdir}}${TEST_FILE}/foo.txt"
+
+subpackages:
+  - name: env-vars-subpkg-test
+    description: Test that top-level environment variables are accessible for sub-package tests
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.contextdir}}${TEST_FILE}"
+          touch "${{targets.contextdir}}${TEST_FILE}/foo.txt"
+          echo $FOO > "${{targets.contextdir}}${TEST_FILE}/foo.txt"
+    test:
+      environment:
+        contents:
+          packages:
+            - busybox
+      pipeline:
+        - runs: |
+            set -e
+            testdata=$(cat "${TEST_FILE}/foo.txt")
+            [ "$FOO" == "$testdata" ]
+
+test:
+  environment:
+    contents:
+      packages:
+        - busybox
+  pipeline:
+    - runs: |
+        set -e
+        testdata=$(cat "${TEST_FILE}/foo.txt")
+        [ "$FOO" == "$testdata" ]

--- a/e2e-tests/run-tests
+++ b/e2e-tests/run-tests
@@ -39,15 +39,18 @@ for yaml in "$@"; do
   case "$base" in
     *-build-test)
       ops="build test"
+      args="$args --debug"
       ;;
     *-nopkg-test)
       ops="test"
       args="$args --test-package-append busybox"
       args="$args --test-package-append=python-3"
+      args="$args --debug"
       ;;
     *-test)
       ops="test"
       args="${base%-test}"
+      args="$args --debug"
       ;;
     *-build)
       ops="build"

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -1159,9 +1159,7 @@ func (b *Build) buildWorkspaceConfig(ctx context.Context) *container.Config {
 		cfg.Capabilities.Drop = b.Configuration.Capabilities.Drop
 	}
 
-	for k, v := range b.Configuration.Environment.Environment {
-		cfg.Environment[k] = v
-	}
+	maps.Copy(cfg.Environment, b.Configuration.Environment.Environment)
 
 	return &cfg
 }

--- a/pkg/build/test.go
+++ b/pkg/build/test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"io/fs"
 	"log/slog"
+	"maps"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -463,9 +464,8 @@ func (t *Test) buildWorkspaceConfig(ctx context.Context, imgRef, pkgName string,
 		cfg.Capabilities.Drop = t.Configuration.Capabilities.Drop
 	}
 
-	for k, v := range imgcfg.Environment {
-		cfg.Environment[k] = v
-	}
+	maps.Copy(cfg.Environment, t.Configuration.Environment.Environment)
+	maps.Copy(cfg.Environment, imgcfg.Environment)
 
 	if _, ok := cfg.Environment["HOME"]; !ok {
 		cfg.Environment["HOME"] = "/root"


### PR DESCRIPTION
Currently, we only include the contents of `imgcfg.Environment` which looks specifically at a test's environment variables; however, this will ignore top-level environment variables that may be needed by the tests and this is usually just an empty map.

This PR adds the contents of `t.Configuration.Environment.Environment` to `cfg.Environment` for tests and then adds the contents of `imgcfg.Environment` afterward to include any test-specific environment variables that may take precedence over the top-level values.

For example,
```
environment:
  environment:
    FOO: bar
...
test:
  pipeline:
    - runs: |
        echo $FOO
```
will not display anything (and the same goes for sub-package tests).

Using the new e2e example:
```
2025/07/15 12:17:32 INFO running the main test pipeline
2025/07/15 12:17:32 INFO + '[' -d /home/build ]
2025/07/15 12:17:32 INFO + cd /home/build
2025/07/15 12:17:32 INFO + set -e
2025/07/15 12:17:32 INFO + cat /var/test/foo.txt
2025/07/15 12:17:32 INFO + testdata=bar
2025/07/15 12:17:32 INFO + '[' bar '==' bar ]
2025/07/15 12:17:32 INFO + exit 0
2025/07/15 12:17:32 INFO qemu: sending shutdown signal
```
versus:
```
2025/07/15 12:16:18 INFO running the main test pipeline
2025/07/15 12:16:18 INFO + '[' -d /home/build ]
2025/07/15 12:16:18 INFO + cd /home/build
2025/07/15 12:16:18 INFO + set -e
2025/07/15 12:16:18 INFO + cat /foo.txt
2025/07/15 12:16:18 INFO cat: can't open '/foo.txt': No such file or directory
2025/07/15 12:16:18 INFO + testdata=
2025/07/15 12:16:18 ERRO Failed to run command "script -f -q --log-in /dev/null --log-out /dev/null -e -c '/bin/sh -c '\\''set -ex\n[ -d '\\''\\'\\'\\''/home/build'\\''\\'\\'\\'' ] || mkdir -p '\\''\\'\\'\\''/home/build'\\''\\'\\'\\''\ncd '\\''\\'\\'\\''/home/build'\\''\\'\\'\\''\nset -e\ntestdata=$(cat \"${TEST_FILE}/foo.txt\")\n[ \"$FOO\" == \"$testdata\" ]\n\nexit 0'\\'": Process exited with status 1
2025/07/15 12:16:18 INFO qemu: sending shutdown signal
2025/07/15 12:16:18 ERRO ERROR: failed to test package. the test environment has been preserved:
2025/07/15 12:16:18 ERRO failed to test package: unable to run pipeline: unable to run pipeline: Process exited with status 1
```