### PR TITLE
Revert changes related to "avoid SSH lockups, use script for tests"

### DIFF
--- a/.github/workflows/wolfi-presubmit.yaml
+++ b/.github/workflows/wolfi-presubmit.yaml
@@ -75,7 +75,6 @@ jobs:
           - cadvisor # uses cgroups
           - fping # uses get/setcaps
           - fixuid # uses a diff test user
-          - fluent-operator # uses background& process
           - perl-yaml-syck
           - postfix
           - ncurses

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -37,10 +37,10 @@ import (
 	"chainguard.dev/apko/pkg/apk/apk"
 	apkofs "chainguard.dev/apko/pkg/apk/fs"
 	apko_build "chainguard.dev/apko/pkg/build"
+	"chainguard.dev/apko/pkg/tarfs"
 	apko_types "chainguard.dev/apko/pkg/build/types"
 	"chainguard.dev/apko/pkg/options"
 	"chainguard.dev/apko/pkg/sbom/generator/spdx"
-	"chainguard.dev/apko/pkg/tarfs"
 	"github.com/chainguard-dev/clog"
 	purl "github.com/package-url/packageurl-go"
 	"github.com/yookoala/realpath"
@@ -103,7 +103,7 @@ type Build struct {
 	WorkspaceDir    string
 	WorkspaceDirFS  apkofs.FullFS
 	WorkspaceIgnore string
-	GuestFS         apkofs.FullFS
+	GuestFS apkofs.FullFS
 	// Ordered directories where to find 'uses' pipelines.
 	PipelineDirs          []string
 	SourceDir             string
@@ -1125,7 +1125,6 @@ func (b *Build) buildWorkspaceConfig(ctx context.Context) *container.Config {
 		Timeout:      b.Configuration.Package.Timeout,
 		RunAsUID:     runAsUID(b.Configuration.Environment.Accounts),
 		RunAs:        runAs(b.Configuration.Environment.Accounts),
-		TestRun:      false,
 	}
 
 	if b.Configuration.Package.Resources != nil {

--- a/pkg/build/test.go
+++ b/pkg/build/test.go
@@ -30,8 +30,8 @@ import (
 	apko_build "chainguard.dev/apko/pkg/build"
 	"chainguard.dev/apko/pkg/build/types"
 	apko_types "chainguard.dev/apko/pkg/build/types"
-	"chainguard.dev/apko/pkg/options"
 	"chainguard.dev/apko/pkg/tarfs"
+	"chainguard.dev/apko/pkg/options"
 	"github.com/chainguard-dev/clog"
 	"github.com/yookoala/realpath"
 	"go.opentelemetry.io/otel"
@@ -141,13 +141,6 @@ func (t *Test) BuildGuest(ctx context.Context, imgConfig apko_types.ImageConfigu
 		return "", fmt.Errorf("creating apko tempdir: %w", err)
 	}
 	defer os.RemoveAll(tmp)
-
-	// see qemu_runner.go: 1194
-	if t.Runner.Name() == container.QemuName {
-		t.ExtraTestPackages = append(t.ExtraTestPackages, []string{
-			"cmd:script",
-		}...)
-	}
 
 	bc, err := apko_build.New(ctx, guestFS,
 		apko_build.WithImageConfiguration(imgConfig),
@@ -453,7 +446,6 @@ func (t *Test) buildWorkspaceConfig(ctx context.Context, imgRef, pkgName string,
 		Environment:  map[string]string{},
 		RunAsUID:     runAsUID(imgcfg.Accounts),
 		RunAs:        runAs(imgcfg.Accounts),
-		TestRun:      true,
 	}
 	if t.Configuration.Capabilities.Add != nil {
 		cfg.Capabilities.Add = t.Configuration.Capabilities.Add

--- a/pkg/build/test.go
+++ b/pkg/build/test.go
@@ -335,8 +335,6 @@ func (t *Test) TestPackage(ctx context.Context) error {
 			}
 
 			log.Infof("running the main test pipeline")
-
-			pr.config.TestRun = true
 			if err := pr.runPipelines(ctx, t.Configuration.Test.Pipeline); err != nil {
 				return fmt.Errorf("unable to run pipeline: %w", err)
 			}
@@ -391,7 +389,6 @@ func (t *Test) TestPackage(ctx context.Context) error {
 				}()
 			}
 
-			pr.config.TestRun = true
 			if err := pr.runPipelines(ctx, sp.Test.Pipeline); err != nil {
 				return fmt.Errorf("unable to run pipeline: %w", err)
 			}
@@ -456,6 +453,7 @@ func (t *Test) buildWorkspaceConfig(ctx context.Context, imgRef, pkgName string,
 		Environment:  map[string]string{},
 		RunAsUID:     runAsUID(imgcfg.Accounts),
 		RunAs:        runAs(imgcfg.Accounts),
+		TestRun:      true,
 	}
 	if t.Configuration.Capabilities.Add != nil {
 		cfg.Capabilities.Add = t.Configuration.Capabilities.Add

--- a/pkg/build/test_test.go
+++ b/pkg/build/test_test.go
@@ -78,6 +78,7 @@ func TestBuildWorkspaceConfig(t *testing.T) {
 		PackageName:  testPkgName,
 		ImgRef:       testImgRef,
 		WorkspaceDir: "/workspace",
+		TestRun:      true,
 		Capabilities: container.Capabilities{Networking: true},
 		Mounts: []container.BindMount{
 			{Source: testWorkspaceDir, Destination: homeBuild},

--- a/pkg/build/test_test.go
+++ b/pkg/build/test_test.go
@@ -78,7 +78,6 @@ func TestBuildWorkspaceConfig(t *testing.T) {
 		PackageName:  testPkgName,
 		ImgRef:       testImgRef,
 		WorkspaceDir: "/workspace",
-		TestRun:      true,
 		Capabilities: container.Capabilities{Networking: true},
 		Mounts: []container.BindMount{
 			{Source: testWorkspaceDir, Destination: homeBuild},

--- a/pkg/container/config.go
+++ b/pkg/container/config.go
@@ -67,5 +67,4 @@ type Config struct {
 	SSHClient             *ssh.Client
 	WorkspaceClient       *ssh.Client
 	QemuPID               int
-	TestRun               bool
 }

--- a/pkg/container/qemu_runner.go
+++ b/pkg/container/qemu_runner.go
@@ -99,6 +99,7 @@ func (bw *qemu) Run(ctx context.Context, cfg *Config, envOverride map[string]str
 		envOverride,
 		stderr,
 		stdout,
+		false,
 		args,
 	)
 	if err != nil {
@@ -130,6 +131,7 @@ func (bw *qemu) Debug(ctx context.Context, cfg *Config, envOverride map[string]s
 			nil,
 			nil,
 			nil,
+			false,
 			[]string{"sh", "-c", command},
 		)
 		if err == nil {
@@ -383,13 +385,13 @@ func (bw *qemu) TerminatePod(ctx context.Context, cfg *Config) error {
 	defer os.Remove(cfg.SSHHostKey)
 
 	clog.FromContext(ctx).Info("qemu: sending shutdown signal")
-	cfg.TestRun = false
 	err := sendSSHCommand(ctx,
 		cfg.SSHClient,
 		cfg,
 		nil,
 		nil,
 		nil,
+		false,
 		[]string{"sh", "-c", "echo s > /proc/sysrq-trigger && echo o > /proc/sysrq-trigger&"},
 	)
 	if err != nil {
@@ -460,6 +462,7 @@ func (bw *qemu) WorkspaceTar(ctx context.Context, cfg *Config, extraFiles []stri
 		nil,
 		stderr,
 		outFile,
+		false,
 		[]string{"sh", "-c", retrieveCommand},
 	)
 	if err != nil {
@@ -859,6 +862,7 @@ func createMicroVM(ctx context.Context, cfg *Config) error {
 				nil,
 				stderr,
 				stdout,
+				false,
 				[]string{"sh", "-c", setupMountCommand},
 			)
 			if err != nil {
@@ -877,6 +881,7 @@ func createMicroVM(ctx context.Context, cfg *Config) error {
 		nil,
 		stderr,
 		stdout,
+		false,
 		[]string{"sh", "-c", "find /mnt/ -mindepth 1 -maxdepth 1 -exec cp -a {} /home/build/ \\;"},
 	)
 	if err != nil {
@@ -946,6 +951,7 @@ func getWorkspaceLicenseFiles(ctx context.Context, cfg *Config, extraFiles []str
 		nil,
 		nil,
 		bufWriter,
+		false,
 		[]string{"sh", "-c", "cd /mount/home/build && find . -type f -links 1 -print"},
 	)
 	if err != nil {
@@ -1181,7 +1187,7 @@ func getHostKey(ctx context.Context, cfg *Config) error {
 func sendSSHCommand(ctx context.Context, client *ssh.Client,
 	cfg *Config, extraVars map[string]string,
 	stderr, stdout io.Writer,
-	command []string,
+	tty bool, command []string,
 ) error {
 	// Create a session
 	session, err := client.NewSession()
@@ -1215,26 +1221,37 @@ func sendSSHCommand(ctx context.Context, client *ssh.Client,
 		return err
 	}
 
-	cmd := shellquote.Join(command...)
-
-	// Tests expect to be able to put processes in background between steps.
-	// using `script` will avoid ssh hangs for open fds, and will allow to
-	// leave background processes running for the whole duration of the test.
-	if cfg.TestRun {
-		cmd = shellquote.Join(append([]string{
-			"script", "-f", "-q",
-			"--log-in", "/dev/null",
-			"--log-out", "/dev/null",
-			"-e", "-c"}, cmd)...)
-	}
-
 	session.Stderr = stderr
 	session.Stdout = stdout
 
+	if tty {
+		clog.FromContext(ctx).Debug("requesting tty instance")
+		modes := ssh.TerminalModes{
+			ssh.ECHO:          0,     // disable echoing
+			ssh.TTY_OP_ISPEED: 14400, // input speed = 14.4kbaud
+			ssh.TTY_OP_OSPEED: 14400, // output speed = 14.4kbaud
+		}
+		// Request pseudo terminal
+		if err := session.RequestPty("xterm", 40, 80, modes); err != nil {
+			clog.FromContext(ctx).Errorf("request for pseudo terminal failed: %s", err)
+			return err
+		}
+	}
+
+	cmd := shellquote.Join(command...)
+
+	session.Stdin = strings.NewReader(cmd)
+
 	clog.FromContext(ctx).Debugf("running (%d) %v", len(command), cmd)
-	err = session.Run(cmd)
+	err = session.Shell()
 	if err != nil {
 		clog.FromContext(ctx).Errorf("Failed to run command %q: %v", cmd, err)
+		return err
+	}
+
+	// Wait for the session to finish
+	if err := session.Wait(); err != nil {
+		clog.FromContext(ctx).Errorf("Failed wait for session running: %q: %v", cmd, err)
 		return err
 	}
 

--- a/pkg/container/qemu_runner.go
+++ b/pkg/container/qemu_runner.go
@@ -495,6 +495,7 @@ func (bw *qemu) GetReleaseData(ctx context.Context, cfg *Config) (*apko_build.Re
 		nil,
 		nil,
 		bufWriter,
+		false,
 		[]string{"sh", "-c", "cat /etc/os-release"},
 	)
 


### PR DESCRIPTION
Temporarily we want to consider reverting the recent use of `script` for tests as apparently it causes some testing to fail due to input handling. This might be problematic due to the package world-rebuild we need to perform.