### PR TITLE
git pipeline: fix cherry-picking multiple commits

### DIFF
--- a/e2e-tests/git-checkout-build.yaml
+++ b/e2e-tests/git-checkout-build.yaml
@@ -197,13 +197,19 @@ pipeline:
       branch: 1.x
       cherry-picks: |
         main/582b4d7d62f1c512568649ce8b6db085a3d85a9f: here comment
+        cpick/16138cad5f7729c79eca69b4cf808247d5eed76c: second cherry-pick
 
   - name: "check cherry-picks"
     working-directory: cherry-pick-test
     runs: |
       hash=$(git rev-parse --verify HEAD)
+      status=$(git status -b --porcelain)
       expected_hash="225e712ae452645acbd8f137b13d6b1ded8a96a1"
       [ "$hash" != "$expected_hash" ]
+      # git status should show being two commits head
+      [ "$status" == "## 1.x...origin/1.x [ahead 2]" ]
+      # for-cherry-pick.txt should exist as a file
+      [ -f for-cherry-pick.txt ]
       cd ..
       rm -R cherry-pick-test
 

--- a/e2e-tests/test-fixtures/create-git-repo
+++ b/e2e-tests/test-fixtures/create-git-repo
@@ -85,6 +85,13 @@ v gtag dev HEAD
 v wfile README "more stuff on dev"
 v gcommit -m "more stuff on dev" README
 
+v git checkout --quiet -b cpick main
+v wfile README "cherry-pick source branch stuff"
+v gcommit -m "cherry-pick source branch stuff" README
+v wfile for-cherry-pick.txt "cherry-pickable file"
+v git add for-cherry-pick.txt
+v gcommit -m "add second cherry-pick source" for-cherry-pick.txt
+
 v git checkout --quiet main
 v wfile README "mainline stuff"
 v gcommit -m "mainline stuff" README

--- a/pkg/build/pipelines/git-checkout.yaml
+++ b/pkg/build/pipelines/git-checkout.yaml
@@ -94,7 +94,7 @@ pipeline:
             return 1
         fi
 
-        local line="" branch="" hash="" comment=""
+        local line="" branch="" hash="" comment="" unshallow_arg is_shallow
         while IFS= read -r line; do
             # Drop anything after #
             line=${line%%#*}
@@ -118,10 +118,16 @@ pipeline:
             # If branch information exists, strip it off to just leave the branch name
             [ "$branch" != "$hash" ] && branch=${branch%/*} || branch=""
 
+            unshallow_arg=""
+            is_shallow=$(git rev-parse --is-shallow-repository)
+            if [ "$is_shallow" == "true" ] ; then
+                unshallow_arg="--unshallow"
+            fi
+
             if [ -n "$branch" ]; then
                 case " $fetched_branches " in
                     *" $branch "*) ;;
-                    *) vr git fetch --unshallow origin $branch:$branch || {
+                    *) vr git fetch $unshallow_arg origin $branch:$branch || {
                         msg "failed to fetch branch $branch"
                         return 1
                         }


### PR DESCRIPTION
The commit 149f46c7 ("git-checkout: Invoke `git fetch` with `--unshallow` (#2258)") attempted to ensure that commits for cherry-picking could be found by adding the `--unshallow` argument; however this fails when cherry-picking multiple commits because calling `git fetch --unshallow` on a repo that is not a shallow checkout causes a fatal error:

```
[git checkout] Cherry-picked 582b4d7d62f1c512568649ce8b6db085a3d85a9f from main with comment: here comment
[git checkout] execute: git fetch --unshallow origin cpick:cpick
[git checkout] failed to fetch branch cpick
[git checkout] FAIL failed to apply cherry-pick
WARN fatal: --unshallow on a complete repository does not make sense
```

Fix this by only passing the `--unshallow` argument if the repository is in a shallow state and update the e2e tests to check for this condition.

fixes: 149f46c7 ("git-checkout: Invoke `git fetch` with `--unshallow` (#2258)")