### PR TITLE
feat(cli): add edit-vars command to update vars section in Melange config

### DIFF
--- a/pkg/cli/commands.go
+++ b/pkg/cli/commands.go
@@ -56,6 +56,7 @@ func New() *cobra.Command {
 	cmd.AddCommand(completion())
 	cmd.AddCommand(compile())
 	cmd.AddCommand(convert())
+	cmd.AddCommand(editVarsCmd())
 	cmd.AddCommand(indexCmd())
 	cmd.AddCommand(keygen())
 	cmd.AddCommand(licenseCheck())

--- a/pkg/cli/edit_vars.go
+++ b/pkg/cli/edit_vars.go
@@ -1,0 +1,46 @@
+// Copyright 2022 Chainguard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"github.com/spf13/cobra"
+
+	"chainguard.dev/melange/pkg/renovate"
+	"chainguard.dev/melange/pkg/renovate/edit_vars"
+)
+
+func editVarsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "edit-vars",
+		Short:   "Edit the variables in a Melange YAML file",
+		Long:    `Edit the variables in a Melange YAML file.`,
+		Example: `  melange edit-vars <config.yaml> "key1=value1 key2=value2"`,
+		Args:    cobra.MinimumNArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			rc, err := renovate.New(renovate.WithConfig(args[0]))
+			if err != nil {
+				return err
+			}
+
+			editVarsRenovator := edit_vars.New(ctx,
+				edit_vars.WithVariables(args[1]),
+			)
+
+			return rc.Renovate(cmd.Context(), editVarsRenovator)
+		},
+	}
+	return cmd
+}

--- a/pkg/renovate/edit_vars/edit_vars.go
+++ b/pkg/renovate/edit_vars/edit_vars.go
@@ -1,0 +1,119 @@
+// Copyright 2022 Chainguard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package edit_vars
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/chainguard-dev/clog"
+	"gopkg.in/yaml.v3"
+
+	"chainguard.dev/melange/pkg/renovate"
+)
+
+type EditVarsConfig struct {
+	Variables map[string]string
+}
+
+type Option func(cfg *EditVarsConfig) error
+
+func WithVariables(args string) Option {
+	// Parse the argument string into a map of variables.
+	variables := make(map[string]string)
+	pairs := strings.Split(args, " ")
+	for _, pair := range pairs {
+		kv := strings.SplitN(pair, "=", 2)
+		if len(kv) != 2 {
+			return func(cfg *EditVarsConfig) error {
+				return fmt.Errorf("invalid variable format: %s, expected key=value", pair)
+			}
+		}
+		key := strings.TrimSpace(kv[0])
+		value := strings.TrimSpace(kv[1])
+		if key == "" || value == "" {
+			return func(cfg *EditVarsConfig) error {
+				return fmt.Errorf("invalid variable format: %s, key and value must not be empty", pair)
+			}
+		}
+		variables[key] = value
+	}
+	return func(cfg *EditVarsConfig) error {
+		cfg.Variables = variables
+		return nil
+	}
+}
+
+// New returns a renovator which edits variables in the melange configuration.
+func New(ctx context.Context, opts ...Option) renovate.Renovator {
+	log := clog.FromContext(ctx)
+	cfg := &EditVarsConfig{
+		Variables: make(map[string]string),
+	}
+
+	for _, opt := range opts {
+		if err := opt(cfg); err != nil {
+			return func(context.Context, *renovate.RenovationContext) error {
+				return fmt.Errorf("while constructing edit vars renovator: %w", err)
+			}
+		}
+	}
+
+	return func(ctx context.Context, rc *renovate.RenovationContext) error {
+		log.Infof("attempting to edit variables: %v", cfg.Variables)
+
+		// Find the root node
+		rootNode := rc.Configuration.Root().Content[0]
+
+		// Look for vars node
+		varsNode, err := renovate.NodeFromMapping(rootNode, "vars")
+		if err != nil {
+			// If vars section doesn't exist, skip the entire operation
+			log.Infof("vars section not found, skipping edit operation")
+			return nil
+		}
+
+		// Update variables in the vars section
+		for key, value := range cfg.Variables {
+			updated, err := updateVariable(varsNode, key, value, log)
+			if err != nil {
+				return fmt.Errorf("failed to update variable %s: %w", key, err)
+			}
+			if updated {
+				log.Infof("updated variable: %s = %s", key, value)
+			}
+		}
+
+		return nil
+	}
+}
+
+func updateVariable(varsNode *yaml.Node, key, value string, log *clog.Logger) (bool, error) {
+	// Look for existing variable
+	for i := 0; i < len(varsNode.Content); i += 2 {
+		if varsNode.Content[i].Value == key {
+			// Update existing variable
+			varsNode.Content[i+1].Value = value
+			varsNode.Content[i+1].Style = yaml.DoubleQuotedStyle
+			varsNode.Content[i+1].Tag = "!!str"
+			return true, nil
+		}
+	}
+
+	// Variable not found, log and skip
+	log.Infof("variable '%s' not found, skipping", key)
+	return false, nil
+}


### PR DESCRIPTION
- Introduces a new CLI command: melange edit-vars <config.yaml> "key1=value1 key2=value2"

- Enables safe in-place editing of the vars section if it exists in the Melange YAML file

- Designed to assist with manual package version updates and enables potential automation in the future

- Skips editing gracefully if the vars section or requested keys are not present

## Melange Pull Request Template

<!--
*** PULL REQUEST CHECKLIST: PLEASE START HERE ***

The single most important feature of melange is that we can build Wolfi.

Many changes to melange introduce a risk of breaking the build, and sometimes
these are not flushed out until a package is changed (much) later.  This
pertains to basic execution, SCA changes, linter changes, and more.
-->

### Functional Changes

- [x] This change can build all of Wolfi without errors (describe results in notes)

Notes:

### SCA Changes

- [ ] Examining several representative APKs show no regression / the desired effect (details in notes)

Notes:

### Linter

- [ ] The new check is clean across Wolfi
- [ ] The new check is opt-in or a warning

Notes:
