### PR TITLE
fix(user accounts): don't crash if user is specified without a gid

### DIFF
--- a/e2e-tests/accounts-nonstd-non-root-no-guid-build-test.yaml
+++ b/e2e-tests/accounts-nonstd-non-root-no-guid-build-test.yaml
@@ -1,0 +1,135 @@
+# test that packages / subpackages build and test as added non-root user
+# when specified in the build configuration and that if the gid is not
+# specified for the user, melange will fall back to using a gid == uid.
+package:
+  name: accounts-nonstd-non-root-no-guid-build-test
+  description: Test that specifying non-root builds happen as non-root
+  version: 0.1.0
+  epoch: 0
+environment:
+  contents:
+    packages:
+      - busybox
+  accounts:
+    users:
+      - username: nonroot
+        uid: 12345
+    groups:
+      - groupname: nongroup
+        gid: 12346
+      - groupname: unprivileged
+        gid: 12345
+    run-as: nonroot
+pipeline:
+  - uses: check-accounts
+    with:
+      expected_uid: 12345
+      expected_username: nonroot
+      expected_gid: 12345
+      expected_groupname: unprivileged
+subpackages:
+  - name: accounts-nonstd-non-root-build-no-guid-subpackage-test
+    description: test that specifying non-root subpackage builds happen as non-root
+    pipeline:
+      - uses: check-accounts
+        with:
+          expected_uid: 12345
+          expected_username: nonroot
+          expected_gid: 12345
+          expected_groupname: unprivileged
+    test:
+      environment:
+        contents:
+          packages:
+            - busybox
+        accounts:
+          run-as: nonroot
+          users:
+            - username: nonroot
+              uid: 12345
+          groups:
+            - groupname: nongroup
+              gid: 12346
+            - groupname: unprivileged
+              gid: 12345
+      pipeline:
+        - uses: check-accounts
+          with:
+            expected_uid: 12345
+            expected_username: nonroot
+            expected_gid: 12345
+            expected_groupname: unprivileged
+  - name: accounts-nonstd-non-root-build-no-guid-subpackage-root-user-test
+    description: test that when specifying root at the top-level, subpackage tests can be performed as root user
+    # Note: melange does not seem to support specifying a different user in
+    # a subpackage build, so don't do anything in this subpackage's
+    # build phase
+    test:
+      environment:
+        contents:
+          packages:
+            - busybox
+        accounts:
+          # test environments should have the root user (uid=0) created by default
+          run-as: root
+          users:
+            - username: nonroot
+              uid: 12345
+          groups:
+            - groupname: nongroup
+              gid: 12346
+            - groupname: unprivileged
+              gid: 12345
+      pipeline:
+        - uses: check-accounts
+          with:
+            expected_uid: 0
+            expected_username: root
+            expected_gid: 0
+            expected_groupname: root
+  - name: accounts-nonstd-non-root-build-no-guid-subpackage-build-user-test
+    description: test that when specifying root at the top-level, subpackage tests can be performed as build user
+    test:
+      environment:
+        contents:
+          packages:
+            - busybox
+        accounts:
+          run-as: build
+          users:
+            - username: nonroot
+              uid: 12345
+          groups:
+            - groupname: nongroup
+              gid: 12346
+            - groupname: unprivileged
+              gid: 12345
+      pipeline:
+        - uses: check-accounts
+          with:
+            expected_uid: 1000
+            expected_username: build
+            expected_gid: 1000
+            expected_groupname: build
+test:
+  environment:
+    contents:
+      packages:
+        - busybox
+    accounts:
+      run-as: nonroot
+      users:
+        - username: nonroot
+          uid: 12345
+      groups:
+        - groupname: nongroup
+          gid: 12346
+        - groupname: unprivileged
+          gid: 12345
+  pipeline:
+    - uses: check-accounts
+      with:
+        expected_uid: 12345
+        expected_username: nonroot
+        expected_gid: 12345
+        expected_groupname: unprivileged

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -1096,18 +1096,22 @@ func runAsGID(accts apko_types.ImageAccounts) string {
 	}
 	if uid, err := strconv.Atoi(accts.RunAs); err == nil {
 		for _, u := range accts.Users {
-			if u.UID == uint32(uid) {
+			if u.UID == uint32(uid) && u.GID != nil {
 				return fmt.Sprint(*u.GID)
 			}
 		}
 	} else {
 		for _, u := range accts.Users {
-			if accts.RunAs == u.UserName {
+			if accts.RunAs == u.UserName && u.GID != nil {
 				return fmt.Sprint(*u.GID)
 			}
 		}
 	}
-	panic(fmt.Sprintf("unable to find gid for user with username %s", accts.RunAs))
+
+	// Couldn't find group membership, return empty string to use Runner defaults
+	// TODO(stevebeattie): we should probably log this fact, but we
+	// don't have the context to do so
+	return ""
 }
 
 func (b *Build) buildWorkspaceConfig(ctx context.Context) *container.Config {


### PR DESCRIPTION
Under the bubblewrap runner, if a user was added to run the build under, melange would always set the gid to be the same as the uid of the user, including in the case when no gid was given for the user account. However, as part of https://github.com/chainguard-dev/melange/pull/2138 , commit a3612ee ("bubblewrap: when running as custom UID, use corrsponding GID") modified the bubblewrap runner to attempt to look up the primary gid of the user the build was set to run as. However, that lookup did not take into account the possibility that no gid was configured, and thus would cause melange to segfault, as identified in the followup comment to the above PR: https://github.com/chainguard-dev/melange/pull/2138#issuecomment-3275304078

Fix this by falling back to the old behavior when no gid is specified for the user account the build is running as, and add an e2e test yaml for this situation. Both the bubblewrap and qemu runners now use the same behavior in this situation.