### PR TITLE
fix: add --generate-provenance to compile command

### DIFF
--- a/docs/md/melange_compile.md
+++ b/docs/md/melange_compile.md
@@ -43,6 +43,7 @@ melange compile [flags]
       --env-file string             file to use for preloaded environment variables
       --fail-on-lint-warning        turns linter warnings into failures
       --generate-index              whether to generate APKINDEX.tar.gz (default true)
+      --generate-provenance         generate SLSA provenance for builds (included in a separate .attest.tar.gz file next to the APK)
       --git-commit string           commit hash of the git repository containing the build config file (defaults to detecting HEAD)
       --git-repo-url string         URL of the git repository containing the build config file (defaults to detecting from configured git remotes)
   -h, --help                        help for compile

--- a/pkg/cli/compile.go
+++ b/pkg/cli/compile.go
@@ -65,6 +65,7 @@ func compile() *cobra.Command {
 	var configFileGitCommit string
 	var configFileGitRepoURL string
 	var configFileLicense string
+	var generateProvenance bool
 
 	cmd := &cobra.Command{
 		Use:     "compile",
@@ -136,6 +137,7 @@ func compile() *cobra.Command {
 				build.WithConfigFileRepositoryCommit(configFileGitCommit),
 				build.WithConfigFileRepositoryURL(configFileGitRepoURL),
 				build.WithConfigFileLicense(configFileLicense),
+				build.WithGenerateProvenance(generateProvenance),
 			}
 
 			if len(args) > 0 {
@@ -201,6 +203,7 @@ func compile() *cobra.Command {
 	cmd.Flags().StringVar(&cpu, "cpu", "", "default CPU resources to use for builds")
 	cmd.Flags().StringVar(&memory, "memory", "", "default memory resources to use for builds")
 	cmd.Flags().DurationVar(&timeout, "timeout", 0, "default timeout for builds")
+	cmd.Flags().BoolVar(&generateProvenance, "generate-provenance", false, "generate SLSA provenance for builds (included in a separate .attest.tar.gz file next to the APK)")
 
 	cmd.Flags().StringVar(&configFileGitCommit, "git-commit", "", "commit hash of the git repository containing the build config file (defaults to detecting HEAD)")
 	cmd.Flags().StringVar(&configFileGitRepoURL, "git-repo-url", "", "URL of the git repository containing the build config file (defaults to detecting from configured git remotes)")


### PR DESCRIPTION
The [new](https://github.com/wolfi-dev/os/pull/60278), streamlined authentication in Wolfi now runs `melange compile` initially which does not support the `--generate-provenance` flag.

This is currently breaking our CI which runs `make package/foo` which originally ran `melange build`.

This PR adds `--generate-provenance` to the `compile` command for backward compatibility.