### PR TITLE
config: use supplier for namespace for unknown gits

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -538,7 +538,7 @@ func SHA256(text string) string {
 // getGitSBOMPackage creates an SBOM package for Git based repositories.
 // Returns nil package and nil error if the repository is not from a supported platform or
 // if neither a tag of expectedCommit is not provided
-func getGitSBOMPackage(repo, tag, expectedCommit string, idComponents []string, licenseDeclared string, hint string) (*sbom.Package, error) {
+func getGitSBOMPackage(repo, tag, expectedCommit string, idComponents []string, licenseDeclared, hint, supplier string) (*sbom.Package, error) {
 	var repoType, namespace, name, ref string
 	var downloadLocation string
 
@@ -575,7 +575,8 @@ func getGitSBOMPackage(repo, tag, expectedCommit string, idComponents []string, 
 
 	default:
 		repoType = purl.TypeGeneric
-		namespace = ""
+		// We can't determine the namespace so use the supplier passed instead.
+		namespace = supplier
 		name = strings.TrimSuffix(trimmedPath, ".git")
 		// Use first letter of name as a directory to avoid a single huge bucket of tarballs
 		downloadLocation = fmt.Sprintf("https://tarballs.cgr.dev/%s/%s-%s.tar.gz", name[:1], SHA256(name), ref)
@@ -726,7 +727,7 @@ func (p Pipeline) SBOMPackageForUpstreamSource(licenseDeclared, supplier string,
 			idComponents = append(idComponents, uniqueID)
 		}
 
-		gitPackage, err := getGitSBOMPackage(repo, tag, expectedCommit, idComponents, licenseDeclared, hint)
+		gitPackage, err := getGitSBOMPackage(repo, tag, expectedCommit, idComponents, licenseDeclared, hint, supplier)
 		if err != nil {
 			return nil, err
 		} else if gitPackage != nil {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -546,6 +546,7 @@ func TestGetGitSBOMPackage(t *testing.T) {
 		idComponents    []string
 		licenseDeclared string
 		typeHint        string
+		supplier        string
 		expected        *sbom.Package
 		expectError     bool
 	}{
@@ -557,6 +558,7 @@ func TestGetGitSBOMPackage(t *testing.T) {
 			idComponents:    []string{"test-id"},
 			licenseDeclared: "Apache-2.0",
 			typeHint:        "",
+			supplier:        "wolfi",
 			expected: &sbom.Package{
 				IDComponents:     []string{"test-id"},
 				Name:             "melange",
@@ -576,6 +578,7 @@ func TestGetGitSBOMPackage(t *testing.T) {
 			idComponents:    []string{"test-id"},
 			licenseDeclared: "Apache-2.0",
 			typeHint:        "",
+			supplier:        "wolfi",
 			expected: &sbom.Package{
 				IDComponents:     []string{"test-id"},
 				Name:             "melange",
@@ -594,6 +597,7 @@ func TestGetGitSBOMPackage(t *testing.T) {
 			expectedCommit:  "b5d6dcba7c835d8520b06c7f35e747d896c50b61",
 			idComponents:    []string{"test-id"},
 			licenseDeclared: "Apache-2.0",
+			supplier:        "wolfi",
 			expected: &sbom.Package{
 				IDComponents:     []string{"test-id"},
 				Name:             "melange",
@@ -614,6 +618,7 @@ func TestGetGitSBOMPackage(t *testing.T) {
 			idComponents:    []string{"test-id"},
 			licenseDeclared: "MIT",
 			typeHint:        "",
+			supplier:        "wolfi",
 			expected: &sbom.Package{
 				IDComponents:     []string{"test-id"},
 				Name:             "gitlab",
@@ -633,6 +638,7 @@ func TestGetGitSBOMPackage(t *testing.T) {
 			idComponents:    []string{"test-id"},
 			licenseDeclared: "MIT",
 			typeHint:        "",
+			supplier:        "wolfi",
 			expected: &sbom.Package{
 				IDComponents:     []string{"test-id"},
 				Name:             "gitlab",
@@ -652,6 +658,7 @@ func TestGetGitSBOMPackage(t *testing.T) {
 			idComponents:    []string{"test-id"},
 			licenseDeclared: "MIT",
 			typeHint:        "",
+			supplier:        "wolfi",
 			expected: &sbom.Package{
 				IDComponents:     []string{"test-id"},
 				Name:             "gitlab",
@@ -671,6 +678,7 @@ func TestGetGitSBOMPackage(t *testing.T) {
 			idComponents:    []string{"test-id"},
 			licenseDeclared: "BSD-3-Clause",
 			typeHint:        "",
+			supplier:        "wolfi",
 			expected: &sbom.Package{
 				IDComponents:    []string{"test-id"},
 				Name:            "some-project",
@@ -695,6 +703,7 @@ func TestGetGitSBOMPackage(t *testing.T) {
 			idComponents:    []string{"test-id"},
 			licenseDeclared: "BSD-3-Clause",
 			typeHint:        "",
+			supplier:        "wolfi",
 			expected: &sbom.Package{
 				IDComponents:    []string{"test-id"},
 				Name:            "some-project",
@@ -719,6 +728,7 @@ func TestGetGitSBOMPackage(t *testing.T) {
 			idComponents:    []string{"test-id"},
 			licenseDeclared: "BSD-3-Clause",
 			typeHint:        "",
+			supplier:        "wolfi",
 			expected: &sbom.Package{
 				IDComponents:    []string{"test-id"},
 				Name:            "some-project",
@@ -743,6 +753,7 @@ func TestGetGitSBOMPackage(t *testing.T) {
 			idComponents:    []string{"test-id"},
 			licenseDeclared: "BSD-3-Clause",
 			typeHint:        "gitlab",
+			supplier:        "wolfi",
 			expected: &sbom.Package{
 				IDComponents:    []string{"test-id"},
 				Name:            "dav1d",
@@ -767,11 +778,13 @@ func TestGetGitSBOMPackage(t *testing.T) {
 			idComponents:    []string{"test-id"},
 			licenseDeclared: "LGPL-2.1",
 			typeHint:        "",
+			supplier:        "wolfi",
 			expected: &sbom.Package{
 				IDComponents:    []string{"test-id"},
 				Name:            "custom-org/custom-project",
 				Version:         "v3.2.1",
 				LicenseDeclared: "LGPL-2.1",
+				Namespace:       "wolfi",
 				PURL: &purl.PackageURL{
 					Type:       "generic",
 					Name:       "custom-org/custom-project",
@@ -790,11 +803,13 @@ func TestGetGitSBOMPackage(t *testing.T) {
 			idComponents:    []string{"test-id"},
 			licenseDeclared: "LGPL-2.1",
 			typeHint:        "",
+			supplier:        "wolfi",
 			expected: &sbom.Package{
 				IDComponents:    []string{"test-id"},
 				Name:            "custom-org/custom-project",
 				Version:         "abcdef0123456789abcdef0123456789abcdef01",
 				LicenseDeclared: "LGPL-2.1",
+				Namespace:       "wolfi",
 				PURL: &purl.PackageURL{
 					Type:       "generic",
 					Name:       "custom-org/custom-project",
@@ -813,11 +828,13 @@ func TestGetGitSBOMPackage(t *testing.T) {
 			idComponents:    []string{"test-id"},
 			licenseDeclared: "LGPL-2.1",
 			typeHint:        "",
+			supplier:        "wolfi",
 			expected: &sbom.Package{
 				IDComponents:    []string{"test-id"},
 				Name:            "custom-org/custom-project",
 				Version:         "v3.2.1",
 				LicenseDeclared: "LGPL-2.1",
+				Namespace:       "wolfi",
 				PURL: &purl.PackageURL{
 					Type:       "generic",
 					Name:       "custom-org/custom-project",
@@ -836,11 +853,13 @@ func TestGetGitSBOMPackage(t *testing.T) {
 			idComponents:    []string{"test-id"},
 			licenseDeclared: "LGPL-2.1",
 			typeHint:        "",
+			supplier:        "wolfi",
 			expected: &sbom.Package{
 				IDComponents:    []string{"test-id"},
 				Name:            "custom-project",
 				Version:         "v3.2.1",
 				LicenseDeclared: "LGPL-2.1",
+				Namespace:       "wolfi",
 				PURL: &purl.PackageURL{
 					Type:       "generic",
 					Name:       "custom-project",
@@ -855,7 +874,7 @@ func TestGetGitSBOMPackage(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			pkg, err := getGitSBOMPackage(tc.repo, tc.tag, tc.expectedCommit, tc.idComponents, tc.licenseDeclared, tc.typeHint)
+			pkg, err := getGitSBOMPackage(tc.repo, tc.tag, tc.expectedCommit, tc.idComponents, tc.licenseDeclared, tc.typeHint, tc.supplier)
 			if tc.expectError {
 				require.Error(t, err)
 				return


### PR DESCRIPTION
Revert to the previous behaviour of passing the supplier as the
Namespace for any Git sources which cannot be parsed automatically
to provide a path based Namespace.
