### PR TITLE
R build pipeline improvements

### DIFF
--- a/pkg/build/pipelines/R/build.yaml
+++ b/pkg/build/pipelines/R/build.yaml
@@ -4,6 +4,7 @@ needs:
   packages:
     - R
     - R-dev
+    - R-doc
     - busybox
 
 inputs:

--- a/pkg/build/pipelines/R/build.yaml
+++ b/pkg/build/pipelines/R/build.yaml
@@ -25,11 +25,7 @@ inputs:
 pipeline:
   - runs: |
       # Use default R library path
-      mkdir -p /usr/lib/R/library
       mkdir -p ${{targets.contextdir}}/usr/lib/R/library
 
       # Build R package from source
-      Rscript -e 'install.packages("${{inputs.path}}", repos = NULL, type = "source")'
-
-      # Install package
-      mv /usr/lib/R/library/${{inputs.package}} ${{targets.contextdir}}/usr/lib/R/library/
+      Rscript -e 'install.packages("${{inputs.path}}", lib = "${{targets.contextdir}}/usr/lib/R/library/", repos = NULL, type = "source")'


### PR DESCRIPTION
This pull request improves the R/build pipeline in melange in a couple of ways:

1. The The melange R/build pipeline would invoke the R build install process in
   a way that caused the R package being built to be installed into
   `/usr/lib/R/library` and then moved into the melange staging directory.
   This is both inefficient and breaks building packages with a non-root
   user that does not have the privilege to write to system directories.

   Fix this by adjusting the install.packages Rscript call to point to the
   melange staging area directly.

2. R library packages issue warnings at build time when installing their
   stub html help documents:
   ```
    *** installing help indices
    Warning in file.copy(file.path(R.home("doc"), "html", "R.css"), outman) :
    problem copying /usr/share/doc/R/html/R.css to /home/build/melange-out/Rcpp/usr/lib/R/library/00LOCK-build/00new/Rcpp/html/R.css: No such file or directory
   ```
   This is because the `R.css` file is provided by the R-doc package.

   Fix this by adding the `R-doc` package as a default build-time dependency
   for packages using the R/build pipeline.

### Functional Changes

Notes: performed builds and tests against all packages that uses the R/build pipeline in Wolfi under both the qemu and bubblewrap runners, with no failures. Checking the built packages against the existing versions showed no dropped or moved files and the added `R.css` file getting incorporated correctly.
