### PR TITLE
e2e-tests: Always run tests with all compatible runners

### DIFF
--- a/e2e-tests/run-tests
+++ b/e2e-tests/run-tests
@@ -77,17 +77,22 @@ for yaml in "$@"; do
         "test") opargs="--pipeline-dirs $PWD/pipelines";;
     esac
 
-    vrc "Testing $base from $yaml for $op" \
-      ${MELANGE} "$op" \
-        --arch=${ARCH} --source-dir=./test-fixtures \
-        --runner=qemu \
-        "$yaml" \
-        ${args} $opargs \
-        "--keyring-append=$PWD/$key.pub" \
-        "--repository-append=$PWD/packages" \
-        "--repository-append=https://packages.wolfi.dev/os" \
-        "--keyring-append=https://packages.wolfi.dev/os/wolfi-signing.rsa.pub" ||
-        fails="${fails} $yaml/$op"
+    for runner in "qemu" "bubblewrap" "docker"; do
+	if [ $(uname -s) = "Darwin" ] && [ ${runner} = "bubblewrap" ]; then
+	    continue
+	fi
+	vrc "Testing $base from $yaml for $op using $runner" \
+	${MELANGE} "$op" \
+	    --arch=${ARCH} --source-dir=./test-fixtures \
+	    --runner=${runner} \
+	    "$yaml" \
+	    ${args} $opargs \
+	    "--keyring-append=$PWD/$key.pub" \
+	    "--repository-append=$PWD/packages" \
+	    "--repository-append=https://packages.wolfi.dev/os" \
+	    "--keyring-append=https://packages.wolfi.dev/os/wolfi-signing.rsa.pub" ||
+	    fails="${fails} $yaml/$op/$runner"
+    done
   done
 done
 


### PR DESCRIPTION
It doesn't take that much longer to run these tests with the additional runners. It would be nice to have a switch to select that but I didn't want to spend too much time on it.  This is roughly on top of https://github.com/chainguard-dev/melange/pull/2134 but has divered once I realized I wouldn't be able to fix the failing tests easily.

For example on x86_64 linux we have the following tests that fail with both the same for x86_64 testing and aarch64 testing/ 

```
FAIL:  env-vars-build-test.yaml/build/docker git-checkout-build.yaml/build/qemu git-checkout-build.yaml/build/docker xcover-nopkg-test.yaml/test/qemu xcover-nopkg-test.yaml/test/bubblewrap xcover-nopkg-test.yaml/test/docker
```