### PR TITLE
qemu runner: open permissions on melange cache upper overlay

### DIFF
--- a/e2e-tests/pipelines/check-accounts.yaml
+++ b/e2e-tests/pipelines/check-accounts.yaml
@@ -37,3 +37,7 @@ pipeline:
     runs: mktemp -p "${HOME}"
   - name: ensure we can write to our default dir
     runs: mktemp -p .
+  - name: ensure we can write to the melange cache overlay directory
+    # the melange cache overlay is only mounted in build pipelines. not
+    # test pipelines so only perform the test if the directory exists
+    runs: test ! -d /var/cache/melange || mktemp -p /var/cache/melange

--- a/pkg/container/qemu_runner.go
+++ b/pkg/container/qemu_runner.go
@@ -881,7 +881,9 @@ func createMicroVM(ctx context.Context, cfg *Config) error {
 	if cfg.CacheDir != "" {
 		clog.FromContext(ctx).Infof("qemu: setting up melange cachedir: %s", cfg.CacheDir)
 		setupMountCommand := fmt.Sprintf(
-			"mkdir -p %s %s /mount/upper /mount/work && mount -t 9p melange_cache %s && "+
+			"mkdir -p %s %s /mount/upper /mount/work && "+
+				"chmod 1777 /mount/upper && "+
+				"mount -t 9p melange_cache %s && "+
 				"mount -t overlay overlay -o lowerdir=%s,upperdir=/mount/upper,workdir=/mount/work %s",
 			DefaultCacheDir,
 			filepath.Join("/mount", DefaultCacheDir),


### PR DESCRIPTION
As part of supporting non-root builds in the qemu runner, make the upper portion of the melange_cache mount overlay be world writable with the sticky bit set to act similar to a tmpdir. This way non-root builds can write to the overlay. Also add a check that this directory is writable during builds in the e2e account tests.

(Because of the overlay, these permissions and writes will not propagate through to the underlying mounted filesystem from the host.)

Also reformat the injected sequence of commands to make them more human readable.
