### PR TITLE
SCA: temporarily no-vendored-cross-package-deps defaulting to true

### DIFF
--- a/pkg/build/sca_interface.go
+++ b/pkg/build/sca_interface.go
@@ -77,7 +77,7 @@ func (scabi *SCABuildInterface) Filesystem() (sca.SCAFS, error) {
 // Options returns the configured SCA engine options for the package being built.
 func (scabi *SCABuildInterface) Options() config.PackageOption {
 	if scabi.PackageBuild.Options == nil {
-		return config.PackageOption{}
+		return config.DefaultPackageOption()
 	}
 	return *scabi.PackageBuild.Options
 }

--- a/pkg/cli/scan.go
+++ b/pkg/cli/scan.go
@@ -441,7 +441,7 @@ func (s *scaImpl) Filesystem() (sca.SCAFS, error) {
 
 func (s *scaImpl) Options() config.PackageOption {
 	if s.pb.Options == nil {
-		return config.PackageOption{}
+		return config.DefaultPackageOption()
 	}
 	return *s.pb.Options
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -94,8 +94,15 @@ type PackageOption struct {
 	NoVersionedShlibDeps bool `json:"no-versioned-shlib-deps,omitempty" yaml:"no-versioned-shlib-deps,omitempty"`
 	// Optional: Don't generate inter-package depends when one
 	// subpackage depends on a vendored shared library shipped by
-	// another.
+	// another. Defaults to true (disabled).
 	NoVendoredCrossPackageDeps bool `json:"no-vendored-cross-package-deps,omitempty" yaml:"no-vendored-cross-package-deps,omitempty"`
+}
+
+// DefaultPackageOption returns a PackageOption with appropriate default values.
+func DefaultPackageOption() PackageOption {
+	return PackageOption{
+		NoVendoredCrossPackageDeps: true,
+	}
 }
 
 type Checks struct {

--- a/pkg/sca/sca_test.go
+++ b/pkg/sca/sca_test.go
@@ -74,7 +74,7 @@ func (th *testHandle) Filesystem() (SCAFS, error) {
 
 func (th *testHandle) Options() config.PackageOption {
 	if th.cfg.Package.Options == nil {
-		return config.PackageOption{}
+		return config.DefaultPackageOption()
 	}
 	return *th.cfg.Package.Options
 }


### PR DESCRIPTION
The recent new functionality might be a bit problematic, so let's default to skipping it.