### PR TITLE
cmake pipeline: add verbosty to cmake/install

### DIFF
--- a/pkg/build/pipelines/cmake/install.yaml
+++ b/pkg/build/pipelines/cmake/install.yaml
@@ -13,4 +13,4 @@ inputs:
 
 pipeline:
   - runs: |
-      DESTDIR="${{targets.contextdir}}" cmake --install ${{inputs.output-dir}}
+      VERBOSE=1 DESTDIR="${{targets.contextdir}}" cmake --install "${{inputs.output-dir}}"


### PR DESCRIPTION
When debugging behaviors in the install phase of a build, it's useful to have verbose output.

Also, quote the directory name argument to cmake --install
