### PR TITLE
feat(config): point UV_CACHE_DIR and PIP_CACHE_DIR to /var/cache/melange/ by default

### DIFF
--- a/docs/BUILD-CACHE.md
+++ b/docs/BUILD-CACHE.md
@@ -85,3 +85,42 @@ pipeline:
 ```
 
 This caching support helps significantly speed up Python builds that use UV by avoiding repeated downloads of packages across builds.
+
+### Example: Python pip
+
+If you're using Melange to build a Python project with the standard `pip` package manager, you can take advantage of melange's built-in pip cache support to speed up your builds.
+
+Melange automatically sets the `PIP_CACHE_DIR` environment variable to `/var/cache/melange/pip` by default. This means you can use the `--cache-dir` flag to mount a local directory that will be used as the pip cache:
+
+```shell
+melange build --cache-dir /path/to/your/cache ...
+```
+
+When using a dedicated pip cache directory on your host, you can mount it directly:
+
+```shell
+# Create a cache directory
+mkdir -p ~/.cache/melange
+
+# Run melange with the cache directory
+melange build --cache-dir ~/.cache/melange ...
+```
+
+The pip cache will be stored under `/var/cache/melange/pip` inside the build environment. If you want to customize this path, you can override it in your Melange config:
+
+```yaml
+environment:
+  environment:
+    PIP_CACHE_DIR: '/var/cache/melange/pip'   # This is the default
+```
+
+Or set it within a pipeline step:
+
+```yaml
+pipeline:
+  - runs: |
+      PIP_CACHE_DIR="/var/cache/melange/pip"
+      pip install -r requirements.txt
+```
+
+This caching support helps significantly speed up Python builds by avoiding repeated downloads of packages across builds.

--- a/pkg/build/build_test.go
+++ b/pkg/build/build_test.go
@@ -203,10 +203,11 @@ func TestConfiguration_Load(t *testing.T) {
 				},
 				Environment: apko_types.ImageConfiguration{
 					Environment: map[string]string{
-						"GOMODCACHE":   "/var/cache/melange/gomodcache",
-						"HOME":         "/home/build/special-case",
-						"GOPATH":       "/var/cache/melange/go",
-						"UV_CACHE_DIR": "/var/cache/melange/uv",
+						"GOMODCACHE":    "/var/cache/melange/gomodcache",
+						"HOME":          "/home/build/special-case",
+						"GOPATH":        "/var/cache/melange/go",
+						"UV_CACHE_DIR":  "/var/cache/melange/uv",
+						"PIP_CACHE_DIR": "/var/cache/melange/pip",
 					},
 					Accounts: apko_types.ImageAccounts{
 						Users:  []apko_types.User{{UserName: buildUser, UID: 1000, GID: apko_types.GID(&gid1000)}},
@@ -295,10 +296,11 @@ package:
 		Members:   []string{buildUser},
 	}}
 	expected.Environment.Environment = map[string]string{
-		"HOME":         "/home/build",
-		"GOPATH":       "/home/build/.cache/go",
-		"GOMODCACHE":   "/var/cache/melange/gomodcache",
-		"UV_CACHE_DIR": "/var/cache/melange/uv",
+		"HOME":          "/home/build",
+		"GOPATH":        "/home/build/.cache/go",
+		"GOMODCACHE":    "/var/cache/melange/gomodcache",
+		"UV_CACHE_DIR":  "/var/cache/melange/uv",
+		"PIP_CACHE_DIR": "/var/cache/melange/pip",
 	}
 
 	f := filepath.Join(t.TempDir(), "config")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1691,10 +1691,11 @@ func ParseConfiguration(ctx context.Context, configurationFilePath string, opts 
 	}
 
 	const (
-		defaultEnvVarHOME       = "/home/build"
-		defaultEnvVarGOPATH     = "/home/build/.cache/go"
-		defaultEnvVarGOMODCACHE = "/var/cache/melange/gomodcache"
-		defaultEnvVarUVCACHEDIR = "/var/cache/melange/uv"
+		defaultEnvVarHOME        = "/home/build"
+		defaultEnvVarGOPATH      = "/home/build/.cache/go"
+		defaultEnvVarGOMODCACHE  = "/var/cache/melange/gomodcache"
+		defaultEnvVarUVCACHEDIR  = "/var/cache/melange/uv"
+		defaultEnvVarPIPCACHEDIR = "/var/cache/melange/pip"
 	)
 
 	setIfEmpty := func(key, value string) {
@@ -1707,6 +1708,7 @@ func ParseConfiguration(ctx context.Context, configurationFilePath string, opts 
 	setIfEmpty("GOPATH", defaultEnvVarGOPATH)
 	setIfEmpty("GOMODCACHE", defaultEnvVarGOMODCACHE)
 	setIfEmpty("UV_CACHE_DIR", defaultEnvVarUVCACHEDIR)
+	setIfEmpty("PIP_CACHE_DIR", defaultEnvVarPIPCACHEDIR)
 
 	if err := cfg.applySubstitutionsForProvides(); err != nil {
 		return nil, err

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1931,10 +1931,11 @@ package:
   epoch: 0
 `,
 			expectedEnv: map[string]string{
-				"HOME":         "/home/build",
-				"GOPATH":       "/home/build/.cache/go",
-				"GOMODCACHE":   "/var/cache/melange/gomodcache",
-				"UV_CACHE_DIR": "/var/cache/melange/uv",
+				"HOME":          "/home/build",
+				"GOPATH":        "/home/build/.cache/go",
+				"GOMODCACHE":    "/var/cache/melange/gomodcache",
+				"UV_CACHE_DIR":  "/var/cache/melange/uv",
+				"PIP_CACHE_DIR": "/var/cache/melange/pip",
 			},
 		},
 		{
@@ -1949,10 +1950,11 @@ environment:
     UV_CACHE_DIR: '/custom/uv/cache'
 `,
 			expectedEnv: map[string]string{
-				"HOME":         "/home/build",
-				"GOPATH":       "/home/build/.cache/go",
-				"GOMODCACHE":   "/var/cache/melange/gomodcache",
-				"UV_CACHE_DIR": "/custom/uv/cache",
+				"HOME":          "/home/build",
+				"GOPATH":        "/home/build/.cache/go",
+				"GOMODCACHE":    "/var/cache/melange/gomodcache",
+				"UV_CACHE_DIR":  "/custom/uv/cache",
+				"PIP_CACHE_DIR": "/var/cache/melange/pip",
 			},
 		},
 		{
@@ -1968,12 +1970,14 @@ environment:
     GOPATH: '/custom/gopath'
     GOMODCACHE: '/custom/gomodcache'
     UV_CACHE_DIR: '/custom/uv'
+    PIP_CACHE_DIR: '/custom/pip'
 `,
 			expectedEnv: map[string]string{
-				"HOME":         "/custom/home",
-				"GOPATH":       "/custom/gopath",
-				"GOMODCACHE":   "/custom/gomodcache",
-				"UV_CACHE_DIR": "/custom/uv",
+				"HOME":          "/custom/home",
+				"GOPATH":        "/custom/gopath",
+				"GOMODCACHE":    "/custom/gomodcache",
+				"UV_CACHE_DIR":  "/custom/uv",
+				"PIP_CACHE_DIR": "/custom/pip",
 			},
 		},
 		{
@@ -1992,6 +1996,7 @@ environment:
 				"GOPATH":        "/home/build/.cache/go",
 				"GOMODCACHE":    "/var/cache/melange/gomodcache",
 				"UV_CACHE_DIR":  "/var/cache/melange/uv",
+				"PIP_CACHE_DIR": "/var/cache/melange/pip",
 				"MY_CUSTOM_VAR": "custom_value",
 			},
 		},


### PR DESCRIPTION
Similar to what's done for the GOMODCACHE env variable, set UV_CACHE_DIR so whenever uv is used, the default melange cache dir is used and the cache can be used for iterating over a package that uses uv to speed-up builds.

## Melange Pull Request Template

<!--
*** PULL REQUEST CHECKLIST: PLEASE START HERE ***

The single most important feature of melange is that we can build Wolfi.

Many changes to melange introduce a risk of breaking the build, and sometimes
these are not flushed out until a package is changed (much) later.  This
pertains to basic execution, SCA changes, linter changes, and more.
-->

### Functional Changes

- [ ] This change can build all of Wolfi without errors (describe results in notes)

Notes:

I've not tested that you. I can when this approach is welcomed. 

### SCA Changes

- [ ] Examining several representative APKs show no regression / the desired effect (details in notes)

Notes:

### Linter

- [ ] The new check is clean across Wolfi
- [ ] The new check is opt-in or a warning

Notes:
