### PR TITLE
config.go: Remove `no-vendored-cross-package-deps` stanza

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -92,10 +92,6 @@ type PackageOption struct {
 	NoCommands bool `json:"no-commands,omitempty" yaml:"no-commands,omitempty"`
 	// Optional: Don't generate versioned depends for shared libraries
 	NoVersionedShlibDeps bool `json:"no-versioned-shlib-deps,omitempty" yaml:"no-versioned-shlib-deps,omitempty"`
-	// Optional: Don't generate inter-package depends when one
-	// subpackage depends on a vendored shared library shipped by
-	// another.
-	NoVendoredCrossPackageDeps bool `json:"no-vendored-cross-package-deps,omitempty" yaml:"no-vendored-cross-package-deps,omitempty"`
 }
 
 type Checks struct {


### PR DESCRIPTION
Now that we don't have packages using this no-op stanza, we can remove it from the config file.

For reference, this was introduced by
https://github.com/chainguard-dev/melange/pull/2072 (which got reverted in https://github.com/chainguard-dev/melange/pull/2116).