### PR TITLE
qemu runner: make virtfs 9p bindings read-only

### DIFF
--- a/pkg/container/qemu_runner.go
+++ b/pkg/container/qemu_runner.go
@@ -707,11 +707,11 @@ func createMicroVM(ctx context.Context, cfg *Config) error {
 	// kill all performances (lots of small files)
 	// instead we will copy back the finished workspace artifacts when done.
 	// this dramatically improves compile time, making them comparable to bwrap or docker runners.
-	baseargs = append(baseargs, "-fsdev", "local,security_model=mapped,id=fsdev100,path="+cfg.WorkspaceDir)
+	baseargs = append(baseargs, "-fsdev", "local,security_model=mapped,id=fsdev100,readonly=on,path="+cfg.WorkspaceDir)
 	baseargs = append(baseargs, "-device", "virtio-9p-pci,id=fs100,fsdev=fsdev100,mount_tag=defaultshare")
 
 	if cfg.CacheDir != "" {
-		baseargs = append(baseargs, "-fsdev", "local,security_model=mapped,id=fsdev101,path="+cfg.CacheDir)
+		baseargs = append(baseargs, "-fsdev", "local,security_model=mapped,id=fsdev101,readonly=on,path="+cfg.CacheDir)
 		baseargs = append(baseargs, "-device", "virtio-9p-pci,id=fs101,fsdev=fsdev101,mount_tag=melange_cache")
 
 		// ensure the cachedir exists
@@ -881,7 +881,7 @@ func createMicroVM(ctx context.Context, cfg *Config) error {
 	if cfg.CacheDir != "" {
 		clog.FromContext(ctx).Infof("qemu: setting up melange cachedir: %s", cfg.CacheDir)
 		setupMountCommand := fmt.Sprintf(
-			"mkdir -p %s %s /mount/upper /mount/work && mount -t 9p melange_cache %s && "+
+			"mkdir -p %s %s /mount/upper /mount/work && mount -t 9p -o ro melange_cache %s && "+
 				"mount -t overlay overlay -o lowerdir=%s,upperdir=/mount/upper,workdir=/mount/work %s",
 			DefaultCacheDir,
 			filepath.Join("/mount", DefaultCacheDir),


### PR DESCRIPTION
The QEMU runner uses virtfs 9p mount bindings to inject some artifacts into the build environment, but unlike the docker and bubblewrap runners, does not use any bind mounts to extract out artifacts to produce apks; instead tar over ssh is used for artifact extraction.

Thus, to reduce risk of a malicious build being able to write artifacts outside of the QEMU guest, make the virtfs 9p bindings be read-only. (There has also has been at least one vulnerability the virtfs 9p implementation that allowed writes outside of the specified path.)

Note that in order for this to land, a [change to the microvm-init package in wolfi-dev/os]( **must** land that removes a chmod that happens on the workspace directory (`/mount/mnt`) or else builds will fail.

My longer term plan is to drop the use of the 9p virtfs mounts entirely in the QEMU runner and inject per-package additions through other means, to reduce the mechanisms that the QEMU guest can influence the hosting melange environment.