### PR TITLE
fetch: add support for no checksum validation

### DIFF
--- a/pkg/build/pipelines/README.md
+++ b/pkg/build/pipelines/README.md
@@ -23,6 +23,7 @@ Fetch and extract external object into workspace
 | delete | false | Whether to delete the fetched artifact after unpacking.  | false |
 | directory | false | The directory to extract the artifact into (passed to `tar -C`)  | . |
 | dns-timeout | false | The timeout (in seconds) to use for DNS lookups. The fetch will fail if the timeout is hit.  | 20 |
+| expected-none | false | There is no expected checksum.  |  |
 | expected-sha256 | false | The expected SHA256 of the downloaded artifact.  |  |
 | expected-sha512 | false | The expected SHA512 of the downloaded artifact.  |  |
 | extract | false | Whether to extract the downloaded artifact as a source tarball.  | true |

--- a/pkg/build/pipelines/fetch.yaml
+++ b/pkg/build/pipelines/fetch.yaml
@@ -28,6 +28,10 @@ inputs:
     description: |
       The expected SHA512 of the downloaded artifact.
 
+  expected-none:
+    description: |
+      There is no expected checksum.
+
   purl-name:
     description: |
       package-URL (PURL) name for use in SPDX SBOM External References
@@ -67,7 +71,7 @@ inputs:
 
 pipeline:
   - runs: |
-      if [ "${{inputs.expected-sha256}}" == "" ] && [ "${{inputs.expected-sha512}}" == "" ]; then
+      if [ "${{inputs.expected-sha256}}" == "" ] && [ "${{inputs.expected-sha512}}" == "" ] && [ "${{inputs.expected-none}}" == "" ]; then
         printf "One of expected-sha256 or expected-sha512 is required"
         exit 1
       fi
@@ -92,7 +96,9 @@ pipeline:
         wget '-T${{inputs.timeout}}' '--dns-timeout=${{inputs.dns-timeout}}' '--tries=${{inputs.retry-limit}}' --random-wait --retry-connrefused --continue '${{inputs.uri}}'
       fi
 
-      if [ "${{inputs.expected-sha256}}" != "" ]; then
+      if [ "${{inputs.expected-none}}" != "" ]; then
+        printf "fetch: Checksum validation skipped\n"
+      elif [ "${{inputs.expected-sha256}}" != "" ]; then
         printf "fetch: Expected sha256: ${{inputs.expected-sha256}}\n"
         sum=$(sha256sum $bn | awk '{print $1}')
         if [ "${{inputs.expected-sha256}}" != "$sum" ]; then


### PR DESCRIPTION
I need to download an HTML web page, which I need to end up in the
SBOM, which has no expected checksum.

This is due to website encoding current date and time on the page.

I hope this download option can be added as an explicit opt in.
