### PR TITLE
source: copy package contents when fetching source

### DIFF
--- a/pkg/source/source.go
+++ b/pkg/source/source.go
@@ -24,7 +24,9 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 
+	apkofs "chainguard.dev/apko/pkg/apk/fs"
 	"chainguard.dev/melange/pkg/build"
 	"chainguard.dev/melange/pkg/config"
 	"github.com/chainguard-dev/clog"
@@ -175,6 +177,24 @@ func FetchSourceFromMelange(ctx context.Context, filePath, destDir string) (*con
 		fmt.Println(err)
 	}
 	defer os.Chdir(wd) //nolint:errcheck
+
+	// Also, if we're handling a melange yaml file, check if next to it there is a
+	// directory called the same name as the melange yaml file, and if so, copy its
+	// contents to the destination directory. This is needed for patch and others.
+	if !isApk {
+		pkgd := strings.TrimSuffix(filePath, filepath.Ext(filePath))
+
+		if _, err := os.Stat(pkgd); err == nil {
+			log.Infof("Found melange directory: %s\nCopying contents to %s\n", pkgd, destDir)
+			srcFS := apkofs.DirFS(ctx, pkgd)
+			err := os.CopyFS(destDir, srcFS)
+			if err != nil {
+				return nil, fmt.Errorf("failed to copy melange directory contents: %v", err)
+			}
+		} else if !os.IsNotExist(err) {
+			return nil, fmt.Errorf("error checking melange directory: %v", err)
+		}
+	}
 
 	// Iterate over the pipeline steps and look for any source fetching steps.
 	for _, step := range cfg.Pipeline {

--- a/pkg/source/source_test.go
+++ b/pkg/source/source_test.go
@@ -124,10 +124,11 @@ func TestFetchSourceFromMelange(t *testing.T) {
 		fileName      string
 		expectedSteps []string
 		expectedName  string
+		expectedFiles []string
 	}{
-		{"fetch.yaml", []string{"fetch"}, "fetch"},
-		{"fetch-with-patch.yaml", []string{"fetch", "patch"}, "fetch-with-patch"},
-		{"git-checkout.yaml", []string{"git-checkout"}, "git-checkout"},
+		{"fetch.yaml", []string{"fetch"}, "fetch", nil},
+		{"fetch-with-patch.yaml", []string{"fetch", "patch"}, "fetch-with-patch", []string{"foo.patch"}},
+		{"git-checkout.yaml", []string{"git-checkout"}, "git-checkout", nil},
 	}
 
 	// Test each file
@@ -159,6 +160,16 @@ func TestFetchSourceFromMelange(t *testing.T) {
 			for i, step := range stepsRun {
 				if step != tc.expectedSteps[i] {
 					t.Errorf("Expected step %s, got %s", tc.expectedSteps[i], step)
+				}
+			}
+
+			// Validate the files in the destination directory
+			if tc.expectedFiles != nil {
+				for _, file := range tc.expectedFiles {
+					filePath := filepath.Join(destDir, file)
+					if _, err := os.Stat(filePath); os.IsNotExist(err) {
+						t.Errorf("Expected file %s to exist in %s, but it does not", file, destDir)
+					}
 				}
 			}
 		})


### PR DESCRIPTION
Right now in most cases `patch` calls do not work as we don't have the patches present.