### PR TITLE
build: derive logger from incoming context

### DIFF
--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log/slog"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -393,8 +392,8 @@ func BuildCmd(ctx context.Context, archs []apko_types.Architecture, baseOpts ...
 		errg.Go(func() error {
 			lctx := ctx
 			if len(bcs) != 1 {
-				log := clog.New(slog.Default().Handler()).With("arch", bc.Arch.ToAPK())
-				lctx = clog.WithLogger(ctx, log)
+				alog := log.With("arch", bc.Arch.ToAPK())
+				lctx = clog.WithLogger(ctx, alog)
 			}
 
 			if err := bc.BuildPackage(lctx); err != nil {


### PR DESCRIPTION
Instead of making a new logger, annotate the logger from the incoming context with the arch information. This makes it more flexible to provide custom loggers from other sources.