### PR TITLE
qemu_runner: Improve error output when tarring workspace

### DIFF
--- a/pkg/container/qemu_runner.go
+++ b/pkg/container/qemu_runner.go
@@ -444,6 +444,13 @@ func (bw *qemu) WorkspaceTar(ctx context.Context, cfg *Config, extraFiles []stri
 	}
 	defer outFile.Close()
 
+	errFile_path := filepath.Join(cfg.WorkspaceDir, ".error-file")
+	errFile, err := os.Create(errFile_path)
+	if err != nil {
+		return nil, err
+	}
+	defer errFile.Close()
+
 	clog.FromContext(ctx).Infof("fetching remote workspace")
 	// work around missing scp (needs openssh-sftp package), we just tar the file
 	// and pipe the output to our local file. It is potentially slower, but being
@@ -459,26 +466,25 @@ func (bw *qemu) WorkspaceTar(ctx context.Context, cfg *Config, extraFiles []stri
 		retrieveCommand += " -T extrafiles.txt"
 	}
 
-	log := clog.FromContext(ctx)
-	stderr := logwriter.New(log.Debug)
 	err = sendSSHCommand(ctx,
 		cfg.SSHControlClient,
 		cfg,
 		nil,
-		stderr,
+		errFile,
 		outFile,
 		false,
 		[]string{"sh", "-c", retrieveCommand},
 	)
 	if err != nil {
-		var buf bytes.Buffer
-		_, cerr := io.Copy(&buf, outFile)
-		if cerr != nil {
-			clog.FromContext(ctx).Errorf("failed to tar workspace: %v", cerr)
-			return nil, cerr
+		savederr := err
+		outErr, err := os.ReadFile(errFile_path)
+		if err == nil {
+			clog.FromContext(ctx).Errorf("failed to tar workspace:\n%s", string(outErr))
+		} else {
+			clog.FromContext(ctx).Errorf("failed to tar workspace; failed to obtain error output")
 		}
-		clog.FromContext(ctx).Errorf("failed to tar workspace: %v", buf.String())
-		return nil, err
+
+		return nil, savederr
 	}
 
 	return os.Open(outFile.Name())


### PR DESCRIPTION
When tarring the workspace fails, we try to obtain some information from the output file.  This doesn't make much sense as it's either going to be a corrupted tar file, or an empty file.

Instead, let's save the stderr output in a separate file and print its contents in case there's some issue.  This makes is clearer what happened, and allows us to have an output like:

```
2026/01/10 00:28:31 ERRO Failed to run command "sh -c 'cd /mount/home/build && find melange-out -type p -delete > /dev/null 2>&1 || true && tar cvpf - --xattrs --acls melange-out -T extrafiles.txt'": Process exited with status 2
2026/01/10 00:28:31 ERRO failed to tar workspace:
tar: POSIX ACL support is not available
melange-out/
melange-out/example-package/
melange-out/example-package/usr/
melange-out/example-package/usr/test
tar: Removing leading `/' from member names
tar: /non/existent/path: Cannot stat: No such file or directory
tar: Exiting with failure status due to previous errors

2026/01/10 00:28:31 INFO qemu: sending shutdown signal
```

Fixes: https://github.com/chainguard-dev/melange/issues/2286