### PR TITLE
Improve SCA handling of bogus shlib dependencies

### DIFF
--- a/pkg/sca/sca.go
+++ b/pkg/sca/sca.go
@@ -698,6 +698,11 @@ func generateSharedObjectNameDeps(ctx context.Context, hdl SCAHandle, generated 
 		}
 		defer ef.Close()
 
+		if ef.Machine != elf.EM_X86_64 && ef.Machine != elf.EM_AARCH64 {
+			log.Debugf("skipping binary %s; unsupported architecture %s", path, ef.Machine.String())
+			return nil
+		}
+
 		interp, err := findInterpreter(ef)
 		if err != nil {
 			return err

--- a/pkg/sca/sca.go
+++ b/pkg/sca/sca.go
@@ -40,6 +40,37 @@ import (
 
 var libDirs = []string{"lib/", "usr/lib/", "lib64/", "usr/lib64/"}
 
+// List of libraries that are provided by the host.
+var hostLibs = []string{
+	"libEGL_nvidia.so.1",
+	"libGLESv1_CM_nvidia.so.1",
+	"libGLESv2_nvidia.so.1",
+	"libGLX_nvidia.so.1",
+	"libcuda.so.1",
+	"libcudadebugger.so.1",
+	"libnvcuvid.so.1",
+	"libnvidia-allocator.so.1",
+	"libnvidia-cfg.so.1",
+	"libnvidia-eglcore.so.1",
+	"libnvidia-encode.so.1",
+	"libnvidia-fbc.so.1",
+	"libnvidia-glcore.so.1",
+	"libnvidia-glsi.so.1",
+	"libnvidia-glvkspirv.so.1",
+	"libnvidia-gpucomp.so.1",
+	"libnvidia-ml.so.1",
+	"libnvidia-ngx.so.1",
+	"libnvidia-nvvm.so.1",
+	"libnvidia-opencl.so.1",
+	"libnvidia-opticalflow.so.1",
+	"libnvidia-pkcs11-openssl3.so.1",
+	"libnvidia-pkcs11.so.1",
+	"libnvidia-ptxjitcompiler.so.1",
+	"libnvidia-rtcore.so.1",
+	"libnvidia-tls.so.1",
+	"libnvoptix.so.1",
+}
+
 // SCAFS represents the minimum required filesystem accessors which are needed by
 // the SCA engine.
 type SCAFS interface {
@@ -113,42 +144,8 @@ func isInDir(path string, dirs []string) bool {
 // system and should not be included in dependency or provides generation.
 // These are typically NVIDIA libraries that are installed by the host driver.
 func isHostProvidedLibrary(lib string) bool {
-	hostLibs := []string{
-		"libEGL_nvidia.so.1",
-		"libGLESv1_CM_nvidia.so.1",
-		"libGLESv2_nvidia.so.1",
-		"libGLX_nvidia.so.1",
-		"libcuda.so.1",
-		"libcudadebugger.so.1",
-		"libnvcuvid.so.1",
-		"libnvidia-allocator.so.1",
-		"libnvidia-cfg.so.1",
-		"libnvidia-eglcore.so.1",
-		"libnvidia-encode.so.1",
-		"libnvidia-fbc.so.1",
-		"libnvidia-glcore.so.1",
-		"libnvidia-glsi.so.1",
-		"libnvidia-glvkspirv.so.1",
-		"libnvidia-gpucomp.so.1",
-		"libnvidia-ml.so.1",
-		"libnvidia-ngx.so.1",
-		"libnvidia-nvvm.so.1",
-		"libnvidia-opencl.so.1",
-		"libnvidia-opticalflow.so.1",
-		"libnvidia-pkcs11-openssl3.so.1",
-		"libnvidia-pkcs11.so.1",
-		"libnvidia-ptxjitcompiler.so.1",
-		"libnvidia-rtcore.so.1",
-		"libnvidia-tls.so.1",
-		"libnvoptix.so.1",
-	}
-	
-	for _, hostLib := range hostLibs {
-		if lib == hostLib {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(hostLibs, lib)
+}
 }
 
 // getLdSoConfDLibPaths will iterate over the files being installed by
@@ -695,6 +692,7 @@ func generateSharedObjectNameDeps(ctx context.Context, hdl SCAHandle, generated 
 		for _, lib := range libs {
 			// These are dangling libraries, which must come from the host
 			if isHostProvidedLibrary(lib) {
+				log.Debugf("  skipping lib %s because it is provided by the host", lib)
 				continue
 			}
 			if strings.Contains(lib, ".so.") || strings.HasSuffix(lib, ".so") {


### PR DESCRIPTION
A few issues have either been introduced or uncovered by two recent melange SCA changes:

* https://github.com/chainguard-dev/melange/commit/6b78277c45de0f61c78070fd916ff1eebdd29b66: `SCA: Generate "depends" for shlibs ending in ".so"`

* https://github.com/chainguard-dev/melange/commit/b3bba3c9d48addada5202ec4bd04f60b3fcfe6a3: `Do not require .so files to be executable`

melange is now processing more shared libraries and binaries when calculating the necessary dependencies of a package, and we're encountering weird cases.  The root cause is almost always the same: some of our packages ship prebuilt binaries (ugh) for different systems/architectures.  For example, `grafana-image-renderer` ships binaries compiled for Android.  `code-server` ships binaries linked against musl.  Ideally we should fix these packages and get rid of these bogus binaries, but it's hard to cover the whole archive and detect all these cases.

In order to unbreak some of the most common cases, I'd like to propose yet another heuristic for melange.  Let's carry a list of libraries that are known to be bogus when they appear on `NEEDED`, so that we can ignore them during SCA.  I realize that this is moving more policy inside the mechanism, and I'm not happy with it, but I talked to @jonjohnsonjr and @dannf and told them that I'd create a future roadmap item to proper move these lists out of our source code and into configuration files.