### PR TITLE
add check for -march=native to autoconf/configure pipeline

### DIFF
--- a/pkg/build/pipelines/autoconf/configure.yaml
+++ b/pkg/build/pipelines/autoconf/configure.yaml
@@ -45,3 +45,14 @@ pipeline:
         --infodir=/usr/share/info \
         --localstatedir=/var \
         ${{inputs.opts}}
+
+      # Check for -march=native in generated autotools files
+      march_native_files=$(find . -name "config.log" -o -name "config.status" -o -name "Makefile" -o -name "*.pc")
+      if [[ -n "${march_native_files}" ]]; then
+        for file in ${march_native_files}; do
+          if grep -E 'C(XX)?FLAGS(.+)?-march=native(.+)?' "${file}"; then
+            echo "Error: Found -march=native CFLAGS/CXXFLAGS in ${file}. This creates non-portable binaries."
+            exit 1
+          fi
+        done
+      fi


### PR DESCRIPTION
## Melange Pull Request Template

<!--
*** PULL REQUEST CHECKLIST: PLEASE START HERE ***

The single most important feature of melange is that we can build Wolfi.

Many changes to melange introduce a risk of breaking the build, and sometimes
these are not flushed out until a package is changed (much) later.  This
pertains to basic execution, SCA changes, linter changes, and more.
-->

### Functional Changes

- [ ] This change can build all of Wolfi without errors (describe results in notes)

Notes:

### SCA Changes

- [ ] Examining several representative APKs show no regression / the desired effect (details in notes)

Notes:

### Linter

- [ ] The new check is clean across Wolfi
- [ ] The new check is opt-in or a warning

Notes:
