### PR TITLE
chore: address more findings; improve QEMU host key verification

### DIFF
--- a/.github/workflows/wolfi-presubmit.yaml
+++ b/.github/workflows/wolfi-presubmit.yaml
@@ -104,6 +104,9 @@ jobs:
           sudo chmod a+x /usr/bin/melange
           melange version
 
+      # needed to run tests for Bubblewrap packages
+      - uses: docker/setup-docker-action@3fb92d6d9c634363128c8cce4bc3b2826526370a # v4.4.0
+
       # this need to point to main to always get the latest action
       - uses: wolfi-dev/actions/install-wolfictl@main # main
 
@@ -122,6 +125,9 @@ jobs:
       - if: matrix.runner == 'bubblewrap'
         run: |
           make SHELL="/bin/bash" MELANGE="sudo melange" MELANGE_RUNNER="bubblewrap" MELANGE_EXTRA_OPTS="--generate-provenance" package/${{ matrix.package }}
+      - if: matrix.runner == 'bubblewrap'
+        run: |
+          make SHELL="/bin/bash" MELANGE="sudo melange" MELANGE_RUNNER="docker" test/${{ matrix.package }}
 
       - name: Download kernel for VMs
         if: matrix.runner == 'qemu'

--- a/go.mod
+++ b/go.mod
@@ -148,7 +148,7 @@ require (
 	github.com/skeema/knownhosts v1.3.1 // indirect
 	github.com/spf13/afero v1.14.0 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
-	github.com/u-root/u-root v0.15.0 // indirect
+	github.com/u-root/u-root v0.15.0
 	github.com/u-root/uio v0.0.0-20240224005618-d2acac8f3701 // indirect
 	github.com/vbatts/tar-split v0.12.1 // indirect
 	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -1069,12 +1069,13 @@ func runAs(accts apko_types.ImageAccounts) string {
 	default:
 	}
 	// If accts.RunAs is numeric, then look up the username.
-	uid, err := strconv.Atoi(accts.RunAs)
-	if err != nil {
+	parsed, err := strconv.ParseUint(accts.RunAs, 10, 32)
+	if err != nil || parsed > math.MaxInt32 {
 		return accts.RunAs
 	}
+	uid := uint32(parsed)
 	for _, u := range accts.Users {
-		if u.UID == uint32(uid) {
+		if u.UID == uid {
 			return u.UserName
 		}
 	}
@@ -1089,9 +1090,10 @@ func runAsGID(accts apko_types.ImageAccounts) string {
 		return "0"
 	default:
 	}
-	if uid, err := strconv.Atoi(accts.RunAs); err == nil {
+	if parsed, err := strconv.ParseUint(accts.RunAs, 10, 32); err == nil {
+		uid := uint32(parsed)
 		for _, u := range accts.Users {
-			if u.UID == uint32(uid) && u.GID != nil {
+			if u.UID == uid && u.GID != nil {
 				return fmt.Sprint(*u.GID)
 			}
 		}

--- a/pkg/build/package.go
+++ b/pkg/build/package.go
@@ -133,8 +133,14 @@ func (pc *PackageBuild) AppendBuildLog(dir string) error {
 	defer f.Close()
 
 	// separate with pipe so it is easy to parse
-	_, err = fmt.Fprintf(f, "%s|%s|%s|%s-r%d\n", pc.Arch, pc.OriginName, pc.PackageName, pc.Origin.Version, pc.Origin.Epoch)
-	return err
+	if _, err = fmt.Fprintf(f, "%s|%s|%s|%s-r%d\n", pc.Arch, pc.OriginName, pc.PackageName, pc.Origin.Version, pc.Origin.Epoch); err != nil {
+		return err
+	}
+
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("failed to close package info file: %w", err)
+	}
+	return nil
 }
 
 func (pc *PackageBuild) Identity() string {

--- a/pkg/cli/scan.go
+++ b/pkg/cli/scan.go
@@ -609,7 +609,6 @@ func Diff(oldName string, old []byte, newName string, new []byte, comments bool)
 				count.x++
 				count.y++
 			}
-			done = pair{start.x + n, start.y + n}
 
 			// Format and emit chunk.
 			// Convert line numbers to 1-indexed.

--- a/pkg/container/config.go
+++ b/pkg/container/config.go
@@ -15,6 +15,7 @@
 package container
 
 import (
+	"crypto/ed25519"
 	"time"
 
 	apko_types "chainguard.dev/apko/pkg/build/types"
@@ -46,27 +47,32 @@ type Capabilities struct {
 }
 
 type Config struct {
-	PackageName           string
-	Mounts                []BindMount
-	Capabilities          Capabilities
-	Environment           map[string]string
-	ImgRef                string
-	PodID                 string
-	Arch                  apko_types.Architecture
-	RunAsUID              string
-	RunAs                 string
-	WorkspaceDir          string
-	CacheDir              string
-	CPU, CPUModel, Memory string
-	SSHKey                ssh.Signer
-	SSHAddress            string // SSH address for the build / chrooted environment
-	SSHControlAddress     string // SSH address for the control / management environment
-	SSHHostKey            string
-	Disk                  string
-	Timeout               time.Duration
-	SSHBuildClient        *ssh.Client // SSH client for the build environment, may not have privileges
-	SSHControlBuildClient *ssh.Client // SSH client for control operations in the build environment, has privileges
-	SSHControlClient      *ssh.Client // SSH client for unrestricted control environment, has privileges
-	QemuPID               int
-	RunAsGID              string
+	PackageName              string
+	Mounts                   []BindMount
+	Capabilities             Capabilities
+	Environment              map[string]string
+	ImgRef                   string
+	PodID                    string
+	Arch                     apko_types.Architecture
+	RunAsUID                 string
+	RunAs                    string
+	WorkspaceDir             string
+	CacheDir                 string
+	CPU, CPUModel, Memory    string
+	SSHKey                   ssh.Signer
+	SSHAddress               string             // SSH address for the build / chrooted environment
+	SSHControlAddress        string             // SSH address for the control / management environment
+	SSHHostKey               string             // Path to known_hosts file containing the VM's host key
+	VMHostKeySigner          ssh.Signer         // VM's SSH host key (private signer)
+	VMHostKeyPublic          ssh.PublicKey      // VM's SSH host key (public) - for verification
+	VMHostKeyPrivateKeyBytes []byte             // VM's SSH host key (raw private key bytes) - for injection
+	VMHostKeyPrivate         ed25519.PrivateKey // VM's SSH host key (raw private key) - for explicit zeroing
+	InitramfsPath            string             // Path to temp initramfs file (contains sensitive key material)
+	Disk                     string
+	Timeout                  time.Duration
+	SSHBuildClient           *ssh.Client // SSH client for the build environment, may not have privileges
+	SSHControlBuildClient    *ssh.Client // SSH client for control operations in the build environment, has privileges
+	SSHControlClient         *ssh.Client // SSH client for unrestricted control environment, has privileges
+	QemuPID                  int
+	RunAsGID                 string
 }

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -41,7 +41,7 @@ func (m *GeneratedMelangeConfig) SetGeneratedFromComment(comment string) {
 
 func (m *GeneratedMelangeConfig) Write(ctx context.Context, dir string) error {
 	if _, err := os.Stat(dir); os.IsNotExist(err) {
-		err = os.MkdirAll(dir, os.ModePerm)
+		err = os.MkdirAll(dir, 0o755)
 		if err != nil {
 			return fmt.Errorf("creating output directory %s: %w", dir, err)
 		}


### PR DESCRIPTION
This PR addresses some of the remaining findings we've seen. The main change is that the QEMU VM will now boot with a pre-provisioned SSH key instead of automatically trusting the host's key on boot.

To do this, we'll generate a new key, append it to the initramfs, boot the VM, and then zero out all of the sensitive material as soon as the VM is running. This ensures that none of the credentials are hanging around in memory or on disk (we also ensure that the initramfs can't be modified between its creation, the VM booting, and then its deletion) and that the sensitive material exists outside of the VM for only a handful of seconds.

Based on my local testing, this period is about 2-3 seconds:
```
2025/10/29 14:44:20 DEBU qemu: ssh - create ssh key pair
2025/10/29 14:44:20 INFO qemu: generating ssh key pairs for ephemeral VM
...
2025/10/29 14:44:23 DEBU qemu: zeroing sensitive cryptographic material from memory
2025/10/29 14:44:23 DEBU qemu: sensitive key material zeroed and GC triggered
2025/10/29 14:44:23 INFO running step "git-checkout"
...
```

`make fmt; make lint; make test` and `golangci-lint run` are clean and I can build packages with QEMU as expected (i.e., SSH works and does not immediately fail when doing the handshake).

I also added melange testing for Bubblewrap-built packages to CI (which we already do for QEMU), so the Bubblewrap changes should be verified as well. The tests use the Docker runner which is needed for the binaries with xattrs and capabilities.