### PR TITLE
pipelines: add new split/docs pipeline

### DIFF
--- a/pkg/build/pipelines/split/README.md
+++ b/pkg/build/pipelines/split/README.md
@@ -1,3 +1,4 @@
+
 <!-- start:pipeline-reference-gen -->
 # Pipeline Reference
 
@@ -5,6 +6,7 @@
 - [split/bin](#splitbin)
 - [split/debug](#splitdebug)
 - [split/dev](#splitdev)
+- [split/docs](#splitdocs)
 - [split/infodir](#splitinfodir)
 - [split/locales](#splitlocales)
 - [split/manpages](#splitmanpages)
@@ -39,6 +41,16 @@ Split development files
 | Name | Required | Description | Default |
 | ---- | -------- | ----------- | ------- |
 | package | false | The package to split development files from  |  |
+
+## split/docs
+
+Split docs
+
+### Inputs
+
+| Name | Required | Description | Default |
+| ---- | -------- | ----------- | ------- |
+| package | false | The package to split docs from  |  |
 
 ## split/infodir
 

--- a/pkg/build/pipelines/split/docs.yaml
+++ b/pkg/build/pipelines/split/docs.yaml
@@ -1,0 +1,34 @@
+name: Split docs
+
+needs:
+  packages:
+    - busybox
+
+inputs:
+  package:
+    description: |
+      The package to split docs from
+    required: false
+
+pipeline:
+  - runs: |
+      PACKAGE_DIR="${{targets.destdir}}"
+      if [ -n "${{inputs.package}}" ]; then
+        PACKAGE_DIR="${{targets.outdir}}/${{inputs.package}}"
+      fi
+
+      if [ "$PACKAGE_DIR" = "${{targets.contextdir}}" ]; then
+        echo "ERROR: Package can not split files from itself!"
+        exit 1
+      fi
+
+      for docdir in \
+        "$PACKAGE_DIR/usr/share/doc" \
+        "$PACKAGE_DIR/usr/local/share/doc"; do
+
+        if [ -d "$docdir" ]; then
+          mkdir -p "${{targets.contextdir}}/usr/share/doc"
+          mv "$docdir"/* "${{targets.contextdir}}/usr/share/doc/"
+          rmdir --parents --ignore-fail-on-non-empty "$docdir"
+        fi
+      done


### PR DESCRIPTION
A fork of the split/manpages one, specifically configured to work on other docs from /usr/share/doc and friends.