### PR TITLE
Qemu runner: debug initial connection

### DIFF
--- a/pkg/container/qemu_runner.go
+++ b/pkg/container/qemu_runner.go
@@ -1158,7 +1158,7 @@ func generateDiskFile(ctx context.Context, diskSize string) (string, error) {
 // this avoids the ssh client trying to connect on a booting server.
 func checkSSHServer(address string) error {
 	// Establish a connection to the address
-	conn, err := net.DialTimeout("tcp", address, 50*time.Millisecond)
+	conn, err := net.DialTimeout("tcp", address, 150*time.Millisecond)
 	if err != nil {
 		return fmt.Errorf("dial: %w", err)
 	}


### PR DESCRIPTION
We are seeing some build failures in production where melange does not 
appear to be able to get the openssh protocol version string to know
that the ssh service has successfully started, though log messages
indicate that the ssh daemon has started enough to notice melange's
attempts to make initial contact.

To try to address this there are two separate changes here:
- bump the logging level from debug to info on the error message when the initial ssh check fails
- increase the connection Dial timeout from 50ms to 150ms to see if resource contention is causing the initial detection that the ssh daemon is started to fail

These are created independently so that if we'd like to cherrypick one or the other, we can do so.