### PR TITLE
sca: fix SCA for go-fips-1.25

### DIFF
--- a/pkg/sca/e2e_test.go
+++ b/pkg/sca/e2e_test.go
@@ -40,7 +40,6 @@ func TestGoFipsBinDeps(t *testing.T) {
 			"so:ld-linux-x86-64.so.2",
 			"so:libc.so.6",
 			"so:libcrypto.so.3",
-			"so:libssl.so.3",
 		},
 		Provides: []string{"cmd:go-fips-bin=0.0.1-r0"},
 	}

--- a/pkg/sca/sca.go
+++ b/pkg/sca/sca.go
@@ -132,7 +132,7 @@ func isHostProvidedLibrary(lib string) bool {
 		"libnvidia-tls.so.1",
 		"libnvoptix.so.1",
 	}
-	
+
 	for _, hostLib := range hostLibs {
 		if lib == hostLib {
 			return true
@@ -702,12 +702,14 @@ func generateSharedObjectNameDeps(ctx context.Context, hdl SCAHandle, generated 
 			if setting.Key == "GOEXPERIMENT" && slices.Contains(fipsexperiments, setting.Value) {
 				fipscrypto = true
 			}
+			if setting.Key == "microsoft_systemcrypto" && setting.Value == "1" {
+				fipscrypto = true
+			}
 		}
 		// strong indication of go-fips openssl compiled binary, will dlopen the below at runtime
 		if cgo && fipscrypto {
 			generated.Runtime = append(generated.Runtime, "openssl-config-fipshardened")
 			generated.Runtime = append(generated.Runtime, "so:libcrypto.so.3")
-			generated.Runtime = append(generated.Runtime, "so:libssl.so.3")
 		}
 
 		return nil


### PR DESCRIPTION
Ensure that Melange SCA generates depends for packages that use the
new go-msft-1.25 toolchain.

Tried to create a test case for this, but failed in:
- https://github.com/chainguard-dev/melange/pull/2152

It would require enterprise-packages access which is not great.

Separately test cases are available as, currently:
- 1.24 works https://github.com/chainguard-dev/enterprise-packages/pull/33090
- 1.25 doesn't https://github.com/chainguard-dev/enterprise-packages/pull/33091

And with this PR both should start working again.

Suggestions on how to make test cases work are welcomed to catch this.

My plan is to add SCA check to go-msft packages themselves, such that it breaks when there are changes to build-info in the future:
- https://github.com/chainguard-dev/enterprise-packages/pull/32952

Also note that libssl.so is unused, and only libcrypto is dlopened.