### PR TITLE
pipelines: add split/alldocs

### DIFF
--- a/pkg/build/pipelines/split/README.md
+++ b/pkg/build/pipelines/split/README.md
@@ -2,6 +2,7 @@
 # Pipeline Reference
 
 
+- [split/alldocs](#splitalldocs)
 - [split/bin](#splitbin)
 - [split/debug](#splitdebug)
 - [split/dev](#splitdev)
@@ -9,6 +10,16 @@
 - [split/locales](#splitlocales)
 - [split/manpages](#splitmanpages)
 - [split/static](#splitstatic)
+
+## split/alldocs
+
+Split all docs
+
+### Inputs
+
+| Name | Required | Description | Default |
+| ---- | -------- | ----------- | ------- |
+| package | false | The package to split all docs from  |  |
 
 ## split/bin
 

--- a/pkg/build/pipelines/split/alldocs.yaml
+++ b/pkg/build/pipelines/split/alldocs.yaml
@@ -1,0 +1,56 @@
+name: Split all docs
+
+needs:
+  packages:
+    - busybox
+
+inputs:
+  package:
+    description: |
+      The package to split all docs from
+    required: false
+
+pipeline:
+  - name: "split all docs"
+    runs: |
+      PACKAGE_DIR="${{targets.destdir}}"
+      if [ -n "${{inputs.package}}" ]; then
+        PACKAGE_DIR="${{targets.outdir}}/${{inputs.package}}"
+      fi
+
+      if [ "$PACKAGE_DIR" = "${{targets.contextdir}}" ]; then
+        echo "ERROR: Package can not split files from itself!"
+        exit 1
+      fi
+
+      # info dir
+      if [ -d "$PACKAGE_DIR/usr/share/info" ]; then
+        rm -f "$PACKAGE_DIR"/usr/share/info/dir
+
+        mkdir -p "${{targets.contextdir}}/usr/share"
+        mv "$PACKAGE_DIR"/usr/share/info "${{targets.contextdir}}/usr/share"
+      fi
+
+      # man pages
+      for mandir in \
+        "$PACKAGE_DIR/usr/share/man" \
+        "$PACKAGE_DIR/usr/local/share/man" \
+        "$PACKAGE_DIR/usr/man"; do
+
+        if [ -d "$mandir" ]; then
+          mkdir -p "${{targets.contextdir}}/usr/share/man"
+          mv "$mandir"/* "${{targets.contextdir}}/usr/share/man/"
+          rmdir --parents --ignore-fail-on-non-empty "$mandir"
+        fi
+      done
+
+      # other docs
+      for docdir in \
+        "$PACKAGE_DIR/usr/share/doc" \
+        "$PACKAGE_DIR/usr/local/share/doc"; do
+        if [ -d "$docdir" ]; then
+          mkdir -p "${{targets.contextdir}}/usr/share/doc"
+          mv "$docdir"/* "${{targets.contextdir}}/usr/share/doc/"
+          rmdir --parents --ignore-fail-on-non-empty "$docdir"
+        fi
+      done


### PR DESCRIPTION
Add new pipeline that contains all logic for dealing with APK docs.

Over time, as we adopt this new pipeline, we would be able to drop both
the split/infodir and split/manpages pipelines.

Signed-off-by: Arturo Borrero Gonzalez <arturo.borrero@chainguard.dev>
