### PR TITLE
Refactor build, rebuild, test commands for flag parsing.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -147,7 +147,7 @@ require (
 	github.com/sirupsen/logrus v1.9.4-0.20230606125235-dd1b4c2e81af // indirect
 	github.com/skeema/knownhosts v1.3.1 // indirect
 	github.com/spf13/afero v1.14.0 // indirect
-	github.com/spf13/pflag v1.0.10 // indirect
+	github.com/spf13/pflag v1.0.10
 	github.com/u-root/u-root v0.15.0
 	github.com/u-root/uio v0.0.0-20240224005618-d2acac8f3701 // indirect
 	github.com/vbatts/tar-split v0.12.1 // indirect

--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -29,6 +29,7 @@ import (
 	"github.com/chainguard-dev/clog"
 	"github.com/go-git/go-git/v5"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/exporters/stdout/stdouttrace"
 	"go.opentelemetry.io/otel/sdk/trace"
@@ -42,47 +43,120 @@ import (
 
 const BuiltinPipelineDir = "/usr/share/melange/pipelines"
 
-func buildCmd() *cobra.Command {
-	var buildDate string
-	var workspaceDir string
-	var pipelineDir string
-	var sourceDir string
-	var cacheDir string
-	var cacheSource string
-	var apkCacheDir string
-	var signingKey string
-	var generateIndex bool
-	var emptyWorkspace bool
-	var stripOriginName bool
-	var outDir string
-	var archstrs []string
-	var extraKeys []string
-	var extraRepos []string
-	var dependencyLog string
-	var envFile string
-	var varsFile string
-	var purlNamespace string
-	var buildOption []string
-	var createBuildLog bool
-	var persistLintResults bool
-	var debug bool
-	var debugRunner bool
-	var interactive bool
-	var remove bool
-	var runner string
-	var cpu, cpumodel, memory, disk string
-	var timeout time.Duration
-	var extraPackages []string
-	var libc string
-	var lintRequire, lintWarn []string
-	var ignoreSignatures bool
-	var cleanup bool
-	var configFileGitCommit string
-	var configFileGitRepoURL string
-	var configFileLicense string
-	var generateProvenance bool
+// addBuildFlags registers all build command flags to the provided FlagSet using the BuildFlags struct
+func addBuildFlags(fs *pflag.FlagSet, flags *BuildFlags) {
+	fs.StringVar(&flags.BuildDate, "build-date", "", "date used for the timestamps of the files inside the image")
+	fs.StringVar(&flags.WorkspaceDir, "workspace-dir", "", "directory used for the workspace at /home/build")
+	fs.StringVar(&flags.PipelineDir, "pipeline-dir", "", "directory used to extend defined built-in pipelines")
+	fs.StringVar(&flags.SourceDir, "source-dir", "", "directory used for included sources")
+	fs.StringVar(&flags.CacheDir, "cache-dir", "./melange-cache/", "directory used for cached inputs")
+	fs.StringVar(&flags.CacheSource, "cache-source", "", "directory or bucket used for preloading the cache")
+	fs.StringVar(&flags.ApkCacheDir, "apk-cache-dir", "", "directory used for cached apk packages (default is system-defined cache directory)")
+	fs.StringVar(&flags.SigningKey, "signing-key", "", "key to use for signing")
+	fs.StringVar(&flags.EnvFile, "env-file", "", "file to use for preloaded environment variables")
+	fs.StringVar(&flags.VarsFile, "vars-file", "", "file to use for preloaded build configuration variables")
+	fs.BoolVar(&flags.GenerateIndex, "generate-index", true, "whether to generate APKINDEX.tar.gz")
+	fs.BoolVar(&flags.EmptyWorkspace, "empty-workspace", false, "whether the build workspace should be empty")
+	fs.BoolVar(&flags.StripOriginName, "strip-origin-name", false, "whether origin names should be stripped (for bootstrap)")
+	fs.StringVar(&flags.OutDir, "out-dir", "./packages/", "directory where packages will be output")
+	fs.StringVar(&flags.DependencyLog, "dependency-log", "", "log dependencies to a specified file")
+	fs.StringVar(&flags.PurlNamespace, "namespace", "unknown", "namespace to use in package URLs in SBOM (eg wolfi, alpine)")
+	fs.StringSliceVar(&flags.Archstrs, "arch", nil, "architectures to build for (e.g., x86_64,ppc64le,arm64) -- default is all, unless specified in config")
+	fs.StringVar(&flags.Libc, "override-host-triplet-libc-substitution-flavor", "gnu", "override the flavor of libc for ${{host.triplet.*}} substitutions (e.g. gnu,musl) -- default is gnu")
+	fs.StringSliceVar(&flags.BuildOption, "build-option", []string{}, "build options to enable")
+	fs.StringVar(&flags.Runner, "runner", "", fmt.Sprintf("which runner to use to enable running commands, default is based on your platform. Options are %q", build.GetAllRunners()))
+	fs.StringSliceVarP(&flags.ExtraKeys, "keyring-append", "k", []string{}, "path to extra keys to include in the build environment keyring")
+	fs.StringSliceVarP(&flags.ExtraRepos, "repository-append", "r", []string{}, "path to extra repositories to include in the build environment")
+	fs.StringSliceVar(&flags.ExtraPackages, "package-append", []string{}, "extra packages to install for each of the build environments")
+	fs.BoolVar(&flags.CreateBuildLog, "create-build-log", false, "creates a package.log file containing a list of packages that were built by the command")
+	fs.BoolVar(&flags.PersistLintResults, "persist-lint-results", false, "persist lint results to JSON files in packages/{arch}/ directory")
+	fs.BoolVar(&flags.Debug, "debug", false, "enables debug logging of build pipelines")
+	fs.BoolVar(&flags.DebugRunner, "debug-runner", false, "when enabled, the builder pod will persist after the build succeeds or fails")
+	fs.BoolVarP(&flags.Interactive, "interactive", "i", false, "when enabled, attaches stdin with a tty to the pod on failure")
+	fs.BoolVar(&flags.Remove, "rm", true, "clean up intermediate artifacts (e.g. container images, temp dirs)")
+	fs.StringVar(&flags.CPU, "cpu", "", "default CPU resources to use for builds")
+	fs.StringVar(&flags.CPUModel, "cpumodel", "", "default memory resources to use for builds")
+	fs.StringVar(&flags.Disk, "disk", "", "disk size to use for builds")
+	fs.StringVar(&flags.Memory, "memory", "", "default memory resources to use for builds")
+	fs.DurationVar(&flags.Timeout, "timeout", 0, "default timeout for builds")
+	fs.StringVar(&flags.TraceFile, "trace", "", "where to write trace output")
+	fs.StringSliceVar(&flags.LintRequire, "lint-require", linter.DefaultRequiredLinters(), "linters that must pass")
+	fs.StringSliceVar(&flags.LintWarn, "lint-warn", linter.DefaultWarnLinters(), "linters that will generate warnings")
+	fs.BoolVar(&flags.IgnoreSignatures, "ignore-signatures", false, "ignore repository signature verification")
+	fs.BoolVar(&flags.Cleanup, "cleanup", true, "when enabled, the temp dir used for the guest will be cleaned up after completion")
+	fs.StringVar(&flags.ConfigFileGitCommit, "git-commit", "", "commit hash of the git repository containing the build config file (defaults to detecting HEAD)")
+	fs.StringVar(&flags.ConfigFileGitRepoURL, "git-repo-url", "", "URL of the git repository containing the build config file (defaults to detecting from configured git remotes)")
+	fs.StringVar(&flags.ConfigFileLicense, "license", "NOASSERTION", "license to use for the build config file itself")
+	fs.BoolVar(&flags.GenerateProvenance, "generate-provenance", false, "generate SLSA provenance for builds (included in a separate .attest.tar.gz file next to the APK)")
 
-	var traceFile string
+	_ = fs.Bool("fail-on-lint-warning", false, "DEPRECATED: DO NOT USE")
+	_ = fs.MarkDeprecated("fail-on-lint-warning", "use --lint-require and --lint-warn instead")
+}
+
+// BuildFlags holds all parsed build command flags
+type BuildFlags struct {
+	BuildDate            string
+	WorkspaceDir         string
+	PipelineDir          string
+	SourceDir            string
+	CacheDir             string
+	CacheSource          string
+	ApkCacheDir          string
+	SigningKey           string
+	GenerateIndex        bool
+	EmptyWorkspace       bool
+	StripOriginName      bool
+	OutDir               string
+	Archstrs             []string
+	ExtraKeys            []string
+	ExtraRepos           []string
+	DependencyLog        string
+	EnvFile              string
+	VarsFile             string
+	PurlNamespace        string
+	BuildOption          []string
+	CreateBuildLog       bool
+	PersistLintResults   bool
+	Debug                bool
+	DebugRunner          bool
+	Interactive          bool
+	Remove               bool
+	Runner               string
+	CPU                  string
+	CPUModel             string
+	Memory               string
+	Disk                 string
+	Timeout              time.Duration
+	ExtraPackages        []string
+	Libc                 string
+	LintRequire          []string
+	LintWarn             []string
+	IgnoreSignatures     bool
+	Cleanup              bool
+	ConfigFileGitCommit  string
+	ConfigFileGitRepoURL string
+	ConfigFileLicense    string
+	GenerateProvenance   bool
+	TraceFile            string
+}
+
+// ParseBuildFlags parses build flags from the provided args and returns a BuildFlags struct
+func ParseBuildFlags(args []string) (*BuildFlags, []string, error) {
+	flags := &BuildFlags{}
+
+	fs := pflag.NewFlagSet("build", pflag.ContinueOnError)
+	addBuildFlags(fs, flags)
+
+	if err := fs.Parse(args); err != nil {
+		return nil, nil, err
+	}
+
+	return flags, fs.Args(), nil
+}
+
+func buildCmd() *cobra.Command {
+	// Create BuildFlags struct (defaults are set in addBuildFlags)
+	flags := &BuildFlags{}
 
 	cmd := &cobra.Command{
 		Use:     "build",
@@ -99,8 +173,8 @@ func buildCmd() *cobra.Command {
 				buildConfigFilePath = args[0] // e.g. "crane.yaml"
 			}
 
-			if traceFile != "" {
-				w, err := os.Create(traceFile) // #nosec G304 - User-specified trace file output
+			if flags.TraceFile != "" {
+				w, err := os.Create(flags.TraceFile) // #nosec G304 - User-specified trace file output
 				if err != nil {
 					return fmt.Errorf("creating trace file: %w", err)
 				}
@@ -123,7 +197,7 @@ func buildCmd() *cobra.Command {
 				ctx = tctx
 			}
 
-			r, err := getRunner(ctx, runner, remove)
+			r, err := getRunner(ctx, flags.Runner, flags.Remove)
 			if err != nil {
 				return err
 			}
@@ -132,78 +206,78 @@ func buildCmd() *cobra.Command {
 			// melange build definition. As a fallback, detect this from local git state.
 			// Git auto-detection should be "best effort" and not fail the build if it
 			// fails.
-			if configFileGitCommit == "" {
+			if flags.ConfigFileGitCommit == "" {
 				log.Debugf("git commit for build config not provided, attempting to detect automatically")
 				commit, err := detectGitHead(ctx, buildConfigFilePath)
 				if err != nil {
 					log.Warnf("unable to detect commit for build config file: %v", err)
-					configFileGitCommit = "unknown"
+					flags.ConfigFileGitCommit = "unknown"
 				} else {
-					configFileGitCommit = commit
+					flags.ConfigFileGitCommit = commit
 				}
 			}
-			if configFileGitRepoURL == "" {
+			if flags.ConfigFileGitRepoURL == "" {
 				log.Warnf("git repository URL for build config not provided")
-				configFileGitRepoURL = "https://unknown/unknown/unknown"
+				flags.ConfigFileGitRepoURL = "https://unknown/unknown/unknown"
 			}
 
-			archs := apko_types.ParseArchitectures(archstrs)
-			log.Infof("melange version %s with runner %s building %s at commit %s for arches %s", cmd.Version, r.Name(), buildConfigFilePath, configFileGitCommit, archs)
+			archs := apko_types.ParseArchitectures(flags.Archstrs)
+			log.Infof("melange version %s with runner %s building %s at commit %s for arches %s", cmd.Version, r.Name(), buildConfigFilePath, flags.ConfigFileGitCommit, archs)
 			options := []build.Option{
-				build.WithBuildDate(buildDate),
-				build.WithWorkspaceDir(workspaceDir),
+				build.WithBuildDate(flags.BuildDate),
+				build.WithWorkspaceDir(flags.WorkspaceDir),
 				// Order matters, so add any specified pipelineDir before
 				// builtin pipelines.
-				build.WithPipelineDir(pipelineDir),
+				build.WithPipelineDir(flags.PipelineDir),
 				build.WithPipelineDir(BuiltinPipelineDir),
-				build.WithCacheDir(cacheDir),
-				build.WithCacheSource(cacheSource),
-				build.WithPackageCacheDir(apkCacheDir),
-				build.WithSigningKey(signingKey),
-				build.WithGenerateIndex(generateIndex),
-				build.WithEmptyWorkspace(emptyWorkspace),
-				build.WithOutDir(outDir),
-				build.WithExtraKeys(extraKeys),
-				build.WithExtraRepos(extraRepos),
-				build.WithExtraPackages(extraPackages),
-				build.WithDependencyLog(dependencyLog),
-				build.WithStripOriginName(stripOriginName),
-				build.WithEnvFile(envFile),
-				build.WithVarsFile(varsFile),
-				build.WithNamespace(purlNamespace),
-				build.WithEnabledBuildOptions(buildOption),
-				build.WithCreateBuildLog(createBuildLog),
-				build.WithPersistLintResults(persistLintResults),
-				build.WithDebug(debug),
-				build.WithDebugRunner(debugRunner),
-				build.WithInteractive(interactive),
-				build.WithRemove(remove),
+				build.WithCacheDir(flags.CacheDir),
+				build.WithCacheSource(flags.CacheSource),
+				build.WithPackageCacheDir(flags.ApkCacheDir),
+				build.WithSigningKey(flags.SigningKey),
+				build.WithGenerateIndex(flags.GenerateIndex),
+				build.WithEmptyWorkspace(flags.EmptyWorkspace),
+				build.WithOutDir(flags.OutDir),
+				build.WithExtraKeys(flags.ExtraKeys),
+				build.WithExtraRepos(flags.ExtraRepos),
+				build.WithExtraPackages(flags.ExtraPackages),
+				build.WithDependencyLog(flags.DependencyLog),
+				build.WithStripOriginName(flags.StripOriginName),
+				build.WithEnvFile(flags.EnvFile),
+				build.WithVarsFile(flags.VarsFile),
+				build.WithNamespace(flags.PurlNamespace),
+				build.WithEnabledBuildOptions(flags.BuildOption),
+				build.WithCreateBuildLog(flags.CreateBuildLog),
+				build.WithPersistLintResults(flags.PersistLintResults),
+				build.WithDebug(flags.Debug),
+				build.WithDebugRunner(flags.DebugRunner),
+				build.WithInteractive(flags.Interactive),
+				build.WithRemove(flags.Remove),
 				build.WithRunner(r),
-				build.WithLintRequire(lintRequire),
-				build.WithLintWarn(lintWarn),
-				build.WithCPU(cpu),
-				build.WithCPUModel(cpumodel),
-				build.WithDisk(disk),
-				build.WithMemory(memory),
-				build.WithTimeout(timeout),
-				build.WithLibcFlavorOverride(libc),
-				build.WithIgnoreSignatures(ignoreSignatures),
-				build.WithConfigFileRepositoryCommit(configFileGitCommit),
-				build.WithConfigFileRepositoryURL(configFileGitRepoURL),
-				build.WithConfigFileLicense(configFileLicense),
-				build.WithGenerateProvenance(generateProvenance),
+				build.WithLintRequire(flags.LintRequire),
+				build.WithLintWarn(flags.LintWarn),
+				build.WithCPU(flags.CPU),
+				build.WithCPUModel(flags.CPUModel),
+				build.WithDisk(flags.Disk),
+				build.WithMemory(flags.Memory),
+				build.WithTimeout(flags.Timeout),
+				build.WithLibcFlavorOverride(flags.Libc),
+				build.WithIgnoreSignatures(flags.IgnoreSignatures),
+				build.WithConfigFileRepositoryCommit(flags.ConfigFileGitCommit),
+				build.WithConfigFileRepositoryURL(flags.ConfigFileGitRepoURL),
+				build.WithConfigFileLicense(flags.ConfigFileLicense),
+				build.WithGenerateProvenance(flags.GenerateProvenance),
 			}
 
 			if len(args) > 0 {
 				options = append(options, build.WithConfig(buildConfigFilePath))
 
-				if sourceDir == "" {
-					sourceDir = filepath.Dir(buildConfigFilePath)
+				if flags.SourceDir == "" {
+					flags.SourceDir = filepath.Dir(buildConfigFilePath)
 				}
 			}
 
-			if sourceDir != "" {
-				options = append(options, build.WithSourceDir(sourceDir))
+			if flags.SourceDir != "" {
+				options = append(options, build.WithSourceDir(flags.SourceDir))
 			}
 
 			if auth, ok := os.LookupEnv("HTTP_AUTH"); !ok {
@@ -221,52 +295,8 @@ func buildCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&buildDate, "build-date", "", "date used for the timestamps of the files inside the image")
-	cmd.Flags().StringVar(&workspaceDir, "workspace-dir", "", "directory used for the workspace at /home/build")
-	cmd.Flags().StringVar(&pipelineDir, "pipeline-dir", "", "directory used to extend defined built-in pipelines")
-	cmd.Flags().StringVar(&sourceDir, "source-dir", "", "directory used for included sources")
-	cmd.Flags().StringVar(&cacheDir, "cache-dir", "./melange-cache/", "directory used for cached inputs")
-	cmd.Flags().StringVar(&cacheSource, "cache-source", "", "directory or bucket used for preloading the cache")
-	cmd.Flags().StringVar(&apkCacheDir, "apk-cache-dir", "", "directory used for cached apk packages (default is system-defined cache directory)")
-	cmd.Flags().StringVar(&signingKey, "signing-key", "", "key to use for signing")
-	cmd.Flags().StringVar(&envFile, "env-file", "", "file to use for preloaded environment variables")
-	cmd.Flags().StringVar(&varsFile, "vars-file", "", "file to use for preloaded build configuration variables")
-	cmd.Flags().BoolVar(&generateIndex, "generate-index", true, "whether to generate APKINDEX.tar.gz")
-	cmd.Flags().BoolVar(&emptyWorkspace, "empty-workspace", false, "whether the build workspace should be empty")
-	cmd.Flags().BoolVar(&stripOriginName, "strip-origin-name", false, "whether origin names should be stripped (for bootstrap)")
-	cmd.Flags().StringVar(&outDir, "out-dir", "./packages/", "directory where packages will be output")
-	cmd.Flags().StringVar(&dependencyLog, "dependency-log", "", "log dependencies to a specified file")
-	cmd.Flags().StringVar(&purlNamespace, "namespace", "unknown", "namespace to use in package URLs in SBOM (eg wolfi, alpine)")
-	cmd.Flags().StringSliceVar(&archstrs, "arch", nil, "architectures to build for (e.g., x86_64,ppc64le,arm64) -- default is all, unless specified in config")
-	cmd.Flags().StringVar(&libc, "override-host-triplet-libc-substitution-flavor", "gnu", "override the flavor of libc for ${{host.triplet.*}} substitutions (e.g. gnu,musl) -- default is gnu")
-	cmd.Flags().StringSliceVar(&buildOption, "build-option", []string{}, "build options to enable")
-	cmd.Flags().StringVar(&runner, "runner", "", fmt.Sprintf("which runner to use to enable running commands, default is based on your platform. Options are %q", build.GetAllRunners()))
-	cmd.Flags().StringSliceVarP(&extraKeys, "keyring-append", "k", []string{}, "path to extra keys to include in the build environment keyring")
-	cmd.Flags().StringSliceVarP(&extraRepos, "repository-append", "r", []string{}, "path to extra repositories to include in the build environment")
-	cmd.Flags().StringSliceVar(&extraPackages, "package-append", []string{}, "extra packages to install for each of the build environments")
-	cmd.Flags().BoolVar(&createBuildLog, "create-build-log", false, "creates a package.log file containing a list of packages that were built by the command")
-	cmd.Flags().BoolVar(&persistLintResults, "persist-lint-results", false, "persist lint results to JSON files in packages/{arch}/ directory")
-	cmd.Flags().BoolVar(&debug, "debug", false, "enables debug logging of build pipelines")
-	cmd.Flags().BoolVar(&debugRunner, "debug-runner", false, "when enabled, the builder pod will persist after the build succeeds or fails")
-	cmd.Flags().BoolVarP(&interactive, "interactive", "i", false, "when enabled, attaches stdin with a tty to the pod on failure")
-	cmd.Flags().BoolVar(&remove, "rm", true, "clean up intermediate artifacts (e.g. container images, temp dirs)")
-	cmd.Flags().StringVar(&cpu, "cpu", "", "default CPU resources to use for builds")
-	cmd.Flags().StringVar(&cpumodel, "cpumodel", "", "default memory resources to use for builds")
-	cmd.Flags().StringVar(&disk, "disk", "", "disk size to use for builds")
-	cmd.Flags().StringVar(&memory, "memory", "", "default memory resources to use for builds")
-	cmd.Flags().DurationVar(&timeout, "timeout", 0, "default timeout for builds")
-	cmd.Flags().StringVar(&traceFile, "trace", "", "where to write trace output")
-	cmd.Flags().StringSliceVar(&lintRequire, "lint-require", linter.DefaultRequiredLinters(), "linters that must pass")
-	cmd.Flags().StringSliceVar(&lintWarn, "lint-warn", linter.DefaultWarnLinters(), "linters that will generate warnings")
-	cmd.Flags().BoolVar(&ignoreSignatures, "ignore-signatures", false, "ignore repository signature verification")
-	cmd.Flags().BoolVar(&cleanup, "cleanup", true, "when enabled, the temp dir used for the guest will be cleaned up after completion")
-	cmd.Flags().StringVar(&configFileGitCommit, "git-commit", "", "commit hash of the git repository containing the build config file (defaults to detecting HEAD)")
-	cmd.Flags().StringVar(&configFileGitRepoURL, "git-repo-url", "", "URL of the git repository containing the build config file (defaults to detecting from configured git remotes)")
-	cmd.Flags().StringVar(&configFileLicense, "license", "NOASSERTION", "license to use for the build config file itself")
-	cmd.Flags().BoolVar(&generateProvenance, "generate-provenance", false, "generate SLSA provenance for builds (included in a separate .attest.tar.gz file next to the APK)")
-
-	_ = cmd.Flags().Bool("fail-on-lint-warning", false, "DEPRECATED: DO NOT USE")
-	_ = cmd.Flags().MarkDeprecated("fail-on-lint-warning", "use --lint-require and --lint-warn instead")
+	// Register all flags using the helper function
+	addBuildFlags(cmd.Flags(), flags)
 
 	return cmd
 }


### PR DESCRIPTION
Allows for flexible flag parsing so that flags can be parsed outside of the command libraries.

This is largely a refactor and is not intended to have any effect on behavior.