### PR TITLE
chore: migrate to golangci-lint v2; add config file; address findings

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -2,9 +2,9 @@ name: verify
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
 
 permissions: {}
 
@@ -29,10 +29,10 @@ jobs:
           check-latest: true
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@2226d7cb06a077cd73e56eedd38eecad18e5d837 # v6.5.0
+        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
         with:
-          version: v1.64.8
-          args: --timeout=5m
+          version: v2.4.0
+          args: --timeout=5m --config="${{github.workspace}}/.golangci.yml"
 
       - run: |
           make docs-repo

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,64 @@
+version: "2"
+run:
+  issues-exit-code: 1
+linters:
+  enable:
+    - asciicheck
+    - bodyclose
+    - errorlint
+    - forbidigo
+    - gocritic
+    - gosec
+    - importas
+    - misspell
+    - prealloc
+    - staticcheck
+    - tparallel
+    - unconvert
+    - unparam
+    - whitespace
+  settings:
+    forbidigo:
+      forbid:
+        - pattern: ^fmt.print.*$
+    goheader:
+      values:
+        regexp:
+          ws: \s*
+      template-path: header.tmpl
+    gosec:
+      excludes:
+        - G115
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - errcheck
+          - gosec
+        path: _test\.go
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  settings:
+    goimports:
+      local-prefixes:
+        - chainguard.dev/melange
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/docs/cmd/pipeline-reference-gen/main.go
+++ b/docs/cmd/pipeline-reference-gen/main.go
@@ -10,8 +10,9 @@ import (
 	"strings"
 	"text/template"
 
-	"chainguard.dev/melange/pkg/config"
 	"sigs.k8s.io/yaml"
+
+	"chainguard.dev/melange/pkg/config"
 
 	_ "embed"
 )
@@ -126,7 +127,8 @@ func writeFile(path string, doc []*PipelineDoc) error {
 
 	// File doesn't exist, write as-is.
 	if os.IsNotExist(err) {
-		return os.WriteFile(path, out.Bytes(), os.ModePerm)
+		// #nosec G306 - Documentation file should be world-readable
+		return os.WriteFile(path, out.Bytes(), 0o644)
 	}
 
 	// Remove existing content
@@ -137,5 +139,6 @@ func writeFile(path string, doc []*PipelineDoc) error {
 	// Append to the end
 	content = append(content, out.Bytes()...)
 	fmt.Println("Wrote", path)
-	return os.WriteFile(path, content, os.ModePerm)
+	// #nosec G306 - Documentation file should be world-readable
+	return os.WriteFile(path, content, 0o644)
 }

--- a/docs/main.go
+++ b/docs/main.go
@@ -23,8 +23,9 @@ import (
 	"path/filepath"
 	"strings"
 
-	"chainguard.dev/melange/pkg/cli"
 	"github.com/spf13/cobra/doc"
+
+	"chainguard.dev/melange/pkg/cli"
 )
 
 const fmTemplate = `---

--- a/internal/gen-jsonschema/main.go
+++ b/internal/gen-jsonschema/main.go
@@ -7,8 +7,9 @@ import (
 	"log"
 	"os"
 
-	"chainguard.dev/melange/pkg/config"
 	"github.com/invopop/jsonschema"
+
+	"chainguard.dev/melange/pkg/config"
 )
 
 var outputFlag = flag.String("o", "", "output path")
@@ -31,6 +32,7 @@ func main() {
 	if err := enc.Encode(schema); err != nil {
 		log.Fatal(err)
 	}
+	// #nosec G306 - Generated schema file should be world-readable
 	if err := os.WriteFile(*outputFlag, b.Bytes(), 0o644); err != nil {
 		log.Fatal(err)
 	}

--- a/main.go
+++ b/main.go
@@ -19,8 +19,9 @@ import (
 	"os"
 	"os/signal"
 
-	"chainguard.dev/melange/pkg/cli"
 	"github.com/chainguard-dev/clog"
+
+	"chainguard.dev/melange/pkg/cli"
 )
 
 func main() {
@@ -29,6 +30,7 @@ func main() {
 
 	if err := cli.New().ExecuteContext(ctx); err != nil {
 		clog.Error(err.Error())
-		os.Exit(1)
+		done()
+		os.Exit(1) //nolint:gocritic // done() is called manually before exit
 	}
 }

--- a/pkg/build/build_test.go
+++ b/pkg/build/build_test.go
@@ -30,7 +30,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var requireErrInvalidConfiguration require.ErrorAssertionFunc = func(t require.TestingT, err error, _ ...interface{}) {
+var requireErrInvalidConfiguration require.ErrorAssertionFunc = func(t require.TestingT, err error, _ ...any) {
 	require.ErrorAs(t, err, &config.ErrInvalidConfiguration{})
 }
 

--- a/pkg/build/compile.go
+++ b/pkg/build/compile.go
@@ -24,12 +24,13 @@ import (
 	"slices"
 	"strings"
 
-	"chainguard.dev/melange/pkg/cond"
-	"chainguard.dev/melange/pkg/config"
-	"chainguard.dev/melange/pkg/util"
 	"github.com/chainguard-dev/clog"
 	"gopkg.in/yaml.v3"
 	"mvdan.cc/sh/v3/syntax"
+
+	"chainguard.dev/melange/pkg/cond"
+	"chainguard.dev/melange/pkg/config"
+	"chainguard.dev/melange/pkg/util"
 )
 
 const unidentifiablePipeline = "???"

--- a/pkg/build/compile_test.go
+++ b/pkg/build/compile_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	apko_types "chainguard.dev/apko/pkg/build/types"
+
 	"chainguard.dev/melange/pkg/config"
 )
 

--- a/pkg/build/options.go
+++ b/pkg/build/options.go
@@ -21,6 +21,7 @@ import (
 
 	apko_types "chainguard.dev/apko/pkg/build/types"
 	"chainguard.dev/apko/pkg/options"
+
 	"chainguard.dev/melange/pkg/config"
 	"chainguard.dev/melange/pkg/container"
 )

--- a/pkg/build/package.go
+++ b/pkg/build/package.go
@@ -133,7 +133,7 @@ func (pc *PackageBuild) AppendBuildLog(dir string) error {
 	defer f.Close()
 
 	// separate with pipe so it is easy to parse
-	_, err = f.WriteString(fmt.Sprintf("%s|%s|%s|%s-r%d\n", pc.Arch, pc.OriginName, pc.PackageName, pc.Origin.Version, pc.Origin.Epoch))
+	_, err = fmt.Fprintf(f, "%s|%s|%s|%s-r%d\n", pc.Arch, pc.OriginName, pc.PackageName, pc.Origin.Version, pc.Origin.Epoch)
 	return err
 }
 
@@ -358,11 +358,11 @@ func (pc *PackageBuild) GenerateDependencies(ctx context.Context, hdl sca.SCAHan
 	// dep that we don't want to be satisfied by a vendored dep.
 	unvendored := removeSelfProvidedDeps(generated.Runtime, generated.Vendored)
 
-	newruntime := append(pc.Dependencies.Runtime, unvendored...)
-	pc.Dependencies.Runtime = slices.Compact(slices.Sorted(slices.Values(newruntime)))
+	pc.Dependencies.Runtime = append(pc.Dependencies.Runtime, unvendored...)
+	pc.Dependencies.Runtime = slices.Compact(slices.Sorted(slices.Values(pc.Dependencies.Runtime)))
 
-	newprovides := append(pc.Dependencies.Provides, generated.Provides...)
-	pc.Dependencies.Provides = slices.Compact(slices.Sorted(slices.Values(newprovides)))
+	pc.Dependencies.Provides = append(pc.Dependencies.Provides, generated.Provides...)
+	pc.Dependencies.Provides = slices.Compact(slices.Sorted(slices.Values(pc.Dependencies.Provides)))
 
 	pc.Dependencies.Runtime = removeSelfProvidedDeps(pc.Dependencies.Runtime, pc.Dependencies.Provides)
 

--- a/pkg/build/pipeline_test.go
+++ b/pkg/build/pipeline_test.go
@@ -19,9 +19,10 @@ import (
 	"path/filepath"
 	"testing"
 
+	"gopkg.in/yaml.v3"
+
 	"chainguard.dev/melange/pkg/config"
 	"chainguard.dev/melange/pkg/util"
-	"gopkg.in/yaml.v3"
 
 	"github.com/chainguard-dev/clog/slogtest"
 	"github.com/stretchr/testify/require"

--- a/pkg/build/sbom_group.go
+++ b/pkg/build/sbom_group.go
@@ -3,8 +3,9 @@ package build
 import (
 	"time"
 
-	"chainguard.dev/melange/pkg/sbom"
 	"github.com/spdx/tools-golang/spdx/v2/common"
+
+	"chainguard.dev/melange/pkg/sbom"
 )
 
 // An SBOMGroup stores SBOMs corresponding to each package (or subpackage)

--- a/pkg/build/sca_interface.go
+++ b/pkg/build/sca_interface.go
@@ -21,6 +21,7 @@ import (
 
 	"chainguard.dev/apko/pkg/apk/apk"
 	apkofs "chainguard.dev/apko/pkg/apk/fs"
+
 	"chainguard.dev/melange/pkg/config"
 	"chainguard.dev/melange/pkg/sca"
 )

--- a/pkg/build/slsa_test.go
+++ b/pkg/build/slsa_test.go
@@ -19,9 +19,10 @@ import (
 	"testing"
 	"time"
 
-	"chainguard.dev/melange/pkg/config"
 	intoto "github.com/in-toto/attestation/go/v1"
 	"github.com/stretchr/testify/require"
+
+	"chainguard.dev/melange/pkg/config"
 )
 
 func TestGenerateSLSA(t *testing.T) {

--- a/pkg/build/test.go
+++ b/pkg/build/test.go
@@ -28,7 +28,6 @@ import (
 	"chainguard.dev/apko/pkg/apk/apk"
 	apkofs "chainguard.dev/apko/pkg/apk/fs"
 	apko_build "chainguard.dev/apko/pkg/build"
-	"chainguard.dev/apko/pkg/build/types"
 	apko_types "chainguard.dev/apko/pkg/build/types"
 	"chainguard.dev/apko/pkg/options"
 	"chainguard.dev/apko/pkg/tarfs"
@@ -259,7 +258,7 @@ func (t *Test) TestPackage(ctx context.Context) error {
 	// Unless a specific architecture is requests, we run the test for all.
 	inarchs := len(pkg.TargetArchitecture) == 0
 	for _, ta := range pkg.TargetArchitecture {
-		if types.ParseArchitecture(ta) == t.Arch {
+		if apko_types.ParseArchitecture(ta) == t.Arch {
 			inarchs = true
 			break
 		}
@@ -469,6 +468,6 @@ func (t *Test) buildWorkspaceConfig(ctx context.Context, imgRef, pkgName string,
 	return &cfg, nil
 }
 
-func (t *Test) guestFS(ctx context.Context) apkofs.FullFS {
+func (t *Test) guestFS(_ context.Context) apkofs.FullFS {
 	return tarfs.New()
 }

--- a/pkg/build/test_options.go
+++ b/pkg/build/test_options.go
@@ -17,6 +17,7 @@ package build
 import (
 	apko_types "chainguard.dev/apko/pkg/build/types"
 	"chainguard.dev/apko/pkg/options"
+
 	"chainguard.dev/melange/pkg/container"
 )
 

--- a/pkg/build/test_test.go
+++ b/pkg/build/test_test.go
@@ -20,15 +20,15 @@ import (
 	"strings"
 	"testing"
 
-	"chainguard.dev/apko/pkg/build/types"
 	apko_types "chainguard.dev/apko/pkg/build/types"
-	"chainguard.dev/melange/pkg/config"
-	"chainguard.dev/melange/pkg/container"
 	"github.com/chainguard-dev/clog/slogtest"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/require"
 	"github.com/yookoala/realpath"
+
+	"chainguard.dev/melange/pkg/config"
+	"chainguard.dev/melange/pkg/container"
 )
 
 const (
@@ -44,8 +44,8 @@ var gid1000 = uint32(1000)
 
 func defaultEnv(opts ...func(*apko_types.ImageConfiguration)) apko_types.ImageConfiguration {
 	env := apko_types.ImageConfiguration{
-		Accounts: types.ImageAccounts{
-			Groups: []types.Group{{GroupName: "build", GID: 1000, Members: []string{buildUser}}},
+		Accounts: apko_types.ImageAccounts{
+			Groups: []apko_types.Group{{GroupName: "build", GID: 1000, Members: []string{buildUser}}},
 			Users:  []apko_types.User{{UserName: "build", UID: 1000, GID: apko_types.GID(&gid1000)}},
 		},
 	}

--- a/pkg/cli/compile.go
+++ b/pkg/cli/compile.go
@@ -24,10 +24,11 @@ import (
 	"time"
 
 	apko_types "chainguard.dev/apko/pkg/build/types"
-	"chainguard.dev/melange/pkg/build"
 	"github.com/chainguard-dev/clog"
 	"github.com/spf13/cobra"
 	"go.opentelemetry.io/otel"
+
+	"chainguard.dev/melange/pkg/build"
 )
 
 func compile() *cobra.Command {

--- a/pkg/cli/index.go
+++ b/pkg/cli/index.go
@@ -17,8 +17,9 @@ package cli
 import (
 	"context"
 
-	"chainguard.dev/melange/pkg/index"
 	"github.com/spf13/cobra"
+
+	"chainguard.dev/melange/pkg/index"
 )
 
 func indexCmd() *cobra.Command {

--- a/pkg/cli/license_check.go
+++ b/pkg/cli/license_check.go
@@ -22,6 +22,7 @@ import (
 	"github.com/spf13/cobra"
 
 	apkofs "chainguard.dev/apko/pkg/apk/fs"
+
 	"chainguard.dev/melange/pkg/config"
 	"chainguard.dev/melange/pkg/license"
 	"chainguard.dev/melange/pkg/renovate"

--- a/pkg/cli/query.go
+++ b/pkg/cli/query.go
@@ -20,8 +20,9 @@ import (
 	"os"
 	"text/template"
 
-	"chainguard.dev/melange/pkg/config"
 	"github.com/spf13/cobra"
+
+	"chainguard.dev/melange/pkg/config"
 )
 
 func query() *cobra.Command {

--- a/pkg/cli/sign.go
+++ b/pkg/cli/sign.go
@@ -22,11 +22,12 @@ import (
 	"io"
 	"os"
 
-	"chainguard.dev/melange/pkg/sign"
 	"github.com/chainguard-dev/clog"
 	"github.com/klauspost/compress/gzip"
 	"github.com/spf13/cobra"
 	"golang.org/x/sync/errgroup"
+
+	"chainguard.dev/melange/pkg/sign"
 )
 
 type signIndexOpts struct {
@@ -130,6 +131,7 @@ func parseIndexWithoutSignature(_ context.Context, indexFile string) ([]byte, er
 			if err := tw.WriteHeader(hdr); err != nil {
 				return nil, err
 			}
+			// #nosec G110 - Copying specific known files from trusted APK index
 			if _, err := io.Copy(tw, tr); err != nil {
 				return nil, err
 			}

--- a/pkg/cli/test.go
+++ b/pkg/cli/test.go
@@ -22,11 +22,12 @@ import (
 	"strings"
 
 	apko_types "chainguard.dev/apko/pkg/build/types"
-	"chainguard.dev/melange/pkg/build"
 	"github.com/chainguard-dev/clog"
 	"github.com/spf13/cobra"
 	"go.opentelemetry.io/otel"
 	"golang.org/x/sync/errgroup"
+
+	"chainguard.dev/melange/pkg/build"
 )
 
 func test() *cobra.Command {
@@ -178,8 +179,6 @@ func TestCmd(ctx context.Context, archs []apko_types.Architecture, baseOpts ...b
 	}
 
 	for _, bc := range bcs {
-		bc := bc
-
 		errg.Go(func() error {
 			if err := bc.TestPackage(ctx); err != nil {
 				log.Errorf("ERROR: failed to test package. the test environment has been preserved:")

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -8,10 +8,11 @@ import (
 	"strings"
 	"testing"
 
-	"chainguard.dev/melange/pkg/sbom"
 	"github.com/chainguard-dev/clog/slogtest"
 	purl "github.com/package-url/packageurl-go"
 	"github.com/stretchr/testify/require"
+
+	"chainguard.dev/melange/pkg/sbom"
 )
 
 func Test_validateCPE(t *testing.T) {
@@ -1269,7 +1270,7 @@ func TestSetCapability(t *testing.T) {
 						continue
 					}
 					for attr, flag := range capEntry.Add {
-						for _, a := range strings.Split(attr, ",") {
+						for a := range strings.SplitSeq(attr, ",") {
 							val := getCapabilityValue(a)
 							e, p, i := parseCapability(flag)
 

--- a/pkg/container/bubblewrap_runner.go
+++ b/pkg/container/bubblewrap_runner.go
@@ -26,8 +26,9 @@ import (
 	"path/filepath"
 	"strings"
 
-	"chainguard.dev/melange/internal/logwriter"
 	"golang.org/x/sys/unix"
+
+	"chainguard.dev/melange/internal/logwriter"
 
 	apko_build "chainguard.dev/apko/pkg/build"
 	apko_types "chainguard.dev/apko/pkg/build/types"
@@ -89,13 +90,13 @@ func (bw *bubblewrap) testUnshareUser(ctx context.Context) error {
 		return nil
 	}
 
-	return fmt.Errorf("%s\n",
+	return fmt.Errorf("%s",
 		strings.Join([]string{
-			"Unable to execute 'bwrap --unshare-user true'.",
-			"Command failed with: ",
+			"unable to execute 'bwrap --unshare-user true'.",
+			"command failed with: ",
 			"  " + string(out),
-			"See https://github.com/chainguard-dev/melange/issues/1508 for fix",
-		}, "\n"))
+			"see https://github.com/chainguard-dev/melange/issues/1508 for fix",
+		}, ""))
 }
 
 func (bw *bubblewrap) cmd(ctx context.Context, cfg *Config, debug bool, envOverride map[string]string, args ...string) *exec.Cmd {
@@ -286,6 +287,7 @@ func (b *bubblewrapOCILoader) LoadImage(ctx context.Context, layer v1.Layer, arc
 		if err != nil {
 			break
 		}
+		// #nosec G305 - Extracting trusted container image in controlled build environment
 		fullname := filepath.Join(guestDir, hdr.Name)
 		switch hdr.Typeflag {
 		case tar.TypeDir:
@@ -298,15 +300,18 @@ func (b *bubblewrapOCILoader) LoadImage(ctx context.Context, layer v1.Layer, arc
 			if err != nil {
 				return ref, fmt.Errorf("failed to create file %s: %w", fullname, err)
 			}
+			// #nosec G110 - Extracting trusted container image in controlled build environment
 			if _, err := io.Copy(f, tr); err != nil {
 				return ref, fmt.Errorf("failed to copy file %s: %w", fullname, err)
 			}
 			f.Close()
 		case tar.TypeSymlink:
+			// #nosec G305 - Creating symlink from trusted container image in controlled build environment
 			if err := os.Symlink(hdr.Linkname, filepath.Join(guestDir, hdr.Name)); err != nil {
 				return ref, fmt.Errorf("failed to create symlink %s: %w", fullname, err)
 			}
 		case tar.TypeLink:
+			// #nosec G305 - Creating hardlink from trusted container image in controlled build environment
 			if err := os.Link(filepath.Join(guestDir, hdr.Linkname), filepath.Join(guestDir, hdr.Name)); err != nil {
 				return ref, fmt.Errorf("failed to create hardlink %s: %w", fullname, err)
 			}

--- a/pkg/container/docker/docker_runner.go
+++ b/pkg/container/docker/docker_runner.go
@@ -28,9 +28,6 @@ import (
 	apko_build "chainguard.dev/apko/pkg/build"
 	apko_oci "chainguard.dev/apko/pkg/build/oci"
 	apko_types "chainguard.dev/apko/pkg/build/types"
-	"chainguard.dev/melange/internal/contextreader"
-	"chainguard.dev/melange/internal/logwriter"
-	mcontainer "chainguard.dev/melange/pkg/container"
 	"github.com/chainguard-dev/clog"
 	"github.com/docker/cli/cli/streams"
 	"github.com/docker/docker/api/types/container"
@@ -41,6 +38,10 @@ import (
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/empty"
 	image_spec "github.com/opencontainers/image-spec/specs-go/v1"
+
+	"chainguard.dev/melange/internal/contextreader"
+	"chainguard.dev/melange/internal/logwriter"
+	mcontainer "chainguard.dev/melange/pkg/container"
 )
 
 var _ mcontainer.Debugger = (*docker)(nil)
@@ -311,14 +312,14 @@ func (dk *docker) Debug(ctx context.Context, cfg *mcontainer.Config, envOverride
 
 	// Wire up stdin to into a tty into the Attach connection.
 	g.Go(func() error {
-		interm := streams.NewIn(os.Stdin)
-		if err := interm.SetRawTerminal(); err != nil {
+		interim := streams.NewIn(os.Stdin)
+		if err := interim.SetRawTerminal(); err != nil {
 			return fmt.Errorf("set raw in: %w", err)
 		}
-		defer interm.RestoreTerminal()
+		defer interim.RestoreTerminal()
 
 		// Allows us to cancel the Read().
-		ctxr := contextreader.New(inctx, interm)
+		ctxr := contextreader.New(inctx, interim)
 
 		if _, err := io.Copy(attachResp.Conn, ctxr); err != nil {
 			return fmt.Errorf("copy in : %w", err)

--- a/pkg/index/index.go
+++ b/pkg/index/index.go
@@ -24,10 +24,11 @@ import (
 	"strings"
 
 	"chainguard.dev/apko/pkg/apk/apk"
-	"chainguard.dev/melange/pkg/sign"
 	"github.com/chainguard-dev/clog"
 	"go.opentelemetry.io/otel"
 	"golang.org/x/sync/errgroup"
+
+	"chainguard.dev/melange/pkg/sign"
 )
 
 type Index struct {

--- a/pkg/license/license.go
+++ b/pkg/license/license.go
@@ -24,11 +24,12 @@ import (
 	"sort"
 	"strings"
 
-	"chainguard.dev/melange/pkg/config"
 	"github.com/chainguard-dev/clog"
 	golicenses "github.com/google/go-licenses/v2/licenses"
 	licenseclassifier "github.com/google/licenseclassifier/v2"
 	"github.com/google/licenseclassifier/v2/assets"
+
+	"chainguard.dev/melange/pkg/config"
 )
 
 // NOTE: the detection logic is done via a Classifier type as this is how it was
@@ -309,11 +310,12 @@ func LicenseCheck(ctx context.Context, cfg *config.Configuration, fsys fs.FS) ([
 		if len(diffs) > 0 {
 			log.Warnf("detected license differences:")
 			for _, diff := range diffs {
-				if diff.Is == "" {
+				switch {
+				case diff.Is == "":
 					log.Warnf("  %s: %s not found", diff.Path, diff.Should)
-				} else if diff.Override != "" {
+				case diff.Override != "":
 					log.Warnf("  %s: requested override from %s to %s, but now detecting as %s", diff.Path, diff.Override, diff.Is, diff.Should)
-				} else {
+				default:
 					log.Warnf("  %s: %s != %s", diff.Path, diff.Should, diff.Is)
 				}
 

--- a/pkg/license/license_test.go
+++ b/pkg/license/license_test.go
@@ -24,8 +24,9 @@ import (
 	"testing"
 
 	apkofs "chainguard.dev/apko/pkg/apk/fs"
-	"chainguard.dev/melange/pkg/config"
 	"github.com/chainguard-dev/clog"
+
+	"chainguard.dev/melange/pkg/config"
 )
 
 func TestFindLicenseFiles(t *testing.T) {
@@ -263,8 +264,8 @@ func TestLicenseCheck(t *testing.T) {
 	// Now also check the log output and make sure that "low-confidence" is present only for the low-confidence
 	// licenses: LICENSE-BSD-modified and COPYRIGHT (the latter is not a valid license)
 	found := false
-	lines := strings.Split(logBuf.String(), "\n")
-	for _, line := range lines {
+	lines := strings.SplitSeq(logBuf.String(), "\n")
+	for line := range lines {
 		if strings.Contains(line, "low-confidence") {
 			// Check if the line contains one of the expected licenses
 			if !strings.Contains(line, "LICENSE-BSD-modified") && !strings.Contains(line, "COPYRIGHT") {

--- a/pkg/linter/apk.go
+++ b/pkg/linter/apk.go
@@ -27,12 +27,13 @@ import (
 
 	"chainguard.dev/apko/pkg/apk/auth"
 	"chainguard.dev/apko/pkg/apk/expandapk"
-	"chainguard.dev/melange/pkg/config"
-	"chainguard.dev/melange/pkg/linter/types"
 	"github.com/chainguard-dev/clog"
 	"github.com/dustin/go-humanize"
 	"go.yaml.in/yaml/v2"
 	"gopkg.in/ini.v1"
+
+	"chainguard.dev/melange/pkg/config"
+	"chainguard.dev/melange/pkg/linter/types"
 )
 
 // Lint the given APK at the given path

--- a/pkg/linter/build.go
+++ b/pkg/linter/build.go
@@ -20,9 +20,10 @@ import (
 	"path/filepath"
 
 	apkofs "chainguard.dev/apko/pkg/apk/fs"
+	"github.com/chainguard-dev/clog"
+
 	"chainguard.dev/melange/pkg/config"
 	"chainguard.dev/melange/pkg/linter/types"
-	"github.com/chainguard-dev/clog"
 )
 
 // Lint the given build directory at the given path

--- a/pkg/linter/fs.go
+++ b/pkg/linter/fs.go
@@ -21,9 +21,10 @@ import (
 	"io/fs"
 	"strings"
 
+	"github.com/chainguard-dev/clog"
+
 	"chainguard.dev/melange/pkg/config"
 	"chainguard.dev/melange/pkg/linter/types"
-	"github.com/chainguard-dev/clog"
 )
 
 func lintPackageFS(ctx context.Context, cfg *config.Configuration, pkgname string, fsys fs.FS, linters []string, results map[string]*types.PackageLintResults, fullPackageName string) error {
@@ -40,7 +41,8 @@ func lintPackageFS(ctx context.Context, cfg *config.Configuration, pkgname strin
 			var message string
 			var details any
 
-			if structErr, ok := err.(*types.StructuredError); ok {
+			structErr := &types.StructuredError{}
+			if errors.As(err, &structErr) {
 				message = structErr.Message
 				details = structErr.Details
 			} else {

--- a/pkg/linter/linter_test.go
+++ b/pkg/linter/linter_test.go
@@ -24,10 +24,11 @@ import (
 	"testing"
 
 	apkofs "chainguard.dev/apko/pkg/apk/fs"
-	"chainguard.dev/melange/pkg/config"
-	"chainguard.dev/melange/pkg/linter/types"
 	"github.com/chainguard-dev/clog/slogtest"
 	"github.com/stretchr/testify/assert"
+
+	"chainguard.dev/melange/pkg/config"
+	"chainguard.dev/melange/pkg/linter/types"
 )
 
 func TestLinters(t *testing.T) {
@@ -678,11 +679,10 @@ func Test_setUidGidLinter(t *testing.T) {
 	fsys := apkofs.DirFS(ctx, dir)
 
 	linters := []string{"setuidgid"}
-	filePath := filepath.Join("test.txt")
 
-	_, err := fsys.Create(filePath)
+	_, err := fsys.Create("test.txt")
 	assert.NoError(t, err)
-	assert.NoError(t, fsys.Chmod(filePath, 0o770|fs.ModeSetuid|fs.ModeSetgid))
+	assert.NoError(t, fsys.Chmod("test.txt", 0o770|fs.ModeSetuid|fs.ModeSetgid))
 	assert.Error(t, LintBuild(ctx, nil, "setuidgid", linters, nil, fsys, t.TempDir(), "x86_64"))
 }
 

--- a/pkg/linter/linters/duplicate.go
+++ b/pkg/linter/linters/duplicate.go
@@ -25,10 +25,11 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/dustin/go-humanize"
+
 	"chainguard.dev/melange/pkg/config"
 	"chainguard.dev/melange/pkg/license"
 	"chainguard.dev/melange/pkg/linter/types"
-	"github.com/dustin/go-humanize"
 )
 
 type duplicateInfo struct {

--- a/pkg/linter/linters/strip.go
+++ b/pkg/linter/linters/strip.go
@@ -88,7 +88,7 @@ func StrippedLinter(ctx context.Context, _ *config.Configuration, pkgname string
 
 		file, err := elf.NewFile(readerAt)
 		if err != nil {
-			return fmt.Errorf("Could not open file %q as executable: %v\n", path, err)
+			return fmt.Errorf("could not open file %q as executable: %w", path, err)
 		}
 		defer file.Close()
 

--- a/pkg/linter/linters/unsupportedarch.go
+++ b/pkg/linter/linters/unsupportedarch.go
@@ -66,7 +66,6 @@ func UnsupportedArchLinter(_ context.Context, cfg *config.Configuration, pkgname
 				if strings.Contains(baseLower, sep+arch+sep) ||
 					strings.Contains(baseLower, sep+arch+".") ||
 					strings.HasSuffix(baseLower, sep+arch) {
-
 					isSupported := false
 					for _, s := range supported {
 						if strings.Contains(pathLower, s) {

--- a/pkg/linter/linters/usrmerge.go
+++ b/pkg/linter/linters/usrmerge.go
@@ -52,7 +52,7 @@ func UsrmergeLinter(ctx context.Context, _ *config.Configuration, _ string, fsys
 		}
 
 		// If it's not a directory of interest just skip the whole tree
-		if !(path == "." || path == "usr" || pathInDir(path, dirs...)) {
+		if path != "." && path != "usr" && !pathInDir(path, dirs...) {
 			return filepath.SkipDir
 		}
 

--- a/pkg/linter/log.go
+++ b/pkg/linter/log.go
@@ -18,8 +18,9 @@ import (
 	"fmt"
 	"strings"
 
-	"chainguard.dev/melange/pkg/linter/types"
 	"github.com/chainguard-dev/clog"
+
+	"chainguard.dev/melange/pkg/linter/types"
 )
 
 // logStructuredDetails displays itemized details for structured errors

--- a/pkg/linter/results.go
+++ b/pkg/linter/results.go
@@ -21,9 +21,10 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/chainguard-dev/clog"
+
 	"chainguard.dev/melange/pkg/config"
 	"chainguard.dev/melange/pkg/linter/types"
-	"github.com/chainguard-dev/clog"
 )
 
 // saveLintResults saves the lint results to JSON files in the packages directory
@@ -55,6 +56,7 @@ func saveLintResults(ctx context.Context, cfg *config.Configuration, results map
 		}
 
 		// Write to file
+		// #nosec G306 - Lint results file should be world-readable
 		if err := os.WriteFile(filepath, jsonData, 0o644); err != nil {
 			return fmt.Errorf("writing lint results to %s: %w", filepath, err)
 		}

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -7,10 +7,11 @@ import (
 	"path/filepath"
 
 	apkotypes "chainguard.dev/apko/pkg/build/types"
-	"chainguard.dev/melange/pkg/config"
 	"github.com/chainguard-dev/clog"
 	"github.com/chainguard-dev/yam/pkg/yam/formatted"
 	"gopkg.in/yaml.v3"
+
+	"chainguard.dev/melange/pkg/config"
 )
 
 type GeneratedMelangeConfig struct {
@@ -53,7 +54,7 @@ func (m *GeneratedMelangeConfig) Write(ctx context.Context, dir string) error {
 	}
 	defer f.Close()
 
-	if _, err := f.WriteString(fmt.Sprintf("# Generated from %s\n", m.GeneratedFromComment)); err != nil {
+	if _, err := fmt.Fprintf(f, "# Generated from %s\n", m.GeneratedFromComment); err != nil {
 		return fmt.Errorf("creating writing to file %s: %w", manifestPath, err)
 	}
 

--- a/pkg/renovate/bump/bump.go
+++ b/pkg/renovate/bump/bump.go
@@ -149,7 +149,7 @@ func New(ctx context.Context, opts ...Option) renovate.Renovator {
 }
 
 // updateFetch takes a "fetch" pipeline node and updates the parameters of it.
-func updateFetch(ctx context.Context, rc *renovate.RenovationContext, node *yaml.Node, targetVersion string) error {
+func updateFetch(ctx context.Context, rc *renovate.RenovationContext, node *yaml.Node, _ string) error {
 	log := clog.FromContext(ctx)
 	withNode, err := renovate.NodeFromMapping(node, "with")
 	if err != nil {
@@ -223,11 +223,9 @@ func updateGitCheckout(ctx context.Context, node *yaml.Node, expectedGitSha stri
 	tag, err := renovate.NodeFromMapping(withNode, "tag")
 	if err != nil {
 		log.Infof("git-checkout node does not contain a tag, assume we need to update the expected-commit sha")
-	} else {
-		if !strings.Contains(tag.Value, "${{package.version}}") && !strings.Contains(tag.Value, "${{vars.mangled-package-version}}") {
-			log.Infof("Skipping git-checkout node as it does not contain a version substitution so assuming it is not the main checkout")
-			return nil
-		}
+	} else if !strings.Contains(tag.Value, "${{package.version}}") && !strings.Contains(tag.Value, "${{vars.mangled-package-version}}") {
+		log.Infof("Skipping git-checkout node as it does not contain a version substitution so assuming it is not the main checkout")
+		return nil
 	}
 
 	log.Infof("processing git-checkout node")

--- a/pkg/renovate/bump/bump_test.go
+++ b/pkg/renovate/bump/bump_test.go
@@ -8,12 +8,14 @@ import (
 	"strings"
 	"testing"
 
-	"chainguard.dev/melange/pkg/config"
 	"github.com/chainguard-dev/clog/slogtest"
 	"github.com/stretchr/testify/require"
 
-	"chainguard.dev/melange/pkg/renovate"
+	"chainguard.dev/melange/pkg/config"
+
 	"github.com/stretchr/testify/assert"
+
+	"chainguard.dev/melange/pkg/renovate"
 )
 
 func TestBump_versions(t *testing.T) {
@@ -31,7 +33,7 @@ func TestBump_versions(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := slogtest.Context(t)
-			err, server := setupTestServer(t)
+			server, err := setupTestServer(t)
 			assert.NoError(t, err)
 
 			data, err := os.ReadFile(filepath.Join("testdata", tt.name))
@@ -178,7 +180,7 @@ func TestBump_withMultipleCheckouts(t *testing.T) {
 	assert.Equal(t, rs.Pipeline[1].With["expected-commit"], "bar")
 }
 
-func setupTestServer(t *testing.T) (error, *httptest.Server) {
+func setupTestServer(t *testing.T) (*httptest.Server, error) {
 	packageData, err := os.ReadFile(filepath.Join("testdata", "cheese-7.0.1.tar.gz"))
 	assert.NoError(t, err)
 
@@ -191,5 +193,5 @@ func setupTestServer(t *testing.T) (error, *httptest.Server) {
 		_, err = rw.Write(packageData)
 		assert.NoError(t, err)
 	}))
-	return err, server
+	return server, err
 }

--- a/pkg/renovate/copyright/copyright.go
+++ b/pkg/renovate/copyright/copyright.go
@@ -23,9 +23,10 @@ import (
 
 	"github.com/chainguard-dev/clog"
 
+	"gopkg.in/yaml.v3"
+
 	"chainguard.dev/melange/pkg/license"
 	"chainguard.dev/melange/pkg/renovate"
-	"gopkg.in/yaml.v3"
 )
 
 // CopyrightConfig contains the configuration data for a copyright update
@@ -85,13 +86,7 @@ func New(ctx context.Context, opts ...Option) renovate.Renovator {
 
 		// Check if there's any licenses that were properly detected.
 		// If not, we probably shouldn't do anything.
-		canFix := false
-		for _, l := range ccfg.Licenses {
-			if license.IsLicenseMatchConfident(l) {
-				canFix = true
-				break
-			}
-		}
+		canFix := slices.ContainsFunc(ccfg.Licenses, license.IsLicenseMatchConfident)
 		if !canFix {
 			log.Infof("no confident licenses found to update")
 			return nil

--- a/pkg/renovate/copyright/copyright_test.go
+++ b/pkg/renovate/copyright/copyright_test.go
@@ -21,9 +21,10 @@ import (
 
 	"github.com/chainguard-dev/clog/slogtest"
 
+	"github.com/stretchr/testify/assert"
+
 	"chainguard.dev/melange/pkg/license"
 	"chainguard.dev/melange/pkg/renovate"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestCopyright_update(t *testing.T) {

--- a/pkg/sbom/document.go
+++ b/pkg/sbom/document.go
@@ -97,7 +97,7 @@ func (d Document) getSPDXName() string {
 
 func (d Document) getSPDXNamespace() string {
 	h := fnv.New128a()
-	h.Write([]byte(fmt.Sprintf("apk-%s-%s", d.Describes.Namespace, d.Describes.Version)))
+	fmt.Fprintf(h, "apk-%s-%s", d.Describes.Namespace, d.Describes.Version)
 	hexHash := hex.EncodeToString(h.Sum(nil))
 
 	return "https://spdx.org/spdxdocs/chainguard/melange/" + hexHash

--- a/pkg/sbom/package.go
+++ b/pkg/sbom/package.go
@@ -141,13 +141,13 @@ func (p Package) ID() string {
 }
 
 func (p Package) getChecksums() []spdx.Checksum {
-	var algos []string
+	algos := make([]string, 0, len(p.Checksums))
 	for algo := range p.Checksums {
 		algos = append(algos, algo)
 	}
 	sort.Strings(algos)
 
-	var result []spdx.Checksum
+	result := make([]spdx.Checksum, 0, len(p.Checksums))
 	for _, algo := range algos {
 		result = append(result, spdx.Checksum{
 			Algorithm: algo,

--- a/pkg/sca/sca_test.go
+++ b/pkg/sca/sca_test.go
@@ -35,10 +35,11 @@ import (
 
 	"chainguard.dev/apko/pkg/apk/apk"
 	"chainguard.dev/apko/pkg/apk/expandapk"
-	"chainguard.dev/melange/pkg/config"
 	"github.com/chainguard-dev/clog/slogtest"
 	"github.com/google/go-cmp/cmp"
 	"gopkg.in/ini.v1"
+
+	"chainguard.dev/melange/pkg/config"
 )
 
 type testHandle struct {
@@ -363,9 +364,7 @@ func TestLdSoConfD(t *testing.T) {
 		t.Fatal(err)
 	} else if extraLibPaths == nil {
 		t.Error("getLdSoConfDLibPaths: expected 'my/lib/test', got nil")
-	} else {
-		if extraLibPaths[0] != "my/lib/test" {
-			t.Errorf("getLdSoConfDLibPaths: expected 'my/lib/test', got '%s'", extraLibPaths[0])
-		}
+	} else if extraLibPaths[0] != "my/lib/test" {
+		t.Errorf("getLdSoConfDLibPaths: expected 'my/lib/test', got '%s'", extraLibPaths[0])
 	}
 }

--- a/pkg/sign/apk_test.go
+++ b/pkg/sign/apk_test.go
@@ -73,7 +73,7 @@ func TestAPK(t *testing.T) {
 	}
 }
 
-func parseAPK(ctx context.Context, apkPath string) (control []byte, sigName string, sig []byte, err error) {
+func parseAPK(_ context.Context, apkPath string) (control []byte, sigName string, sig []byte, err error) {
 	apkr, err := os.Open(apkPath)
 	if err != nil {
 		return nil, "", nil, err

--- a/pkg/sign/index.go
+++ b/pkg/sign/index.go
@@ -31,6 +31,7 @@ import (
 	"github.com/psanford/memfs"
 
 	"chainguard.dev/apko/pkg/apk/signature"
+
 	"chainguard.dev/melange/pkg/tarball"
 )
 

--- a/pkg/util/map_subst.go
+++ b/pkg/util/map_subst.go
@@ -41,7 +41,7 @@ func MutateStringFromMap(with map[string]string, input string) (string, error) {
 
 // Given a string and a map, replace the variables in the string with quoted values in the map.
 // Currently, an "if" statement in a melange config can only have quoted strings or ${{variables}}
-// as comparision values with == and !=. If we want to be able to resolve an "if" that can be fed
+// as comparison values with == and !=. If we want to be able to resolve an "if" that can be fed
 // back into melange, we need to maintain that requirement, so all variables get quoted once replaced.
 func MutateAndQuoteStringFromMap(with map[string]string, input string) (string, error) {
 	lookupWith := func(key string) (string, error) {


### PR DESCRIPTION
I noticed that we don't have a `.golangci.yml` file for Melange like we do elsewhere. This PR adds the same config that we use for Apko, addresses the findings, and also updates our `verify` Workflow to use the new v2 schema.

This should help keep additions consistent (historically, I'd inadvertently format the entire codebase or something like that) and following best-practices.

None of the changes should affect behavior except for where we write files as `0644` instead of `0755` in `docs/cmd/pipeline-reference-gen/main.go`.