### PR TITLE
Use session.Run instead of session.Shell

### DIFF
--- a/pkg/container/qemu_runner.go
+++ b/pkg/container/qemu_runner.go
@@ -1241,18 +1241,10 @@ func sendSSHCommand(ctx context.Context, client *ssh.Client,
 
 	cmd := shellquote.Join(command...)
 
-	session.Stdin = strings.NewReader(cmd)
-
 	clog.FromContext(ctx).Debugf("running (%d) %v", len(command), cmd)
-	err = session.Shell()
+	err = session.Run(cmd)
 	if err != nil {
 		clog.FromContext(ctx).Errorf("Failed to run command %q: %v", cmd, err)
-		return err
-	}
-
-	// Wait for the session to finish
-	if err := session.Wait(); err != nil {
-		clog.FromContext(ctx).Errorf("Failed wait for session running: %q: %v", cmd, err)
 		return err
 	}
 


### PR DESCRIPTION
We noticed a subtle edge case during builds (not tests) with `session.Stdin` + `session.Shell()` where the commands would hang and cause OOMs.

This PR moves back to `session.Run` which resolves the issue, but TBD if other edge cases will pop up as a result. I know EOFs were a concern previously, but I don't know if there's a solution that satisfies all issues.

As far as I could tell, there was no way to mitigate this ad-hoc in the pipeline. Input/output redirection, subshells, and other combinations thereof didn't seem to make any difference.