### PR TITLE
Propagate environment between uses and pipelines

### DIFF
--- a/e2e-tests/env-propagation-uses-build.yaml
+++ b/e2e-tests/env-propagation-uses-build.yaml
@@ -1,0 +1,29 @@
+package:
+  name: uses-env-propagation
+  version: "0.0.1"
+  epoch: 0
+  description: Test environment propagation to external pipeline files via uses
+  copyright:
+    - license: APACHE-2.0
+
+environment:
+  contents:
+    repositories:
+      - https://packages.wolfi.dev/os
+    keyring:
+      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    packages:
+      - busybox
+  environment:
+    GLOBAL_VAR: "from_config"
+
+pipeline:
+  - uses: check-env
+    environment:
+      PIPELINE_VAR: "from_uses"
+
+update:
+  enabled: true
+  release-monitor:
+    identifier: 15
+

--- a/e2e-tests/pipelines/check-env.yaml
+++ b/e2e-tests/pipelines/check-env.yaml
@@ -1,0 +1,26 @@
+name: Check environment variable propagation
+pipeline:
+  - name: "Verify environment variables"
+    environment:
+      INTERNAL_PIPELINE_VAR: "internal_pipeline_var"
+    runs: |
+      echo "Checking GLOBAL_VAR: $GLOBAL_VAR"
+      echo "Checking PIPELINE_VAR: $PIPELINE_VAR"
+
+      if [ "$GLOBAL_VAR" != "from_config" ]; then
+        echo "ERROR: GLOBAL_VAR not propagated correctly"
+        exit 1
+      fi
+
+      if [ "$PIPELINE_VAR" != "from_uses" ]; then
+        echo "ERROR: PIPELINE_VAR not propagated correctly"
+        exit 1
+      fi
+
+      if [ "$INTERNAL_PIPELINE_VAR" != "internal_pipeline_var" ]; then
+        echo "ERROR: PIPELINE_VAR not propagated correctly"
+        exit 1
+      fi
+
+      echo "SUCCESS: All environment variables propagated correctly"
+

--- a/e2e-tests/run-tests
+++ b/e2e-tests/run-tests
@@ -70,7 +70,11 @@ for yaml in "$@"; do
   for op in $ops; do
     opargs=""
     case "$op" in
-        build) opargs="--signing-key=$PWD/$key";;
+        # For some reason build takes '--pipeline-dir' and test takes
+        # --pipeline-dirs. And we need to pass both to compile the
+        # melange file
+        "build") opargs="--signing-key=$PWD/$key --pipeline-dir $PWD/pipelines";;
+        "test") opargs="--pipeline-dirs $PWD/pipelines";;
     esac
 
     vrc "Testing $base from $yaml for $op" \

--- a/pkg/build/pipeline.go
+++ b/pkg/build/pipeline.go
@@ -246,6 +246,10 @@ func (r *pipelineRunner) runPipeline(ctx context.Context, pipeline *config.Pipel
 	steps := 0
 
 	for _, p := range pipeline.Pipeline {
+		// Merge nested pipeline environment with parent environment
+		mergedEnv := maps.Clone(envOverride)
+		maps.Copy(mergedEnv, p.Environment)
+		p.Environment = mergedEnv
 		if ran, err := r.runPipeline(ctx, &p); err != nil {
 			return false, fmt.Errorf("unable to run pipeline: %w", err)
 		} else if ran {


### PR DESCRIPTION
If you specify the environment of a uses pipeline it will be ignored when the pipeline is loaded.

You can see grpc-1.76 doing this here:

https://github.com/wolfi-dev/os/blob/0c6b8959949e816f3dbce1af2237ad81ee579618/grpc-1.74.yaml#L120

These variables aren't ever actually set the uses pipeline overwrites it. So we need to fix those places so that the variables are propegated. An easy fix for this when it's needed is to make then environment variables at the top level with the packages. This also explains some additional strange behavior we've had trying to override variables for individual steps.


### Functional Changes

Notes:

We should at a minimum verify that the grpc package still build correctly since some of them vendor things incidentally a spot check will be needed for packages that also build this.

Manual checking doesn't show problems with grpc packages or other that display this.


