### PR TITLE
pipelines/go/build: Add ignore-untracked-files to prevent some +dirty…

### DIFF
--- a/e2e-tests/git-dirty-detection-build.yaml
+++ b/e2e-tests/git-dirty-detection-build.yaml
@@ -1,0 +1,133 @@
+package:
+  name: git-dirty-detection-test
+  version: 1.0.0
+  epoch: 0
+  description: "Test configuration for testing go/build git dirty detection - all cases"
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - go
+      - git
+  environment:
+    CGO_ENABLED: "0"
+
+pipeline:
+  # Initialize git repo once
+  - runs: |
+      mkdir -p hello-app
+      cd hello-app
+
+      cat > go.mod <<"EOF"
+      module test-hello
+
+      go 1.21
+      EOF
+
+      cat > main.go <<"EOF"
+      package main
+
+      import "fmt"
+
+      func main() {
+          fmt.Println("Hello, World!")
+      }
+      EOF
+
+      # Initialize git repo and commit everything (clean state)
+      git init
+      git config user.email "test@example.com"
+      git config user.name "Test User"
+      git add .
+      git commit -m "Initial commit"
+
+  # Test 1: Clean repository should not have +dirty
+  - uses: go/build
+    with:
+      modroot: hello-app
+      packages: .
+      output: git-clean-binary
+      ignore-untracked-files: false
+
+  - name: Verify clean repo does not have +dirty
+    runs: |
+      echo "=== TEST 1: CLEAN REPO ==="
+      go version -m ${{targets.destdir}}/usr/bin/git-clean-binary
+
+      if go version -m ${{targets.destdir}}/usr/bin/git-clean-binary | grep -q "+dirty"; then
+        echo "ERROR: Clean repo binary contains +dirty when it shouldn't"
+        exit 1
+      else
+        echo "PASS: Clean repo binary correctly does not contain +dirty"
+      fi
+
+  # Test 2: Modified tracked file should have +dirty (even with ignore-untracked-files: true)
+  - runs: |
+      cd hello-app
+      echo "// Modified tracked file" >> main.go
+
+  - uses: go/build
+    with:
+      modroot: hello-app
+      packages: .
+      output: git-modified-tracked-binary
+      ignore-untracked-files: true
+
+  - name: Verify modified tracked file has +dirty
+    runs: |
+      echo "=== TEST 2: MODIFIED TRACKED FILE ==="
+      go version -m ${{targets.destdir}}/usr/bin/git-modified-tracked-binary
+
+      if go version -m ${{targets.destdir}}/usr/bin/git-modified-tracked-binary | grep -q "+dirty"; then
+        echo "PASS: Modified tracked file binary correctly contains +dirty"
+      else
+        echo "ERROR: Modified tracked file binary should contain +dirty but doesn't"
+        exit 1
+      fi
+
+  # Test 3: Reset to clean, add untracked file, ignore-untracked-files: false should be +dirty
+  - runs: |
+      cd hello-app
+      git checkout -- main.go  # Reset to clean
+      echo "untracked content" > untracked.txt
+
+  - uses: go/build
+    with:
+      modroot: hello-app
+      packages: .
+      output: git-untracked-not-ignored-binary
+      ignore-untracked-files: false
+
+  - name: Verify untracked files with ignore-untracked-files=false has +dirty
+    runs: |
+      echo "=== TEST 3: UNTRACKED FILES, IGNORE=FALSE ==="
+      go version -m ${{targets.destdir}}/usr/bin/git-untracked-not-ignored-binary
+
+      if go version -m ${{targets.destdir}}/usr/bin/git-untracked-not-ignored-binary | grep -q "+dirty"; then
+        echo "PASS: Untracked files with ignore=false binary correctly contains +dirty"
+      else
+        echo "ERROR: Untracked files with ignore=false binary should contain +dirty but doesn't"
+        exit 1
+      fi
+
+  # Test 4: Same untracked file, ignore-untracked-files: true should NOT be +dirty
+  - uses: go/build
+    with:
+      modroot: hello-app
+      packages: .
+      output: git-untracked-ignored-binary
+      ignore-untracked-files: true
+
+  - name: Verify untracked files with ignore-untracked-files=true does NOT have +dirty
+    runs: |
+      echo "=== TEST 4: UNTRACKED FILES, IGNORE=TRUE ==="
+      go version -m ${{targets.destdir}}/usr/bin/git-untracked-ignored-binary
+
+      if go version -m ${{targets.destdir}}/usr/bin/git-untracked-ignored-binary | grep -q "+dirty"; then
+        echo "ERROR: Untracked files with ignore=true binary contains +dirty when it shouldn't"
+        exit 1
+      else
+        echo "PASS: Untracked files with ignore=true binary correctly does not contain +dirty"
+      fi

--- a/pkg/build/pipelines/go/README.md
+++ b/pkg/build/pipelines/go/README.md
@@ -23,6 +23,7 @@ Run a build using the go compiler
 | experiments | false | A comma-separated list of Golang experiment names (ex: loopvar) to use when building the binary.  |  |
 | extra-args | false | A space-separated list of extra arguments to pass to the go build command.  |  |
 | go-package | false | The go package to install  | go |
+| ignore-untracked-files | false | If true, we will provide a gitignore that ignore all untracked files.  | true |
 | install-dir | false | Directory where binaries will be installed  | bin |
 | ldflags | false | List of [pattern=]arg to append to the go compiler with -ldflags |  |
 | modroot | false | Top directory of the go module, this is where go.mod lives. Before buiding the go pipeline wil cd into this directory.  | . |

--- a/pkg/build/pipelines/go/build.yaml
+++ b/pkg/build/pipelines/go/build.yaml
@@ -101,8 +101,21 @@ inputs:
       If true, "go mod tidy" will run before the build
     default: "false"
 
+  ignore-untracked-files:
+    description: |
+      If true, we will provide a gitignore that ignore all untracked files.
+    default: "true"
+
 pipeline:
   - runs: |
+
+      # We sometimes have stray files in our build environment
+      # That we don't neccesarily want surfaced in the build version
+      if [ "${{inputs.ignore-untracked-files}}" = "true" ]; then
+        mkdir -p ~/.config/git/
+        echo '**' > ~/.config/git/ignore
+      fi
+
       cd "${{inputs.modroot}}"
 
       # check if modroot is set correctly by checking go.mod file exist
@@ -135,3 +148,8 @@ pipeline:
       [ -e /home/build/go.sum.local ] && cp /home/build/go.sum.local go.sum
 
       GOAMD64="${{inputs.amd64}}" GOARM64="${{inputs.arm64}}" GOEXPERIMENT="${{inputs.experiments}}" go build -o "${{targets.contextdir}}"/${BASE_PATH} -tags "${{inputs.toolchaintags}},${{inputs.tags}}" -ldflags "${LDFLAGS}" -trimpath -buildmode ${{inputs.buildmode}} ${{inputs.extra-args}} ${{inputs.packages}}
+
+      # Clean up the gitignore file we created to avoid interfering with subsequent builds
+      if [ "${{inputs.ignore-untracked-files}}" = "true" ]; then
+        rm -f ~/.config/git/ignore
+      fi


### PR DESCRIPTION
… builds

Right now we have some files that are added to the build env that may cause binaries to be built with +dirty in the verison when inappropriate. This adds and option to ignore those loose files.

It doesn't cover modifications to tracked files and commits will still be appended to the version.