### PR TITLE
feat(build/pipelines/cmake): add opts option to cmake/build

### DIFF
--- a/pkg/build/pipelines/cmake/README.md
+++ b/pkg/build/pipelines/cmake/README.md
@@ -14,6 +14,7 @@ Build a CMake project
 
 | Name | Required | Description | Default |
 | ---- | -------- | ----------- | ------- |
+| opts | false | Compile options for the CMake build.  |  |
 | output-dir | false | The output directory for the CMake build.  | output |
 
 ## cmake/configure

--- a/pkg/build/pipelines/cmake/build.yaml
+++ b/pkg/build/pipelines/cmake/build.yaml
@@ -11,6 +11,11 @@ inputs:
       The output directory for the CMake build.
     default: output
 
+  opts:
+    description: |
+      Compile options for the CMake build.
+
 pipeline:
   - runs: |
-      VERBOSE=1 cmake --build ${{inputs.output-dir}}
+      VERBOSE=1 cmake --build ${{inputs.output-dir}} \
+        ${{inputs.opts}}


### PR DESCRIPTION
This is necessary for cases where we need further options, like specifying build targets with --target build option.

## Melange Pull Request Template

<!--
*** PULL REQUEST CHECKLIST: PLEASE START HERE ***

The single most important feature of melange is that we can build Wolfi.

Many changes to melange introduce a risk of breaking the build, and sometimes
these are not flushed out until a package is changed (much) later.  This
pertains to basic execution, SCA changes, linter changes, and more.
-->

### Functional Changes

- [ ] This change can build all of Wolfi without errors (describe results in notes)

Notes:

### SCA Changes

- [ ] Examining several representative APKs show no regression / the desired effect (details in notes)

Notes:

### Linter

- [ ] The new check is clean across Wolfi
- [ ] The new check is opt-in or a warning

Notes:
