### PR TITLE
Allow for ignored license paths to be overridden when checking for duplicate files

### DIFF
--- a/pkg/container/qemu_runner.go
+++ b/pkg/container/qemu_runner.go
@@ -1035,7 +1035,7 @@ func getWorkspaceLicenseFiles(ctx context.Context, cfg *Config, extraFiles []str
 		if strings.Contains(f, "melange-out") {
 			continue
 		}
-		if is, _ := license.IsLicenseFile(f); is {
+		if is, _ := license.IsLicenseFile(f, false); is {
 			licenseFiles = append(licenseFiles, f)
 		}
 	}

--- a/pkg/license/license.go
+++ b/pkg/license/license.go
@@ -143,7 +143,7 @@ func FindLicenseFiles(fsys fs.FS) ([]LicenseFile, error) {
 			return nil
 		}
 
-		is, weight := IsLicenseFile(filePath)
+		is, weight := IsLicenseFile(filePath, false)
 		if is {
 			// Licenses in the top level directory have a higher weight so that they
 			// always appear first
@@ -175,7 +175,10 @@ func FindLicenseFiles(fsys fs.FS) ([]LicenseFile, error) {
 // IsLicenseFile checks if a file is a license file based on its name.
 // Returns true/fals if the file is a license file, and the weight value
 // associated with the match, as some matches are potentially more relevant.
-func IsLicenseFile(filename string) (bool, float64) {
+// overrideIgnore skips over ignored paths to allow linters
+// to correctly determine whether a path is a valid license file
+// (e.g., to avoid listing each instance of a given LICENSE file as a duplicate)
+func IsLicenseFile(filename string, overrideIgnore bool) (bool, float64) {
 	// Ignore files in these paths
 
 	// Packages like Rust embed the semver in certain paths, so replace the segment with `-`
@@ -191,9 +194,11 @@ func IsLicenseFile(filename string) (bool, float64) {
 		"rustc-src",
 		"venv",
 	}
-	for _, i := range ignoredPaths {
-		if slices.Contains(strings.Split(filename, string(filepath.Separator)), i) {
-			return false, 0.0
+	if !overrideIgnore {
+		for _, i := range ignoredPaths {
+			if slices.Contains(strings.Split(filename, string(filepath.Separator)), i) {
+				return false, 0.0
+			}
 		}
 	}
 

--- a/pkg/linter/linter.go
+++ b/pkg/linter/linter.go
@@ -490,7 +490,7 @@ func duplicateLinter(ctx context.Context, _ *config.Configuration, _ string, fsy
 
 		basename := filepath.Base(path)
 
-		if isLicense, _ := license.IsLicenseFile(path); isLicense {
+		if isLicense, _ := license.IsLicenseFile(path, true); isLicense {
 			return nil
 		}
 


### PR DESCRIPTION
Small follow-up for #2192.

When we check whether a provided file is a license file, we have a list of paths that will automatically return false which results in, for example, a linter thinking that the files are not valid license files.

For now, we do not want to consider multiple license files of the same name and contents as duplicates so this PR adds a toggle that will allow us to opt-out of this behavior for the `duplicateLinter` while leaving the behavior unchanged elsewhere.