### PR TITLE
fix(bump & cache): Do not fail when main pipeline is not present

### DIFF
--- a/pkg/renovate/bump/bump.go
+++ b/pkg/renovate/bump/bump.go
@@ -120,6 +120,12 @@ func New(ctx context.Context, opts ...Option) renovate.Renovator {
 		// Find our main pipeline YAML node.
 		pipelineNode, err := renovate.NodeFromMapping(rc.Configuration.Root().Content[0], "pipeline")
 		if err != nil {
+			// The main pipeline doesn't exist. This is valid for empty virtual and metapackages so
+			// we will just return early instead of throwing an error
+			if strings.Contains(err.Error(), "not found in mapping") {
+				log.Infof("no main pipeline found, will not update expected commits or checksums")
+				return nil
+			}
 			return err
 		}
 

--- a/pkg/renovate/cache/cache.go
+++ b/pkg/renovate/cache/cache.go
@@ -99,6 +99,12 @@ func New(opts ...Option) renovate.Renovator {
 		// Find our main pipeline YAML node.
 		pipelineNode, err := renovate.NodeFromMapping(rc.Configuration.Root().Content[0], "pipeline")
 		if err != nil {
+			// The main pipeline doesn't exist. This is valid for empty virtual and metapackages so
+			// we will just return early instead of throwing an error
+			if strings.Contains(err.Error(), "not found in mapping") {
+				log.Infof("no main pipeline found, will not cache any artifacts")
+				return nil
+			}
 			return err
 		}
 


### PR DESCRIPTION
It is now possible to have empty virtal and metapackage manifests that do not contain a main pipeline key. Currently, attempting to bump or use melange cache with these packages will fail as they are unable to find the main pipeline

Instead of throwing an error, handle the case where it's not present and return early