### PR TITLE
chore: pin cosign to v2.x

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -67,6 +67,9 @@ jobs:
       # Cosign is used by goreleaser to sign release artifacts.
       - uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
         if: steps.check.outputs.need_release == 'yes'
+        with:
+          # https://github.com/goreleaser/goreleaser/issues/6195
+          cosign-release: "v2.6.1"
 
       - uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
         if: steps.check.outputs.need_release == 'yes'


### PR DESCRIPTION
Relates to: #2209

This PR pins Cosign to v2.x for the time being. The v3 migration seems relatively straightforward but would also change how we sign release artifacts, so we can just retain the original functionality while we work out those details.