### PR TITLE
fix: replace os.Create with os.OpenFile

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -411,7 +411,7 @@ func copyFile(base, src, dest string, perm fs.FileMode) error {
 		return fmt.Errorf("mkdir -p %s: %w", destDir, err)
 	}
 
-	outF, err := os.Create(destPath)
+	outF, err := os.OpenFile(destPath, os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0o644)
 	if err != nil {
 		return fmt.Errorf("create %s: %w", destPath, err)
 	}
@@ -540,7 +540,7 @@ func (b *Build) populateWorkspace(ctx context.Context, src fs.FS) error {
 	// Write out build settings into workspacedir
 	// For now, just the gcc spec file and just link settings.
 	// In the future can control debug symbol generation, march/mtune, etc.
-	specFile, err := os.Create(filepath.Join(b.WorkspaceDir, ".melange.gcc.spec"))
+	specFile, err := os.OpenFile(filepath.Join(b.WorkspaceDir, ".melange.gcc.spec"), os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0o644)
 	if err != nil {
 		return err
 	}

--- a/pkg/build/package.go
+++ b/pkg/build/package.go
@@ -340,7 +340,7 @@ func (pc *PackageBuild) GenerateDependencies(ctx context.Context, hdl sca.SCAHan
 	if pc.Build.DependencyLog != "" {
 		log.Info("writing dependency log")
 
-		logFile, err := os.Create(fmt.Sprintf("%s.%s", pc.Build.DependencyLog, pc.Arch))
+		logFile, err := os.OpenFile(fmt.Sprintf("%s.%s", pc.Build.DependencyLog, pc.Arch), os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0o644)
 		if err != nil {
 			log.Warnf("Unable to open dependency log: %v", err)
 		}
@@ -585,7 +585,7 @@ func (pc *PackageBuild) EmitPackage(ctx context.Context) error {
 		return fmt.Errorf("unable to create output directory: %w", err)
 	}
 
-	outFile, err := os.Create(pc.Filename())
+	outFile, err := os.OpenFile(pc.Filename(), os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0o644)
 	if err != nil {
 		return fmt.Errorf("unable to create apk file: %w", err)
 	}
@@ -614,7 +614,7 @@ func (pc *PackageBuild) EmitPackage(ctx context.Context) error {
 			return fmt.Errorf("unable to generate provenance: %w", err)
 		}
 
-		provenanceFile, err := os.Create(pc.ProvenanceFilename())
+		provenanceFile, err := os.OpenFile(pc.ProvenanceFilename(), os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0o644)
 		if err != nil {
 			return fmt.Errorf("unable to create provenance file: %w", err)
 		}

--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -98,7 +98,7 @@ func buildCmd() *cobra.Command {
 			}
 
 			if traceFile != "" {
-				w, err := os.Create(traceFile)
+				w, err := os.OpenFile(traceFile, os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0o644)
 				if err != nil {
 					return fmt.Errorf("creating trace file: %w", err)
 				}

--- a/pkg/cli/keygen.go
+++ b/pkg/cli/keygen.go
@@ -87,7 +87,7 @@ func KeygenCmd(ctx context.Context, keyName string, bitSize int) error {
 		Type:  "RSA PRIVATE KEY",
 		Bytes: privateKeyData,
 	}
-	privatePem, err := os.Create(kc.KeyName)
+	privatePem, err := os.OpenFile(kc.KeyName, os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0o644)
 	if err != nil {
 		return fmt.Errorf("unable to open private key for writing: %w", err)
 	}
@@ -107,7 +107,7 @@ func KeygenCmd(ctx context.Context, keyName string, bitSize int) error {
 		Type:  "PUBLIC KEY",
 		Bytes: publicKeyData,
 	}
-	publicPem, err := os.Create(fmt.Sprintf("%s.pub", kc.KeyName))
+	publicPem, err := os.OpenFile(fmt.Sprintf("%s.pub", kc.KeyName), os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0o644)
 	if err != nil {
 		return fmt.Errorf("unable to open public key for writing: %w", err)
 	}

--- a/pkg/cli/sign.go
+++ b/pkg/cli/sign.go
@@ -71,7 +71,7 @@ func (o signIndexOpts) SignIndex(ctx context.Context, indexFile string) error {
 		return err
 	}
 
-	t, err := os.Create(fmt.Sprintf("%s.new", indexFile))
+	t, err := os.OpenFile(fmt.Sprintf("%s.new", indexFile), os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0o644)
 	if err != nil {
 		return err
 	}

--- a/pkg/container/qemu_runner.go
+++ b/pkg/container/qemu_runner.go
@@ -431,7 +431,7 @@ func (bw *qemu) WorkspaceTar(ctx context.Context, cfg *Config, extraFiles []stri
 		}
 	}
 
-	outFile, err := os.Create(filepath.Join(cfg.WorkspaceDir, "melange-out.tar"))
+	outFile, err := os.OpenFile(filepath.Join(cfg.WorkspaceDir, "melange-out.tar"), os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0o644)
 	if err != nil {
 		return nil, err
 	}
@@ -1522,7 +1522,7 @@ func generateCpio(ctx context.Context, cfg *Config) (string, error) {
 		}
 	}
 
-	guestInitramfs, err := os.Create(initramfs)
+	guestInitramfs, err := os.OpenFile(initramfs, os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0o644)
 	if err != nil {
 		clog.FromContext(ctx).Errorf("failed to create cpio initramfs: %v", err)
 		return "", err

--- a/pkg/convert/apkbuild/apkbuild.go
+++ b/pkg/convert/apkbuild/apkbuild.go
@@ -634,7 +634,7 @@ func (c ApkConvertor) write(ctx context.Context, orderNumber, outdir string) err
 
 	// Prepare the file path for the YAML output
 	manifestFile := filepath.Join(outdir, fmt.Sprintf("%s0-%s.yaml", orderNumber, c.Apkbuild.Pkgname))
-	f, err := os.Create(manifestFile)
+	f, err := os.OpenFile(manifestFile, os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0o644)
 	if err != nil {
 		return fmt.Errorf("creating file %s: %w", manifestFile, err)
 	}

--- a/pkg/index/index.go
+++ b/pkg/index/index.go
@@ -240,7 +240,7 @@ func (idx *Index) WriteArchiveIndex(ctx context.Context, destinationFile string)
 	if err != nil {
 		return fmt.Errorf("failed to create archive from index object: %w", err)
 	}
-	outFile, err := os.Create(destinationFile)
+	outFile, err := os.OpenFile(destinationFile, os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0o644)
 	if err != nil {
 		return fmt.Errorf("failed to create archive file: %w", err)
 	}

--- a/pkg/index/index_test.go
+++ b/pkg/index/index_test.go
@@ -87,7 +87,7 @@ func mangleApk(t *testing.T, newDesc string) string {
 		t.Fatal(err)
 	}
 
-	f, err := os.Create(filepath.Join(t.TempDir(), "libcap-2.69-r0.apk"))
+	f, err := os.OpenFile(filepath.Join(t.TempDir(), "libcap-2.69-r0.apk"), os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0o644)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/linter/linter_test.go
+++ b/pkg/linter/linter_test.go
@@ -31,7 +31,7 @@ func TestLinters(t *testing.T) {
 		return func() string {
 			d := t.TempDir()
 			assert.NoError(t, os.MkdirAll(filepath.Join(d, filepath.Dir(path)), 0o700))
-			f, err := os.Create(filepath.Join(d, path))
+			f, err := os.OpenFile(filepath.Join(d, path), os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0o644)
 			assert.NoError(t, err)
 			fmt.Fprintln(f, "blah")
 			defer f.Close()
@@ -261,17 +261,17 @@ func TestLinters(t *testing.T) {
 			assert.NoError(t, os.MkdirAll(filepath.Join(d, "sbin"), 0o700))
 			assert.NoError(t, os.MkdirAll(filepath.Join(d, "usr/sbin"), 0o700))
 			fmt.Printf("Creating dirs and such\n")
-			f, err := os.Create(filepath.Join(d, "bin/test"))
+			f, err := os.OpenFile(filepath.Join(d, "bin/test"), os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0o644)
 			assert.NoError(t, err)
 			fmt.Fprintln(f, "blah")
 			defer f.Close()
 
-			g, err := os.Create(filepath.Join(d, "sbin/test"))
+			g, err := os.OpenFile(filepath.Join(d, "sbin/test"), os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0o644)
 			assert.NoError(t, err)
 			fmt.Fprintln(g, "blah")
 			defer g.Close()
 
-			h, err := os.Create(filepath.Join(d, "usr/sbin/test"))
+			h, err := os.OpenFile(filepath.Join(d, "usr/sbin/test"), os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0o644)
 			assert.NoError(t, err)
 			fmt.Fprintln(h, "blah")
 			defer h.Close()
@@ -327,22 +327,22 @@ func Test_pythonMultiplePackagesLinter(t *testing.T) {
 	assert.NoError(t, LintBuild(ctx, nil, "multiple", dir, linters, nil))
 
 	// Egg info files should not count
-	_, err := os.Create(filepath.Join(pythonPathdir, "fooegg-0.1-py3.14.egg-info"))
+	_, err := os.OpenFile(filepath.Join(pythonPathdir, "fooegg-0.1-py3.14.egg-info"), os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0o644)
 	assert.NoError(t, err)
 	assert.NoError(t, LintBuild(ctx, nil, "multiple", dir, linters, nil))
 
 	// dist info files should not count
-	_, err = os.Create(filepath.Join(pythonPathdir, "foodist-0.1-py3.14.dist-info"))
+	_, err = os.OpenFile(filepath.Join(pythonPathdir, "foodist-0.1-py3.14.dist-info"), os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0o644)
 	assert.NoError(t, err)
 	assert.NoError(t, LintBuild(ctx, nil, "multiple", dir, linters, nil))
 
 	// pth files should not count
-	_, err = os.Create(filepath.Join(pythonPathdir, "foopth-0.1-py3.14.pth"))
+	_, err = os.OpenFile(filepath.Join(pythonPathdir, "foopth-0.1-py3.14.pth"), os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0o644)
 	assert.NoError(t, err)
 	assert.NoError(t, LintBuild(ctx, nil, "multiple", dir, linters, nil))
 
 	// .so files duplicate with a dir should not count
-	_, err = os.Create(filepath.Join(pythonPathdir, "foo.so"))
+	_, err = os.OpenFile(filepath.Join(pythonPathdir, "foo.so"), os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0o644)
 	assert.NoError(t, err)
 	assert.NoError(t, LintBuild(ctx, nil, "multiple", dir, linters, nil))
 
@@ -391,7 +391,7 @@ func Test_setUidGidLinter(t *testing.T) {
 	linters := []string{"setuidgid"}
 	filePath := filepath.Join(t.TempDir(), "test.txt")
 
-	f, err := os.Create(filePath)
+	f, err := os.OpenFile(filePath, os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0o644)
 	assert.NoError(t, err)
 	assert.NoError(t, f.Close())
 	assert.NoError(t, os.Chmod(filePath, 0o770|fs.ModeSetuid|fs.ModeSetgid))
@@ -411,7 +411,7 @@ func Test_worldWriteLinter(t *testing.T) {
 
 	// Create test file
 	filePath := filepath.Join(dir, "usr", "lib", "test.txt")
-	_, err := os.Create(filePath)
+	_, err := os.OpenFile(filePath, os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0o644)
 	assert.NoError(t, err)
 
 	// Set writeable and executable bits for non-world

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -47,7 +47,7 @@ func (m *GeneratedMelangeConfig) Write(ctx context.Context, dir string) error {
 	}
 
 	manifestPath := filepath.Join(dir, fmt.Sprintf("%s.yaml", m.Package.Name))
-	f, err := os.Create(manifestPath)
+	f, err := os.OpenFile(manifestPath, os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0o644)
 	if err != nil {
 		return fmt.Errorf("creating file %s: %w", manifestPath, err)
 	}

--- a/pkg/renovate/cache/cache.go
+++ b/pkg/renovate/cache/cache.go
@@ -190,7 +190,7 @@ func addFileToCache(ctx context.Context, cfg CacheConfig, downloadedFile string,
 		log.Warnf("cache directory is a GCS bucket, not copying file: %s", cfg.CacheDir)
 		return nil
 	}
-	destinationFile, err := os.Create(destinationPath)
+	destinationFile, err := os.OpenFile(destinationPath, os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0o644)
 	if err != nil {
 		return err
 	}

--- a/pkg/renovate/renovate.go
+++ b/pkg/renovate/renovate.go
@@ -121,7 +121,7 @@ func (rc *RenovationContext) LoadConfig(ctx context.Context) error {
 // WriteConfig writes the modified configuration data back to the config
 // file.
 func (rc *RenovationContext) WriteConfig() error {
-	configFile, err := os.Create(rc.Context.ConfigFile)
+	configFile, err := os.OpenFile(rc.Context.ConfigFile, os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0o644)
 	if err != nil {
 		return err
 	}

--- a/pkg/sign/apk.go
+++ b/pkg/sign/apk.go
@@ -93,7 +93,7 @@ func APK(_ context.Context, apkPath string, keyPath string) error {
 		return err
 	}
 
-	w, err := os.Create(apkPath)
+	w, err := os.OpenFile(apkPath, os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0o644)
 	if err != nil {
 		return err
 	}

--- a/pkg/sign/index.go
+++ b/pkg/sign/index.go
@@ -87,7 +87,7 @@ func SignIndex(ctx context.Context, signingKey string, indexFile string) error {
 		return fmt.Errorf("unable to write signature tarball: %w", err)
 	}
 
-	idx, err := os.Create(indexFile)
+	idx, err := os.OpenFile(indexFile, os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0o644)
 	if err != nil {
 		return fmt.Errorf("unable to open index for writing: %w", err)
 	}

--- a/pkg/source/source.go
+++ b/pkg/source/source.go
@@ -81,7 +81,7 @@ func extractMelangeYamlFromTarball(apkPath, destDir string) error {
 			}
 
 			destFilePath := filepath.Join(destDir, ".melange.yaml")
-			destFile, err := os.Create(destFilePath)
+			destFile, err := os.OpenFile(destFilePath, os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0o644)
 			if err != nil {
 				return fmt.Errorf("failed to create destination file: %w", err)
 			}

--- a/pkg/source/source_test.go
+++ b/pkg/source/source_test.go
@@ -28,7 +28,7 @@ import (
 
 // Helper function to create a mock .apk file with a .melange.yaml file inside
 func createMockApk(apkFilePath string, addMelange bool) error {
-	file, err := os.Create(apkFilePath)
+	file, err := os.OpenFile(apkFilePath, os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0o644)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
[`os.Create`](https://pkg.go.dev/os#Create) creates files with `666` permissions, `os.OpenFile(<FILE_NAME>, os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0o644)` is safer because it requires permission bits in function arguments.

This PR replaces all occurrences of `os.Create` with `os.OpenFile`.