### PR TITLE
qemu runner: strip newline from kernel version

### DIFF
--- a/pkg/container/qemu_runner.go
+++ b/pkg/container/qemu_runner.go
@@ -532,7 +532,7 @@ func getGuestKernelVersion(ctx context.Context, cfg *Config) (version string, er
 		return "", err
 	}
 
-	return buf.String(), nil
+	return strings.TrimSpace(buf.String()), nil
 }
 
 type qemuOCILoader struct{}


### PR DESCRIPTION
The commit 4df0da8e ("qemu runner: report kernel version (#2132)") added reporting the kernel version in the QEMU guest, but I somehow managed to overlook that the trailing newline from the version string was being passed along. To fix, strip leading and trailing space before returning the kernel version string.
