### PR TITLE
fix: pin cosign-installer to v3.10.1 to avoid issues with GoReleaser

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -65,7 +65,8 @@ jobs:
           check-latest: true
 
       # Cosign is used by goreleaser to sign release artifacts.
-      - uses: sigstore/cosign-installer@7e8b541eb2e61bf99390e1afd4be13a184e9ebc5 # v3.10.1 # latest cosign v2.x release; v3.x has issues with GoReleaser
+      # The Action is pinned to v3.10.x (cosign binary v2.x) because v4 (cosign binary v3.x) has issues with GoReleaser
+      - uses: sigstore/cosign-installer@7e8b541eb2e61bf99390e1afd4be13a184e9ebc5 # v3.10.1
         if: steps.check.outputs.need_release == 'yes'
 
       - uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0


### PR DESCRIPTION
The v4 release of the `cosign-installer` Action failed with this error during our scheduled release:
```
  ⨯ release failed after 2m1s                       
    error=
    │ sign: cosign failed: exit status 1: Error: must provide --bundle with --signing-config or --use-signing-config
    │ error during command execution: must provide --bundle with --signing-config or --use-signing-config
```

This PR pins the Action to the latest version that still supports cosign v2.x to avoid this.

