### PR TITLE
Do not require .so files to be executable

### DIFF
--- a/pkg/sca/sca.go
+++ b/pkg/sca/sca.go
@@ -544,10 +544,6 @@ func generateSharedObjectNameDeps(ctx context.Context, hdl SCAHandle, generated 
 			return nil
 		}
 
-		if mode.Perm()&0o555 != 0o555 {
-			return nil
-		}
-
 		basename := filepath.Base(path)
 
 		// most likely a shell script instead of an ELF, so treat any


### PR DESCRIPTION
There is no reason to require .so files to be executable and other distributions like Ubuntu do not make their .so files executable. So let's drop that requirement.

I did a melange scan of the archive with this change (details in the linked issue) and the additional provides from this change are minimal and should not cause an issue.