### PR TITLE
fetch pipeline: don't adjust ownership when untarring as root

### DIFF
--- a/pkg/build/pipelines/fetch.yaml
+++ b/pkg/build/pipelines/fetch.yaml
@@ -109,7 +109,7 @@ pipeline:
       fi
 
       if [ "${{inputs.extract}}" = "true" ]; then
-        tar -x '--strip-components=${{inputs.strip-components}}' -C '${{inputs.directory}}' -f $bn
+        tar -x '--strip-components=${{inputs.strip-components}}' --no-same-owner -C '${{inputs.directory}}' -f $bn
       fi
 
       if [ "${{inputs.delete}}" = "true" ]; then


### PR DESCRIPTION
When trying to compensate for defaulting to perform qemu builds as non-root by default, some packages perform operations that need to be root privileges in qemu, like setting filesystem capabilities. However, running as root can cause a failure if the build is performed under the bubblewrap runner when using the fetch pipeline to pull and untar a tarball that has contents that are owned by non-root uids; see the failed aarch64 build in https://github.com/wolfi-dev/os/pull/69787 for example:

```
2025-10-22 18:06:40.247 tar: nginx-1.25.5/man/nginx.8: Cannot change ownership to uid 502, gid 20: Invalid argument
2025-10-22 18:06:40.247 tar: nginx-1.25.5: Cannot change ownership to uid 502, gid 20: Invalid argument
2025-10-22 18:06:40.247 tar: Exiting with failure status due to previous errors
```

This is a similar problem that was addressed for the git fetch pipeline in https://github.com/chainguard-dev/melange/pull/1893

Fix this here by passing `--no-same-owner` to tar in the fetch pipeline.

## Melange Pull Request Template

<!--
*** PULL REQUEST CHECKLIST: PLEASE START HERE ***

The single most important feature of melange is that we can build Wolfi.

Many changes to melange introduce a risk of breaking the build, and sometimes
these are not flushed out until a package is changed (much) later.  This
pertains to basic execution, SCA changes, linter changes, and more.
-->

### Functional Changes

- [ ] This change can build all of Wolfi without errors (describe results in notes)

Notes:

Have confirmed that root and non-root builds using fetch for a tarball that contains non-root uid ownership of files succeeds under both bubblewrap and qemu. Have not done a full wolfi rebuild.

