### PR TITLE
linter.go: Added manInfo linter

### DIFF
--- a/pkg/linter/linter.go
+++ b/pkg/linter/linter.go
@@ -114,6 +114,11 @@ var linterMap = map[string]linter{
 		Explain:         "This package contains intermediate object files",
 		defaultBehavior: Warn,
 	},
+	"maninfo": {
+		LinterFunc:      allPaths(manInfoLinter),
+		Explain:         "Place documentation into a separate package or remove it",
+		defaultBehavior: Warn,
+	},
 	"sbom": {
 		LinterFunc:      allPaths(sbomLinter),
 		Explain:         "Remove any files in /var/lib/db/sbom from the package",
@@ -234,6 +239,19 @@ func documentationLinter(_ context.Context, _ *config.Configuration, pkgname, pa
 	if isDocumentationFileRegex.MatchString(path) && !strings.HasSuffix(pkgname, "-doc") {
 		return errors.New("package contains documentation files but is not a documentation package")
 	}
+	return nil
+}
+
+var (
+    manRegex  = regexp.MustCompile(`(?i)^usr/(?:(?:local/)?share/man|man)/man[0-9][^/]*/[^/]+\.[0-9][^/]*(?:\.(?:gz|bz2|xz|lzma|Z))?$`)
+    infoRegex = regexp.MustCompile(`(?i)^usr/share/info/(?:dir|[^/]+\.info(?:\-[0-9]+)?(?:\.(?:gz|bz2|xz|lzma|Z))?)$`)
+)
+
+func manInfoLinter(_ context.Context, _ *config.Configuration, pkgname, path string) error {
+	if (manRegex.MatchString(path) || infoRegex.MatchString(path)) && !strings.HasSuffix(pkgname, "-doc") {
+		return errors.New("package contains man/info files but is not a documentation package")
+	}
+
 	return nil
 }
 

--- a/pkg/linter/linter_test.go
+++ b/pkg/linter/linter_test.go
@@ -19,6 +19,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"chainguard.dev/melange/pkg/config"
@@ -292,12 +293,67 @@ func TestLinters(t *testing.T) {
 		dirFunc: mkfile(t, "usr/lib/libcuda.so.560.35.05"),
 		linter:  "cudaruntimelib",
 		pass:    false,
+	}, {
+		dirFunc: mkfile(t, "usr/share/man/man1/foo.1"),
+		linter:  "maninfo-regular",
+		pass:    false,
+	}, {
+		dirFunc: mkfile(t, "usr/share/man/man1/foo.1"),
+		linter:  "maninfo-doc",
+		pass:    true,
+	}, {
+		dirFunc: mkfile(t, "usr/share/man/man8/bar.8.gz"),
+		linter:  "maninfo-regular",
+		pass:    false,
+	}, {
+		dirFunc: mkfile(t, "usr/local/share/man/man3/baz.3"),
+		linter:  "maninfo-regular",
+		pass:    false,
+	}, {
+		dirFunc: mkfile(t, "usr/man/man5/qux.5"),
+		linter:  "maninfo-regular",
+		pass:    false,
+	}, {
+		dirFunc: mkfile(t, "usr/share/info/test.info"),
+		linter:  "maninfo-regular",
+		pass:    false,
+	}, {
+		dirFunc: mkfile(t, "usr/share/info/test.info.gz"),
+		linter:  "maninfo-regular",
+		pass:    false,
+	}, {
+		dirFunc: mkfile(t, "usr/share/info/test.info-1"),
+		linter:  "maninfo-regular",
+		pass:    false,
+	}, {
+		dirFunc: mkfile(t, "usr/share/info/dir"),
+		linter:  "maninfo-regular",
+		pass:    false,
+	}, {
+		dirFunc: mkfile(t, "usr/share/info/test.info"),
+		linter:  "maninfo-doc",
+		pass:    true,
+	}, {
+		dirFunc: mkfile(t, "usr/bin/normal"),
+		linter:  "maninfo-regular",
+		pass:    true,
+	}, {
+		dirFunc: mkfile(t, "usr/lib/libfoo.so.1"),
+		linter:  "maninfo-regular",
+		pass:    true,
 	}} {
 		ctx := slogtest.Context(t)
 		t.Run(c.linter, func(t *testing.T) {
 			dir := c.dirFunc()
+
+			// Determine actual linter name
+			actualLinter := c.linter
+			if strings.HasPrefix(c.linter, "maninfo-") {
+				actualLinter = "maninfo"
+			}
+
 			// In required mode, it should raise an error.
-			err := LintBuild(ctx, c.cfg, c.linter, dir, []string{c.linter}, nil)
+			err := LintBuild(ctx, c.cfg, c.linter, dir, []string{actualLinter}, nil)
 			if c.pass {
 				assert.NoError(t, err)
 			} else {
@@ -305,7 +361,7 @@ func TestLinters(t *testing.T) {
 			}
 
 			// In warn mode, it should never raise an error.
-			assert.NoError(t, LintBuild(ctx, c.cfg, c.linter, dir, nil, []string{c.linter}))
+			assert.NoError(t, LintBuild(ctx, c.cfg, c.linter, dir, nil, []string{actualLinter}))
 		})
 	}
 }


### PR DESCRIPTION
A separate linter that is more specific than the current `documentationLinter` whose RegEx also includes `README`, `TODO`, `CREDITS` etc. This linter uses RegEx's that are similar to the `split/doc` and `split/info pipelines`.

Example:
```
./melange lint vim-9.1.1591-r0.apk

2025/07/28 16:40:05 INFO Required checks: [dev infodir tempdir usrmerge varempty]
2025/07/28 16:40:05 INFO Warning checks: [cudaruntimelib lddcheck maninfo object opt pkgconf python/docs python/multiple python/test setuidgid srv strip usrlocal worldwrite]
2025/07/28 16:40:05 INFO linting apk: vim (size: 11 MB)
2025/07/28 16:40:05 WARN linter "maninfo" failed on package "vim": package contains man/info files but is not a documentation package: usr/share/man/man1/evim.1; suggest: Place documentation into a separate package or remove it
```