### PR TITLE
Don't --require-zero in CI scan

### DIFF
--- a/.github/workflows/wolfi-presubmit.yaml
+++ b/.github/workflows/wolfi-presubmit.yaml
@@ -222,6 +222,5 @@ jobs:
           wolfictl scan \
           --advisories-repo-dir 'data/wolfi-advisories' \
           --advisory-filter 'resolved' \
-          --require-zero \
           packages/x86_64/${{ matrix.package }}-*.apk \
           2> /dev/null # The error message renders strangely on GitHub Actions, and the important information is already being sent to stdout.


### PR DESCRIPTION
This blocks us from updating melange if certain packages happen to have detected vulns, which doesn't make sense, especially if updating a package is blocked on a melange change.