### PR TITLE
Include subpackage source data in sboms

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -769,6 +769,20 @@ func (b *Build) BuildPackage(ctx context.Context) error {
 			if err := pr.runPipelines(ctx, sp.Pipeline); err != nil {
 				return fmt.Errorf("unable to run subpackage %s pipeline: %w", sp.Name, err)
 			}
+
+			// Populate SBOM data for the subpackage.
+			for i, p := range sp.Pipeline {
+				uniqueID := strconv.Itoa(i)
+				pkg, err := p.SBOMPackageForUpstreamSource(b.Configuration.Package.LicenseExpression(), namespace, uniqueID)
+				if err != nil {
+					return fmt.Errorf("creating SBOM package for upstream source: %w", err)
+				}
+				if pkg == nil {
+					// This particular pipeline step doesn't tell us about the upstream source code.
+					continue
+				}
+				b.SBOMGroup.Document(sp.Name).AddUpstreamSourcePackage(pkg)
+			}
 		}
 
 		// add the subpackage to the linter queue

--- a/pkg/build/sbom_group.go
+++ b/pkg/build/sbom_group.go
@@ -61,7 +61,6 @@ func (sg *SBOMGroup) AddBuildConfigurationPackage(p *sbom.Package) {
 // package" to all SBOMs in the group.
 func (sg *SBOMGroup) AddUpstreamSourcePackage(p *sbom.Package) {
 	for _, doc := range sg.set {
-		doc.AddPackage(p)
-		doc.AddRelationship(doc.Describes, p, common.TypeRelationshipGeneratedFrom)
+		doc.AddUpstreamSourcePackage(p)
 	}
 }

--- a/pkg/build/sbom_group_test.go
+++ b/pkg/build/sbom_group_test.go
@@ -1,0 +1,242 @@
+package build
+
+import (
+	"testing"
+
+	"chainguard.dev/melange/pkg/sbom"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	purl "github.com/package-url/packageurl-go"
+)
+
+func TestSBOMGroup_SubpackageUpstreamSource(t *testing.T) {
+	// Create a mock SBOM group with a main package and a subpackage
+	sg := NewSBOMGroup("main-pkg", "sub-pkg")
+	if sg == nil {
+		t.Fatal("expected SBOMGroup to be created")
+	}
+
+	mainDoc := sg.Document("main-pkg")
+	subDoc := sg.Document("sub-pkg")
+
+	// Set up the described packages for each document
+	mainPkg := sbom.Package{
+		Name:      "main-pkg",
+		Version:   "1.0.0",
+		Namespace: "test",
+	}
+	mainDoc.AddPackageAndSetDescribed(&mainPkg)
+
+	subPkg := sbom.Package{
+		Name:      "sub-pkg",
+		Version:   "1.0.0",
+		Namespace: "test",
+	}
+	subDoc.AddPackageAndSetDescribed(&subPkg)
+
+	// Create an upstream source package for the main package
+	mainPURL := purl.PackageURL{
+		Type:      purl.TypeGithub,
+		Namespace: "chainguard-dev",
+		Name:      "melange",
+		Version:   "abc123",
+	}
+	mainUpstream := sbom.Package{
+		Name:             "melange",
+		Version:          "abc123",
+		LicenseDeclared:  "Apache-2.0",
+		Namespace:        "chainguard-dev",
+		PURL:             &mainPURL,
+		DownloadLocation: "https://github.com/chainguard-dev/melange/archive/abc123.tar.gz",
+	}
+
+	// Add upstream source to ALL documents (old behavior)
+	sg.AddUpstreamSourcePackage(&mainUpstream)
+
+	// Create a subpackage-specific upstream source package
+	subPURL := purl.PackageURL{
+		Type:      purl.TypeGithub,
+		Namespace: "wolfi-dev",
+		Name:      "os",
+		Version:   "def456",
+	}
+	subUpstream := sbom.Package{
+		Name:             "os",
+		Version:          "def456",
+		LicenseDeclared:  "Apache-2.0",
+		Namespace:        "wolfi-dev",
+		PURL:             &subPURL,
+		DownloadLocation: "https://github.com/wolfi-dev/os/archive/def456.tar.gz",
+	}
+
+	// Add to the subpackage SBOM only (new behavior)
+	subDoc.AddUpstreamSourcePackage(&subUpstream)
+
+	// Table-driven verification of final state
+	tests := []struct {
+		name        string
+		doc         *sbom.Document
+		expectedDoc *sbom.Document
+	}{
+		{
+			name: "main doc has only main upstream source",
+			doc:  mainDoc,
+			expectedDoc: &sbom.Document{
+				Describes: &mainPkg,
+				Packages: []sbom.Package{
+					mainPkg,
+					mainUpstream,
+				},
+				Relationships: mainDoc.Relationships,
+			},
+		},
+		{
+			name: "sub doc has both upstream sources",
+			doc:  subDoc,
+			expectedDoc: &sbom.Document{
+				Describes: &subPkg,
+				Packages: []sbom.Package{
+					subPkg,
+					mainUpstream,
+					subUpstream,
+				},
+				Relationships: subDoc.Relationships,
+			},
+		},
+	}
+
+	sortPackages := cmpopts.SortSlices(func(a, b sbom.Package) bool {
+		return a.Name < b.Name
+	})
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if diff := cmp.Diff(tt.expectedDoc, tt.doc, sortPackages); diff != "" {
+				t.Errorf("document mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestSBOMGroup_NewGroup(t *testing.T) {
+	tests := []struct {
+		name     string
+		pkgNames []string
+	}{
+		{
+			name:     "single package",
+			pkgNames: []string{"test-pkg"},
+		},
+		{
+			name:     "multiple packages",
+			pkgNames: []string{"main-pkg", "sub1-pkg", "sub2-pkg"},
+		},
+		{
+			name:     "no packages",
+			pkgNames: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sg := NewSBOMGroup(tt.pkgNames...)
+			if sg == nil {
+				t.Fatal("expected SBOMGroup to be created")
+			}
+			if sg.set == nil {
+				t.Fatal("expected SBOMGroup.set to be initialized")
+			}
+
+			for _, name := range tt.pkgNames {
+				doc := sg.Document(name)
+				if doc == nil {
+					t.Errorf("document for package %s should not be nil", name)
+				}
+			}
+		})
+	}
+}
+
+func TestSBOMGroup_AddBuildConfigurationPackage(t *testing.T) {
+	sg := NewSBOMGroup("main-pkg", "sub-pkg")
+
+	// Set up the described packages for each document
+	mainDoc := sg.Document("main-pkg")
+	subDoc := sg.Document("sub-pkg")
+
+	mainPkg := sbom.Package{
+		Name:      "main-pkg",
+		Version:   "1.0.0",
+		Namespace: "test",
+	}
+	mainDoc.AddPackageAndSetDescribed(&mainPkg)
+
+	subPkg := sbom.Package{
+		Name:      "sub-pkg",
+		Version:   "1.0.0",
+		Namespace: "test",
+	}
+	subDoc.AddPackageAndSetDescribed(&subPkg)
+
+	buildCfgPURL := purl.PackageURL{
+		Type:      purl.TypeGithub,
+		Namespace: "wolfi-dev",
+		Name:      "os",
+		Version:   "c0ffee",
+		Subpath:   "test.yaml",
+	}
+	buildCfgPkg := sbom.Package{
+		Name:            "test.yaml",
+		Version:         "c0ffee",
+		LicenseDeclared: "Apache-2.0",
+		Namespace:       "wolfi-dev",
+		PURL:            &buildCfgPURL,
+	}
+
+	// Add build config package to all SBOMs
+	sg.AddBuildConfigurationPackage(&buildCfgPkg)
+
+	// Table-driven verification
+	tests := []struct {
+		name     string
+		doc      *sbom.Document
+		expected *sbom.Document
+	}{
+		{
+			name: "main doc has build config",
+			doc:  mainDoc,
+			expected: &sbom.Document{
+				Describes: &mainPkg,
+				Packages: []sbom.Package{
+					mainPkg,
+					buildCfgPkg,
+				},
+				Relationships: mainDoc.Relationships,
+			},
+		},
+		{
+			name: "sub doc has build config",
+			doc:  subDoc,
+			expected: &sbom.Document{
+				Describes: &subPkg,
+				Packages: []sbom.Package{
+					subPkg,
+					buildCfgPkg,
+				},
+				Relationships: subDoc.Relationships,
+			},
+		},
+	}
+
+	sortPackages := cmpopts.SortSlices(func(a, b sbom.Package) bool {
+		return a.Name < b.Name
+	})
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if diff := cmp.Diff(tt.expected, tt.doc, sortPackages); diff != "" {
+				t.Errorf("document mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/sbom/document.go
+++ b/pkg/sbom/document.go
@@ -10,6 +10,7 @@ import (
 	apko_build "chainguard.dev/apko/pkg/build"
 	"chainguard.dev/apko/pkg/sbom/generator/spdx"
 	"github.com/chainguard-dev/clog"
+	"github.com/spdx/tools-golang/spdx/v2/common"
 	"sigs.k8s.io/release-utils/version"
 )
 
@@ -141,4 +142,9 @@ func (d *Document) AddRelationship(a, b Element, typ string) {
 		Related: b.ID(),
 		Type:    typ,
 	})
+}
+
+func (d *Document) AddUpstreamSourcePackage(p *Package) {
+	d.AddPackage(p)
+	d.AddRelationship(d.Describes, p, common.TypeRelationshipGeneratedFrom)
 }


### PR DESCRIPTION
## Melange Pull Request Template

<!--
*** PULL REQUEST CHECKLIST: PLEASE START HERE ***

The single most important feature of melange is that we can build Wolfi.

Many changes to melange introduce a risk of breaking the build, and sometimes
these are not flushed out until a package is changed (much) later.  This
pertains to basic execution, SCA changes, linter changes, and more.
-->

### Functional Changes

We do not re-process source package from subpackages, so if any fetch additional data this is missed in the SBOM.

This fixes that to iterate over each sub-pipeline and do a similar check.

There may be additional refactoring to do here since the main pipeline execution is very similar to subpackage pipeline execution, but that's likely something we want to target in another PR.

- [ ] This change can build all of Wolfi without errors (describe results in notes)

Notes:

### SCA Changes

- [x] Examining several representative APKs show no regression / the desired effect (details in notes)

Notes: tried on new sample package, subpackage git-checkout populates as expected. 👍 
