### PR TITLE
git-checkout: Invoke `git fetch` with `--unshallow`

### DIFF
--- a/pkg/build/pipelines/git-checkout.yaml
+++ b/pkg/build/pipelines/git-checkout.yaml
@@ -121,7 +121,7 @@ pipeline:
             if [ -n "$branch" ]; then
                 case " $fetched_branches " in
                     *" $branch "*) ;;
-                    *) vr git fetch origin $branch:$branch || {
+                    *) vr git fetch --unshallow origin $branch:$branch || {
                         msg "failed to fetch branch $branch"
                         return 1
                         }


### PR DESCRIPTION
Melange currently barfs on specific cherry-pick situations like the one at https://github.com/wolfi-dev/os/pull/74858 .  I spent some time investigating this and found that this happens because the initial `git clone` to fetch a tag is done in shallow mode, and then subsequent `git fetch` commands will be constrained by the "shallowness" that was created.  I was surprised to find @smoser's https://github.com/chainguard-dev/melange/issues/1473 which pretty much reached the same conclusion.

My suggestion is that we should bite the bullet here and just invoke the `git fetch` that's run during `cherry-pick` using the `--unshallow` option.  The downside is that this will pull in the entire repository history, which can be a lot in some cases.

Closes: #1473 