### PR TITLE
More summarize output info.

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -1031,7 +1031,7 @@ func (b *Build) SummarizePaths(ctx context.Context) {
 
 func (b *Build) summarize(ctx context.Context) {
 	log := clog.FromContext(ctx)
-	log.Infof("melange %s is building:", version.GetVersionInfo().GitVersion)
+	log.Infof("melange %s with runner %s is building:", version.GetVersionInfo().GitVersion, b.Runner.Name())
 	log.Debugf("  configuration file: %s", b.ConfigFile)
 	b.SummarizePaths(ctx)
 }

--- a/pkg/build/test.go
+++ b/pkg/build/test.go
@@ -30,8 +30,8 @@ import (
 	apko_build "chainguard.dev/apko/pkg/build"
 	"chainguard.dev/apko/pkg/build/types"
 	apko_types "chainguard.dev/apko/pkg/build/types"
-	"chainguard.dev/apko/pkg/tarfs"
 	"chainguard.dev/apko/pkg/options"
+	"chainguard.dev/apko/pkg/tarfs"
 	"github.com/chainguard-dev/clog"
 	"github.com/yookoala/realpath"
 	"go.opentelemetry.io/otel"
@@ -155,6 +155,7 @@ func (t *Test) BuildGuest(ctx context.Context, imgConfig apko_types.ImageConfigu
 		return "", fmt.Errorf("unable to create build context: %w", err)
 	}
 
+	t.Summarize(ctx)
 	bc.Summarize(ctx)
 
 	// lay out the contents for the image in a directory.
@@ -407,7 +408,7 @@ func (t *Test) SummarizePaths(ctx context.Context) {
 
 func (t *Test) Summarize(ctx context.Context) {
 	log := clog.FromContext(ctx)
-	log.Infof("melange %s is testing:", version.GetVersionInfo().GitVersion)
+	log.Infof("melange %s with runner %s is testing:", version.GetVersionInfo().GitVersion, t.Runner.Name())
 	log.Debugf("  configuration file: %s", t.ConfigFile)
 	t.SummarizePaths(ctx)
 }

--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -146,6 +146,7 @@ func buildCmd() *cobra.Command {
 			}
 
 			archs := apko_types.ParseArchitectures(archstrs)
+			log.Infof("melange version %s with runner %s building %s at commit %s for arches %s", cmd.Version, r.Name(), buildConfigFilePath, configFileGitCommit, archs)
 			options := []build.Option{
 				build.WithBuildDate(buildDate),
 				build.WithWorkspaceDir(workspaceDir),


### PR DESCRIPTION
The change here makes test actually output its 'Summarize', and build and test are now show the runner that is used.

example of output is:

```
melange v0.30.7-0.20250814112845-f15c64318984+dirty with runner qemu is testing:
```