### PR TITLE
Convert instances of new logger creation to clog.FromContext

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"log/slog"
 	"maps"
 	"math"
 	"os"
@@ -183,7 +182,7 @@ func New(ctx context.Context, opts ...Option) (*Build, error) {
 		}
 	}
 
-	log := clog.New(slog.Default().Handler()).With("arch", b.Arch.ToAPK())
+	log := clog.FromContext(ctx).With("arch", b.Arch.ToAPK())
 	ctx = clog.WithLogger(ctx, log)
 
 	// If no workspace directory is explicitly requested, create a

--- a/pkg/build/test.go
+++ b/pkg/build/test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"io/fs"
-	"log/slog"
 	"maps"
 	"os"
 	"path/filepath"
@@ -80,7 +79,7 @@ func NewTest(ctx context.Context, opts ...TestOption) (*Test, error) {
 		}
 	}
 
-	log := clog.New(slog.Default().Handler()).With("arch", t.Arch)
+	log := clog.FromContext(ctx).With("arch", t.Arch)
 	ctx = clog.WithLogger(ctx, log)
 
 	// If no workspace directory is explicitly requested, create a


### PR DESCRIPTION
Changing more instances of respecting loggers already in the context so that callers can configure the logger as needed through the context.
