### PR TITLE
feat: go bump - go work vendor

### DIFF
--- a/docs/PIPELINES-GO.md
+++ b/docs/PIPELINES-GO.md
@@ -148,6 +148,19 @@ pipeline:
 (:bulb: Experiment with this code,
 [download it from the examples directory](https://github.com/chainguard-dev/melange/blob/main/examples/go-bump.yaml))
 
+### Using go workspace mode
+
+The `go/bump` pipeline also supports Go workspace mode through the `work` parameter. When enabled, it will use `go work vendor` instead of `go mod vendor` for dependency management. This is useful for projects that use Go workspaces (go.work files).
+
+Example usage with workspace mode:
+
+```yaml
+  - uses: go/bump
+    with:
+      deps: github.com/sirupsen/logrus@v1.9.3
+      work: true
+```
+
 For the most up to date supported features check the
 [build](https://github.com/chainguard-dev/melange/blob/main/pkg/build/pipelines/go/build.yaml),
 [install](https://github.com/chainguard-dev/melange/blob/main/pkg/build/pipelines/go/install.yaml),

--- a/pkg/build/pipelines/go/README.md
+++ b/pkg/build/pipelines/go/README.md
@@ -50,6 +50,7 @@ Bump go deps to a certain version
 | show-diff | false | Show the difference between the go.mod file before and after the bump | false |
 | tidy | false | Run go mod tidy command before and after the bump | true |
 | tidy-compat | false | Set the go version for which the tidied go.mod and go.sum files should be compatible |  |
+| work | false | Use go work vendor instead of go mod vendor for projects with go work enabled | false |
 
 ## go/covdata
 

--- a/pkg/build/pipelines/go/bump.yaml
+++ b/pkg/build/pipelines/go/bump.yaml
@@ -27,7 +27,7 @@ inputs:
     description: "Set the go version for which the tidied go.mod and go.sum files should be compatible"
     default: ""
   work:
-    description: "use go work vendor instead of go mod vendor"
+    description: "Use go work vendor instead of go mod vendor for projects with go work enabled"
     default: false
 
 pipeline:

--- a/pkg/build/pipelines/go/bump.yaml
+++ b/pkg/build/pipelines/go/bump.yaml
@@ -26,10 +26,13 @@ inputs:
   tidy-compat:
     description: "Set the go version for which the tidied go.mod and go.sum files should be compatible"
     default: ""
+  work:
+    description: "use go work vendor instead of go mod vendor"
+    default: false
 
 pipeline:
   - runs: |
       cd "${{inputs.modroot}}"
 
       # We use the --tidy flag to run go mod tidy before and after in some cases (if old versions of go are used, we need to update the go.mod format)
-      gobump --packages "${{inputs.deps}}" --replaces "${{inputs.replaces}}" --tidy=${{inputs.tidy}} --show-diff=${{inputs.show-diff}} --go-version=${{inputs.go-version}} --compat=${{inputs.tidy-compat}}
+      gobump --packages "${{inputs.deps}}" --replaces "${{inputs.replaces}}" --tidy=${{inputs.tidy}} --show-diff=${{inputs.show-diff}} --go-version=${{inputs.go-version}} --compat=${{inputs.tidy-compat}} --work=${{inputs.work}}


### PR DESCRIPTION
gobump v0.9.2 introduces support for go work vendor; adding support in build pipelines go bump