### PR TITLE
pkg: Emit appCpe stanza in package notes metadata

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -76,7 +76,7 @@ rm -Rf "$@"`,
 }
 
 var gccLinkTemplate = `*link:
-+ --package-metadata={"type":"apk","os":"{{.Namespace}}","name":"{{.Configuration.Package.Name}}","version":"{{.Configuration.Package.FullVersion}}","architecture":"{{.Arch.ToAPK}}"}
++ --package-metadata={"type":"apk","os":"{{.Namespace}}","name":"{{.Configuration.Package.Name}}","version":"{{.Configuration.Package.FullVersion}}","architecture":"{{.Arch.ToAPK}}"{{if .Configuration.Package.CPE.Vendor}},"appCpe":"{{.Configuration.Package.CPEString}}"{{end}}}
 `
 
 var ErrSkipThisArch = errors.New("error: skip this arch")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -192,8 +192,9 @@ type Resources struct {
 // against NVD records.
 func (p Package) CPEString() (string, error) {
 	const anyValue = "*"
+	const partApplication = "a"
 
-	part := anyValue
+	part := partApplication
 	if p.CPE.Part != "" {
 		part = p.CPE.Part
 	}
@@ -231,6 +232,9 @@ func (p Package) CPEString() (string, error) {
 	}
 
 	// Last-mile validation to avoid headaches downstream of this.
+	if !slices.Contains([]string{"a", "h", "o"}, part) {
+		return "", fmt.Errorf("part value must be a, h or o")
+	}
 	if vendor == anyValue {
 		return "", fmt.Errorf("vendor value must be exactly specified")
 	}


### PR DESCRIPTION
Use CPEString() function, to generated appCpe when a package Vendor is set.

This is to comply with the new revision of [UAPI Group Specification](https://uapi-group.org/specifications/specs/package_metadata_for_executable_files/)
and to hint this information to SBOM generators and CVE scanners (for
example grype has implemented support for this).

Note it is quite odd to have "*" value for the CPE part (or type), as
there are currently only three valid values ("a" application, "h"
hardware, and "o" os). hence init the default CPE to "a" application,
and validate that only these three values are acceptable.

There are no direct tests for this, but workplace population is still
successful. And ultimately it matters that gcc is able to process the
new link file and emit correct metadata. I have validated this by
manually building zip (no CPE data) & giflib (with CPE data), and both
build and link correctly.

Once grype/syft support is stable and out in the next release, we
could look into making e2e integration test => come up with a custom
CPE and check that produced package/binary has the declared appCpe in
the syft sbom result.

Note only two packages currently set `cpe:` in wolfi, and both build correctly with this change. Packages without cpe data are tested by existing e2e pipelines within presubmit for this PR.