### PR TITLE
pipelines/patch: report explicitly what patch file is being applied

### DIFF
--- a/pkg/build/pipelines/patch.yaml
+++ b/pkg/build/pipelines/patch.yaml
@@ -38,5 +38,6 @@ pipeline:
       fi
 
       grep -v -E '^(#|$)' $series | (while read patchfile; do
+        echo "INFO: patching file $patchfile"
         patch '-p${{inputs.strip-components}}' --fuzz=${{inputs.fuzz}} --verbose < $patchfile
       done)


### PR DESCRIPTION
Before this change, the patch being applied is never reported. This makes
debug cumbersome, specially in melange packages with many patches.

Report explicitly what patch file we are iterating.

Signed-off-by: Arturo Borrero Gonzalez <arturo.borrero@chainguard.dev>
