### PR TITLE
build: always perform build

### DIFF
--- a/e2e-tests/pipelines-subpackages-build-test.yaml
+++ b/e2e-tests/pipelines-subpackages-build-test.yaml
@@ -1,0 +1,27 @@
+# test that packages / subpackages build and test when there is no
+# main pipeline
+package:
+  name: pipelines-subpackages-build-test
+  description: Test that subpackages pipelines run
+  version: 0.1.0
+  epoch: 0
+environment:
+  contents:
+    packages:
+      - busybox
+
+subpackages:
+  - name: subpackage-pipelines-subpackages-build-test
+    description: test that subpackage pipeline runs without main one
+    pipeline:
+      - runs: |
+          mkdir -p ${{targets.contextdir}}/
+          touch ${{targets.contextdir}}/subpackage-pipeline
+    test:
+      environment:
+        contents:
+          packages:
+            - busybox
+      pipeline:
+        - runs: |
+            [ -e /subpackage-pipeline ]


### PR DESCRIPTION
isBuildLess check is incorrect, it produces empty packages
successfully, if there is no main pipeline, and all computation is
performed in sub-packages pipelines.

This is dangerous, as the build is "successful" when it should not be.

Also linters are skipped and not executed, when they might be needed.
