### PR TITLE
Revert "SCA: Generate depends for shlibs ending in .so" and related commits

### DIFF
--- a/.github/workflows/wolfi-presubmit.yaml
+++ b/.github/workflows/wolfi-presubmit.yaml
@@ -211,9 +211,6 @@ jobs:
             docker run --rm -v $(pwd):/work --workdir /work cgr.dev/chainguard/wolfi-base /bin/sh -c "sed 's|=.*||' -i /etc/apk/world; apk add --allow-untrusted -X ./packages/ packages/x86_64/${{ matrix.package }}-*.apk; ls -hal /usr/bin/sudo"
           elif [[ "${{ matrix.package }}" == "postfix" ]]; then
             docker run --rm -v $(pwd):/work --workdir /work cgr.dev/chainguard/wolfi-base /bin/sh -c "sed 's|=.*||' -i /etc/apk/world; apk add --allow-untrusted -X ./packages/ packages/x86_64/${{ matrix.package }}-*.apk; ls -hal /var/spool/postfix; ls -hal /var/lib/postfix"
-            # Test https://github.com/chainguard-dev/melange/pull/2072
-            PKGVER=$(tar -Oxf ./packages/x86_64/${{ matrix.package }}-stone-*.apk .PKGINFO | grep '^pkgver' | cut -d' ' -f3)
-            tar -Oxf ./packages/x86_64/${{ matrix.package }}-stone-*.apk .PKGINFO | grep "^depend = ${{ matrix.package }}=${PKGVER}"
           else
             docker run --rm -v $(pwd):/work --workdir /work cgr.dev/chainguard/wolfi-base /bin/sh -c "sed 's|=.*||' -i /etc/apk/world; apk add --allow-untrusted -X ./packages/ packages/x86_64/${{ matrix.package }}-*.apk"
           fi

--- a/docs/BUILD-FILE.md
+++ b/docs/BUILD-FILE.md
@@ -218,16 +218,6 @@ options:
   no-versioned-shlib-deps: true
 ```
 
-`no-vendored-cross-package-deps` - When a subpackage `X` ships a
-vendored shared library that's used by subpackage `Y`, melange won't
-generate a `depends` from `Y -> X`.  By default, melange will generate
-a `depends` for `X=version`.
-
-```
-options:
-  no-vendored-cross-package-deps: true
-```
-
 ### scriptlets
 List of executable scripts that run at various stages of the package lifecycle,
 triggered by configurable events. These are useful to handle tasks that only

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -92,10 +92,6 @@ type PackageOption struct {
 	NoCommands bool `json:"no-commands,omitempty" yaml:"no-commands,omitempty"`
 	// Optional: Don't generate versioned depends for shared libraries
 	NoVersionedShlibDeps bool `json:"no-versioned-shlib-deps,omitempty" yaml:"no-versioned-shlib-deps,omitempty"`
-	// Optional: Don't generate inter-package depends when one
-	// subpackage depends on a vendored shared library shipped by
-	// another.
-	NoVendoredCrossPackageDeps bool `json:"no-vendored-cross-package-deps,omitempty" yaml:"no-vendored-cross-package-deps,omitempty"`
 }
 
 type Checks struct {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -92,6 +92,10 @@ type PackageOption struct {
 	NoCommands bool `json:"no-commands,omitempty" yaml:"no-commands,omitempty"`
 	// Optional: Don't generate versioned depends for shared libraries
 	NoVersionedShlibDeps bool `json:"no-versioned-shlib-deps,omitempty" yaml:"no-versioned-shlib-deps,omitempty"`
+	// Optional: Don't generate inter-package depends when one
+	// subpackage depends on a vendored shared library shipped by
+	// another.
+	NoVendoredCrossPackageDeps bool `json:"no-vendored-cross-package-deps,omitempty" yaml:"no-vendored-cross-package-deps,omitempty"`
 }
 
 type Checks struct {

--- a/pkg/sca/e2e_test.go
+++ b/pkg/sca/e2e_test.go
@@ -73,7 +73,6 @@ func TestAnalyze(t *testing.T) {
 				"so:liblcms2-e69eef39.so.2.0.16",
 				"so:liblzma-13fa198c.so.5.4.5",
 				"so:libm.so.6",
-				"so:libopenblas64_p-r0-0cf96a72.3.23.dev.so",
 				"so:libopenjp2-eca49203.so.2.5.0",
 				"so:libpng16-78d422d5.so.16.40.0",
 				"so:libpthread.so.0",
@@ -150,17 +149,6 @@ func TestAnalyze(t *testing.T) {
 				"so:libm.so.6",
 				"so:libmount.so.1",
 				"so:libssl.so.3",
-				// libsystemd-core-256.so and
-				// libsystemd-shared-256.so are
-				// false-positives that get added to
-				// runtime deps because systemd links
-				// against these vendored libraries,
-				// but melange doesn't have enough
-				// context to determine that they are
-				// vendored because they're shipped by
-				// another subpackage.
-				"so:libsystemd-core-256.so",
-				"so:libsystemd-shared-256.so",
 				"so:libudev.so.1",
 			},
 			Provides: []string{

--- a/pkg/sca/sca.go
+++ b/pkg/sca/sca.go
@@ -698,11 +698,6 @@ func generateSharedObjectNameDeps(ctx context.Context, hdl SCAHandle, generated 
 		}
 		defer ef.Close()
 
-		if ef.Machine != elf.EM_X86_64 && ef.Machine != elf.EM_AARCH64 {
-			log.Debugf("skipping binary %s; unsupported architecture %s", path, ef.Machine.String())
-			return nil
-		}
-
 		interp, err := findInterpreter(ef)
 		if err != nil {
 			return err

--- a/pkg/sca/sca.go
+++ b/pkg/sca/sca.go
@@ -84,20 +84,10 @@ type SCAHandle interface {
 	PkgResolver() *apk.PkgResolver
 }
 
-type GeneratorArgs struct {
-	// Extra directories where libraries can be found.  This is
-	// filled by getLdSoConfDLibPaths.
-	extraLibDirs []string
-
-	// A map of vendored shlib -> package name.  This is filled by
-	// getAllVendoredShlibs.
-	allVendoredShlibs map[string]string
-}
-
 // DependencyGenerator takes an SCAHandle, config.Dependencies pointer
-// and a GeneratorArgs struct with extra arguments and returns findings
+// and a list of paths to be appended to libDirs and returns findings
 // based on analysis.
-type DependencyGenerator func(context.Context, SCAHandle, *config.Dependencies, *GeneratorArgs) error
+type DependencyGenerator func(context.Context, SCAHandle, *config.Dependencies, []string) error
 
 func isInDir(path string, dirs []string) bool {
 	mydir := filepath.Dir(path)
@@ -227,7 +217,7 @@ func getLdSoConfDLibPaths(ctx context.Context, hdl SCAHandle) ([]string, error) 
 	return extraLibPaths, nil
 }
 
-func generateCmdProviders(ctx context.Context, hdl SCAHandle, generated *config.Dependencies, args *GeneratorArgs) error {
+func generateCmdProviders(ctx context.Context, hdl SCAHandle, generated *config.Dependencies, extraLibDirs []string) error {
 	log := clog.FromContext(ctx)
 
 	log.Info("scanning for commands...")
@@ -290,7 +280,7 @@ func findInterpreter(bin *elf.File) (string, error) {
 
 // dereferenceCrossPackageSymlink attempts to dereference a symlink across multiple package
 // directories.
-func dereferenceCrossPackageSymlink(hdl SCAHandle, path string, args *GeneratorArgs) (string, string, error) {
+func dereferenceCrossPackageSymlink(hdl SCAHandle, path string, extraLibDirs []string) (string, string, error) {
 	targetPackageNames := hdl.RelativeNames()
 
 	pkgFS, err := hdl.Filesystem()
@@ -305,7 +295,7 @@ func dereferenceCrossPackageSymlink(hdl SCAHandle, path string, args *GeneratorA
 
 	realPath = filepath.Base(realPath)
 
-	expandedLibDirs := append(libDirs, args.extraLibDirs...)
+	expandedLibDirs := append(libDirs, extraLibDirs...)
 
 	for _, pkgName := range targetPackageNames {
 		baseFS, err := hdl.FilesystemForRelative(pkgName)
@@ -500,13 +490,13 @@ func determineShlibVersion(ctx context.Context, hdl SCAHandle, shlib string) (st
 	return "", nil
 }
 
-func processSymlinkSo(ctx context.Context, hdl SCAHandle, path string, generated *config.Dependencies, args *GeneratorArgs) error {
+func processSymlinkSo(ctx context.Context, hdl SCAHandle, path string, generated *config.Dependencies, extraLibDirs []string) error {
 	log := clog.FromContext(ctx)
 	if !strings.Contains(path, ".so") {
 		return nil
 	}
 
-	targetPkg, realPath, err := dereferenceCrossPackageSymlink(hdl, path, args)
+	targetPkg, realPath, err := dereferenceCrossPackageSymlink(hdl, path, extraLibDirs)
 	if err != nil {
 		return nil
 	}
@@ -559,62 +549,7 @@ func processSymlinkSo(ctx context.Context, hdl SCAHandle, path string, generated
 	return nil
 }
 
-func getAllVendoredShlibs(ctx context.Context, hdl SCAHandle, extraLibDirs []string) (map[string]string, error) {
-	log := clog.FromContext(ctx)
-
-	log.Info("gathering list of vendored shlibs...")
-
-	targetPackageNames := hdl.RelativeNames()
-
-	expandedLibDirs := append(libDirs, extraLibDirs...)
-
-	allVendoredShlibs := make(map[string]string)
-
-	for _, pkgName := range targetPackageNames {
-		fsys, err := hdl.FilesystemForRelative(pkgName)
-		if err != nil {
-			return nil, err
-		}
-
-		if err := fs.WalkDir(fsys, "/", func(path string, d fs.DirEntry, err error) error {
-			if err != nil {
-				if errors.Is(err, fs.ErrNotExist) {
-					return fs.SkipAll
-				}
-				return err
-			}
-
-			if !strings.Contains(path, ".so.") && !strings.HasSuffix(path, ".so") {
-				return nil
-			}
-
-			fi, err := d.Info()
-			if err != nil {
-				return err
-			}
-
-			mode := fi.Mode()
-			if !mode.IsRegular() && mode & os.ModeSymlink != os.ModeSymlink {
-				return nil
-			}
-
-			dirPath := filepath.Dir(path)
-			if !isInDir(dirPath, expandedLibDirs) {
-				libName := filepath.Base(path)
-				log.Infof("   found vendored lib %s for package %s", libName, pkgName)
-				allVendoredShlibs[libName] = pkgName
-			}
-
-			return nil
-		}); err != nil {
-			return nil, err
-		}
-	}
-
-	return allVendoredShlibs, nil
-}
-
-func generateSharedObjectNameDeps(ctx context.Context, hdl SCAHandle, generated *config.Dependencies, args *GeneratorArgs) error {
+func generateSharedObjectNameDeps(ctx context.Context, hdl SCAHandle, generated *config.Dependencies, extraLibDirs []string) error {
 	log := clog.FromContext(ctx)
 	log.Infof("scanning for shared object dependencies...")
 
@@ -623,7 +558,7 @@ func generateSharedObjectNameDeps(ctx context.Context, hdl SCAHandle, generated 
 		return err
 	}
 
-	expandedLibDirs := append(libDirs, args.extraLibDirs...)
+	expandedLibDirs := append(libDirs, extraLibDirs...)
 
 	if err := fs.WalkDir(fsys, ".", func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
@@ -641,7 +576,7 @@ func generateSharedObjectNameDeps(ctx context.Context, hdl SCAHandle, generated 
 		isLink := mode.Type()&fs.ModeSymlink == fs.ModeSymlink
 
 		if isLink {
-			if err := processSymlinkSo(ctx, hdl, path, generated, args); err != nil {
+			if err := processSymlinkSo(ctx, hdl, path, generated, extraLibDirs); err != nil {
 				return err
 			}
 		}
@@ -697,36 +632,9 @@ func generateSharedObjectNameDeps(ctx context.Context, hdl SCAHandle, generated 
 			if isHostProvidedLibrary(lib) {
 				continue
 			}
-			if strings.Contains(lib, ".so.") || strings.HasSuffix(lib, ".so") {
-				pkgName, isVendoredDep := args.allVendoredShlibs[lib]
-
-				// There are corner cases when we have
-				// a vendored shared library in a
-				// subpackage X and a binary linked
-				// against it in another subpackage Y
-				// (e.g. see postfix and
-				// postfix-stone).  In this case, we
-				// want to generate a depends
-				// relationship from Y -> X.
-				if isVendoredDep {
-					// Vendored dependency.
-					if pkgName == hdl.PackageName() {
-						log.Infof("  found vendored lib %s", lib)
-						continue
-					}
-
-					if !hdl.Options().NoVendoredCrossPackageDeps {
-						log.Infof("  found vendored lib %s from package %s; depending on %s=%s", lib, pkgName, pkgName, hdl.Version())
-						generated.Runtime = append(generated.Runtime, fmt.Sprintf("%s=%s", pkgName, hdl.Version()))
-					} else {
-						log.Infof("  found vendored lib %s; not generating any depends", lib)
-						continue
-					}
-				} else {
-					// Regular library dependency.
-					log.Infof("  found lib %s for %s", lib, path)
-					generated.Runtime = append(generated.Runtime, fmt.Sprintf("so:%s", lib))
-				}
+			if strings.Contains(lib, ".so.") {
+				log.Infof("  found lib %s for %s", lib, path)
+				generated.Runtime = append(generated.Runtime, fmt.Sprintf("so:%s", lib))
 
 				shlibVer, err := determineShlibVersion(ctx, hdl, lib)
 				if err != nil {
@@ -817,7 +725,7 @@ var generateRuntimePkgConfigDeps = true
 
 // generatePkgConfigDeps generates a list of provided pkg-config package names and versions,
 // as well as dependency relationships.
-func generatePkgConfigDeps(ctx context.Context, hdl SCAHandle, generated *config.Dependencies, args *GeneratorArgs) error {
+func generatePkgConfigDeps(ctx context.Context, hdl SCAHandle, generated *config.Dependencies, extraLibDirs []string) error {
 	log := clog.FromContext(ctx)
 	log.Infof("scanning for pkg-config data...")
 
@@ -907,7 +815,7 @@ func generatePkgConfigDeps(ctx context.Context, hdl SCAHandle, generated *config
 
 // generatePythonDeps generates a python-3.X-base dependency for packages which ship
 // Python modules.
-func generatePythonDeps(ctx context.Context, hdl SCAHandle, generated *config.Dependencies, args *GeneratorArgs) error {
+func generatePythonDeps(ctx context.Context, hdl SCAHandle, generated *config.Dependencies, extraLibDirs []string) error {
 	log := clog.FromContext(ctx)
 	log.Infof("scanning for python modules...")
 
@@ -971,7 +879,7 @@ func generatePythonDeps(ctx context.Context, hdl SCAHandle, generated *config.De
 
 // generateRubyDeps generates a ruby-X.Y dependency for packages which ship
 // Ruby gems.
-func generateRubyDeps(ctx context.Context, hdl SCAHandle, generated *config.Dependencies, args *GeneratorArgs) error {
+func generateRubyDeps(ctx context.Context, hdl SCAHandle, generated *config.Dependencies, extraLibDirs []string) error {
 	log := clog.FromContext(ctx)
 	log.Infof("scanning for ruby gems...")
 
@@ -1018,7 +926,7 @@ func generateRubyDeps(ctx context.Context, hdl SCAHandle, generated *config.Depe
 }
 
 // For a documentation package add a dependency on man-db and / or texinfo as appropriate
-func generateDocDeps(ctx context.Context, hdl SCAHandle, generated *config.Dependencies, args *GeneratorArgs) error {
+func generateDocDeps(ctx context.Context, hdl SCAHandle, generated *config.Dependencies, extraLibDirs []string) error {
 	log := clog.FromContext(ctx)
 	log.Infof("scanning for -doc package...")
 	if !strings.HasSuffix(hdl.PackageName(), "-doc") {
@@ -1141,7 +1049,7 @@ func getShbang(fp io.Reader) (string, error) {
 	return bin, nil
 }
 
-func generateShbangDeps(ctx context.Context, hdl SCAHandle, generated *config.Dependencies, args *GeneratorArgs) error {
+func generateShbangDeps(ctx context.Context, hdl SCAHandle, generated *config.Dependencies, extraLibDirs []string) error {
 	log := clog.FromContext(ctx)
 	log.Infof("scanning for shbang deps...")
 
@@ -1202,16 +1110,6 @@ func Analyze(ctx context.Context, hdl SCAHandle, generated *config.Dependencies)
 		return err
 	}
 
-	allVendoredShlibs, err := getAllVendoredShlibs(ctx, hdl, extraLibDirs)
-	if err != nil {
-		return err
-	}
-
-	args := GeneratorArgs{
-		extraLibDirs,
-		allVendoredShlibs,
-	}
-
 	generators := []DependencyGenerator{
 		generateSharedObjectNameDeps,
 		generateCmdProviders,
@@ -1223,7 +1121,7 @@ func Analyze(ctx context.Context, hdl SCAHandle, generated *config.Dependencies)
 	}
 
 	for _, gen := range generators {
-		if err := gen(ctx, hdl, generated, &args); err != nil {
+		if err := gen(ctx, hdl, generated, extraLibDirs); err != nil {
 			return err
 		}
 	}

--- a/pkg/sca/sca.go
+++ b/pkg/sca/sca.go
@@ -40,37 +40,6 @@ import (
 
 var libDirs = []string{"lib/", "usr/lib/", "lib64/", "usr/lib64/"}
 
-// List of libraries that are provided by the host.
-var hostLibs = []string{
-	"libEGL_nvidia.so.1",
-	"libGLESv1_CM_nvidia.so.1",
-	"libGLESv2_nvidia.so.1",
-	"libGLX_nvidia.so.1",
-	"libcuda.so.1",
-	"libcudadebugger.so.1",
-	"libnvcuvid.so.1",
-	"libnvidia-allocator.so.1",
-	"libnvidia-cfg.so.1",
-	"libnvidia-eglcore.so.1",
-	"libnvidia-encode.so.1",
-	"libnvidia-fbc.so.1",
-	"libnvidia-glcore.so.1",
-	"libnvidia-glsi.so.1",
-	"libnvidia-glvkspirv.so.1",
-	"libnvidia-gpucomp.so.1",
-	"libnvidia-ml.so.1",
-	"libnvidia-ngx.so.1",
-	"libnvidia-nvvm.so.1",
-	"libnvidia-opencl.so.1",
-	"libnvidia-opticalflow.so.1",
-	"libnvidia-pkcs11-openssl3.so.1",
-	"libnvidia-pkcs11.so.1",
-	"libnvidia-ptxjitcompiler.so.1",
-	"libnvidia-rtcore.so.1",
-	"libnvidia-tls.so.1",
-	"libnvoptix.so.1",
-}
-
 // SCAFS represents the minimum required filesystem accessors which are needed by
 // the SCA engine.
 type SCAFS interface {
@@ -144,8 +113,42 @@ func isInDir(path string, dirs []string) bool {
 // system and should not be included in dependency or provides generation.
 // These are typically NVIDIA libraries that are installed by the host driver.
 func isHostProvidedLibrary(lib string) bool {
-	return slices.Contains(hostLibs, lib)
-}
+	hostLibs := []string{
+		"libEGL_nvidia.so.1",
+		"libGLESv1_CM_nvidia.so.1",
+		"libGLESv2_nvidia.so.1",
+		"libGLX_nvidia.so.1",
+		"libcuda.so.1",
+		"libcudadebugger.so.1",
+		"libnvcuvid.so.1",
+		"libnvidia-allocator.so.1",
+		"libnvidia-cfg.so.1",
+		"libnvidia-eglcore.so.1",
+		"libnvidia-encode.so.1",
+		"libnvidia-fbc.so.1",
+		"libnvidia-glcore.so.1",
+		"libnvidia-glsi.so.1",
+		"libnvidia-glvkspirv.so.1",
+		"libnvidia-gpucomp.so.1",
+		"libnvidia-ml.so.1",
+		"libnvidia-ngx.so.1",
+		"libnvidia-nvvm.so.1",
+		"libnvidia-opencl.so.1",
+		"libnvidia-opticalflow.so.1",
+		"libnvidia-pkcs11-openssl3.so.1",
+		"libnvidia-pkcs11.so.1",
+		"libnvidia-ptxjitcompiler.so.1",
+		"libnvidia-rtcore.so.1",
+		"libnvidia-tls.so.1",
+		"libnvoptix.so.1",
+	}
+	
+	for _, hostLib := range hostLibs {
+		if lib == hostLib {
+			return true
+		}
+	}
+	return false
 }
 
 // getLdSoConfDLibPaths will iterate over the files being installed by
@@ -692,7 +695,6 @@ func generateSharedObjectNameDeps(ctx context.Context, hdl SCAHandle, generated 
 		for _, lib := range libs {
 			// These are dangling libraries, which must come from the host
 			if isHostProvidedLibrary(lib) {
-				log.Debugf("  skipping lib %s because it is provided by the host", lib)
 				continue
 			}
 			if strings.Contains(lib, ".so.") || strings.HasSuffix(lib, ".so") {

--- a/pkg/sca/sca.go
+++ b/pkg/sca/sca.go
@@ -92,12 +92,6 @@ var ignoredLibs = []string{
 	"libc.musl-aarch64.so.1",
 }
 
-// List of ELF sections that should not appear in binaries being
-// analyzed by us.  If they do, we can skip the analysis.
-var invalidELFSections = []string {
-	".note.android.ident",
-}
-
 // SCAFS represents the minimum required filesystem accessors which are needed by
 // the SCA engine.
 type SCAFS interface {
@@ -707,12 +701,6 @@ func generateSharedObjectNameDeps(ctx context.Context, hdl SCAHandle, generated 
 		if ef.Machine != elf.EM_X86_64 && ef.Machine != elf.EM_AARCH64 {
 			log.Debugf("skipping binary %s; unsupported architecture %s", path, ef.Machine.String())
 			return nil
-		}
-		for _, elfSection := range invalidELFSections {
-			if ef.Section(elfSection) != nil {
-				log.Debugf("skipping binary %s; invalid ELF section %v found", path, elfSection)
-				return nil
-			}
 		}
 
 		interp, err := findInterpreter(ef)

--- a/pkg/sca/sca.go
+++ b/pkg/sca/sca.go
@@ -750,14 +750,16 @@ func generateSharedObjectNameDeps(ctx context.Context, hdl SCAHandle, generated 
 					// Vendored dependency.
 					if pkgName == hdl.PackageName() {
 						log.Infof("  found vendored lib %s", lib)
-					} else if !hdl.Options().NoVendoredCrossPackageDeps {
+						continue
+					}
+
+					if !hdl.Options().NoVendoredCrossPackageDeps {
 						log.Infof("  found vendored lib %s from package %s; depending on %s=%s", lib, pkgName, pkgName, hdl.Version())
 						generated.Runtime = append(generated.Runtime, fmt.Sprintf("%s=%s", pkgName, hdl.Version()))
 					} else {
-						log.Infof("  found vendored lib %s from package %s; not generating any depends", lib, pkgName)
+						log.Infof("  found vendored lib %s; not generating any depends", lib)
+						continue
 					}
-					// We don't need to generate so-ver statements for vendored libraries.
-					continue
 				} else {
 					// Regular library dependency.
 					log.Infof("  found lib %s for %s", lib, path)

--- a/pkg/sca/sca.go
+++ b/pkg/sca/sca.go
@@ -71,27 +71,6 @@ var hostLibs = []string{
 	"libnvoptix.so.1",
 }
 
-// List of libraries that should be ignored when calculating
-// dependencies.
-var ignoredLibs = []string{
-	// Our glibc libraries are always versioned.  Some packages
-	// might ship prebuilt binaries that depend on unversioned
-	// libc libraries; these can be e.g. Android or musl binaries,
-	// and therefore we should ignore these dependencies.
-	//
-	// For an example of such a package, see Wolfi's grafana-image-renderer.
-	"libc.so",
-	"libdl.so",
-	"libm.so",
-
-	// Some packages ship prebuilt binaries linked against musl.
-	// We don't want to generate dependencies for that.
-	//
-	// For an example of such a package, see Wolfi's code-server.
-	"libc.musl-x86_64.so.1",
-	"libc.musl-aarch64.so.1",
-}
-
 // SCAFS represents the minimum required filesystem accessors which are needed by
 // the SCA engine.
 type SCAFS interface {
@@ -167,14 +146,6 @@ func isInDir(path string, dirs []string) bool {
 func isHostProvidedLibrary(lib string) bool {
 	return slices.Contains(hostLibs, lib)
 }
-
-// isIgnoredLibrary returns true if lib should be ignored during
-// dependency generation.
-//
-// Typically, this happens when dealing with binaries or shared
-// libraries that link against libraries we don't ship or support.
-func isIgnoredLibrary(lib string) bool {
-	return slices.Contains(ignoredLibs, lib)
 }
 
 // getLdSoConfDLibPaths will iterate over the files being installed by
@@ -724,12 +695,6 @@ func generateSharedObjectNameDeps(ctx context.Context, hdl SCAHandle, generated 
 				log.Debugf("  skipping lib %s because it is provided by the host", lib)
 				continue
 			}
-
-			if isIgnoredLibrary(lib) {
-				log.Debugf("  ignoring lib %s", lib)
-				continue
-			}
-
 			if strings.Contains(lib, ".so.") || strings.HasSuffix(lib, ".so") {
 				pkgName, isVendoredDep := args.allVendoredShlibs[lib]
 


### PR DESCRIPTION
Temporary revert to the previous known working state regarding shlib dependency generation.