### PR TITLE
fix: add and leverage helper functions for [safely] setting capacity

### DIFF
--- a/internal/capacity/cap.go
+++ b/internal/capacity/cap.go
@@ -1,0 +1,25 @@
+package capacity
+
+import "math"
+
+// Mul returns a*b if it doesn't overflow, otherwise 0.
+func Mul(a, b int) int {
+	if a <= 0 || b <= 0 {
+		return 0
+	}
+	if a > math.MaxInt/b {
+		return 0
+	}
+	return a * b
+}
+
+// Add returns a+b if it doesn't overflow, otherwise 0.
+func Add(a, b int) int {
+	if a < 0 || b < 0 {
+		return 0
+	}
+	if a > math.MaxInt-b {
+		return 0
+	}
+	return a + b
+}

--- a/internal/capacity/cap_test.go
+++ b/internal/capacity/cap_test.go
@@ -1,0 +1,50 @@
+package capacity
+
+import (
+	"math"
+	"testing"
+)
+
+func TestMul(t *testing.T) {
+	tests := []struct {
+		name string
+		a, b int
+		want int
+	}{
+		{"simple", 3, 4, 12},
+		{"zero a", 0, 5, 0},
+		{"zero b", 5, 0, 0},
+		{"negative", -1, 5, 0},
+		{"at limit", math.MaxInt / 2, 2, (math.MaxInt / 2) * 2},
+		{"overflow", math.MaxInt/2 + 1, 2, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Mul(tt.a, tt.b); got != tt.want {
+				t.Errorf("Mul(%d, %d) = %d, want %d", tt.a, tt.b, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAdd(t *testing.T) {
+	tests := []struct {
+		name string
+		a, b int
+		want int
+	}{
+		{"simple", 3, 4, 7},
+		{"zero a", 0, 5, 5},
+		{"zero b", 5, 0, 5},
+		{"negative", -1, 5, 0},
+		{"at limit", math.MaxInt - 1, 1, math.MaxInt},
+		{"overflow", math.MaxInt, 1, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Add(tt.a, tt.b); got != tt.want {
+				t.Errorf("Add(%d, %d) = %d, want %d", tt.a, tt.b, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/build/sbom/spdx/spdx.go
+++ b/pkg/build/sbom/spdx/spdx.go
@@ -27,6 +27,7 @@ import (
 	"chainguard.dev/apko/pkg/sbom/generator/spdx"
 	"github.com/spdx/tools-golang/spdx/v2/common"
 
+	"chainguard.dev/melange/internal/capacity"
 	build "chainguard.dev/melange/pkg/build/sbom"
 	"chainguard.dev/melange/pkg/sbom"
 )
@@ -99,7 +100,7 @@ type Generator struct{}
 // It returns a map of package names to their corresponding SPDX documents.
 func (g *Generator) GenerateSPDX(ctx context.Context, gc *build.GeneratorContext) (map[string]spdx.Document, error) {
 	// Collect all package names
-	pkgNames := make([]string, 0, len(gc.Configuration.Subpackages)+1)
+	pkgNames := make([]string, 0, capacity.Add(len(gc.Configuration.Subpackages), 1))
 	pkgNames = append(pkgNames, gc.Configuration.Package.Name)
 	for _, sp := range gc.Configuration.Subpackages {
 		pkgNames = append(pkgNames, sp.Name)

--- a/pkg/build/sca_interface.go
+++ b/pkg/build/sca_interface.go
@@ -22,6 +22,7 @@ import (
 	"chainguard.dev/apko/pkg/apk/apk"
 	apkofs "chainguard.dev/apko/pkg/apk/fs"
 
+	"chainguard.dev/melange/internal/capacity"
 	"chainguard.dev/melange/pkg/config"
 	"chainguard.dev/melange/pkg/sca"
 )
@@ -41,7 +42,7 @@ func (scabi *SCABuildInterface) PackageName() string {
 // RelativeNames returns all the package names relating to the package being
 // built.
 func (scabi *SCABuildInterface) RelativeNames() []string {
-	targets := make([]string, 0, len(scabi.PackageBuild.Build.Configuration.Subpackages)+1)
+	targets := make([]string, 0, capacity.Add(len(scabi.PackageBuild.Build.Configuration.Subpackages), 1))
 	targets = append(targets, scabi.PackageBuild.Origin.Name)
 
 	for _, target := range scabi.PackageBuild.Build.Configuration.Subpackages {

--- a/pkg/cli/scan.go
+++ b/pkg/cli/scan.go
@@ -34,6 +34,7 @@ import (
 	"github.com/spf13/cobra"
 	"go.opentelemetry.io/otel"
 
+	"chainguard.dev/melange/internal/capacity"
 	"chainguard.dev/melange/pkg/build"
 	"chainguard.dev/melange/pkg/config"
 	"chainguard.dev/melange/pkg/sca"
@@ -430,7 +431,7 @@ func (s *scaImpl) PackageName() string {
 }
 
 func (s *scaImpl) RelativeNames() []string {
-	targets := make([]string, 0, len(s.pb.Build.Configuration.Subpackages)+1)
+	targets := make([]string, 0, capacity.Add(len(s.pb.Build.Configuration.Subpackages), 1))
 	targets = append(targets, s.pb.Origin.Name)
 
 	for _, target := range s.pb.Build.Configuration.Subpackages {

--- a/pkg/cli/test.go
+++ b/pkg/cli/test.go
@@ -29,6 +29,7 @@ import (
 	"go.opentelemetry.io/otel"
 	"golang.org/x/sync/errgroup"
 
+	"chainguard.dev/melange/internal/capacity"
 	"chainguard.dev/melange/pkg/build"
 )
 
@@ -205,7 +206,7 @@ func TestCmd(ctx context.Context, archs []apko_types.Architecture, baseOpts ...b
 	// https://github.com/distroless/nginx/runs/7219233843?check_suite_focus=true
 	bcs := []*build.Test{}
 	for _, arch := range archs {
-		opts := make([]build.TestOption, 0, len(baseOpts)+1)
+		opts := make([]build.TestOption, 0, capacity.Add(len(baseOpts), 1))
 		opts = append(opts, build.WithTestArch(arch))
 		opts = append(opts, baseOpts...)
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -39,13 +39,13 @@ import (
 	"github.com/github/go-spdx/v2/spdxexp"
 	purl "github.com/package-url/packageurl-go"
 
+	"chainguard.dev/melange/internal/capacity"
 	"chainguard.dev/melange/pkg/sbom"
+	"chainguard.dev/melange/pkg/util"
 
 	"github.com/chainguard-dev/clog"
 	"github.com/joho/godotenv"
 	"gopkg.in/yaml.v3"
-
-	"chainguard.dev/melange/pkg/util"
 )
 
 const (
@@ -1266,7 +1266,7 @@ func buildConfigMap(cfg *Configuration) map[string]string {
 }
 
 func replacerFromMap(with map[string]string) *strings.Replacer {
-	replacements := make([]string, 0, len(with)*2)
+	replacements := make([]string, 0, capacity.Mul(len(with), 2))
 	for k, v := range with {
 		replacements = append(replacements, k, v)
 	}

--- a/pkg/container/qemu_runner.go
+++ b/pkg/container/qemu_runner.go
@@ -58,6 +58,7 @@ import (
 	"golang.org/x/crypto/ssh/knownhosts"
 	"golang.org/x/term"
 
+	"chainguard.dev/melange/internal/capacity"
 	"chainguard.dev/melange/internal/logwriter"
 	"chainguard.dev/melange/pkg/license"
 )
@@ -2006,7 +2007,7 @@ func generateBaseInitramfs(ctx context.Context, cfg *Config, initramfsPath, cach
 	}
 
 	// Start with base packages and add any additional packages from environment
-	packages := make([]string, 0, len(additionalPkgs)+1)
+	packages := make([]string, 0, capacity.Add(len(additionalPkgs), 1))
 	packages = append(packages, "microvm-init")
 	packages = append(packages, additionalPkgs...)
 

--- a/pkg/sca/kernel_sca.go
+++ b/pkg/sca/kernel_sca.go
@@ -29,6 +29,7 @@ import (
 	"strings"
 	"sync"
 
+	"chainguard.dev/melange/internal/capacity"
 	"chainguard.dev/melange/pkg/config"
 
 	"github.com/chainguard-dev/clog"
@@ -58,7 +59,7 @@ func generateKernelDeps(ctx context.Context, hdl SCAHandle, generated *config.De
 		return err
 	}
 
-	allKernelDirs := make([]string, 0, len(BootDirs)+len(ModuleDirs))
+	allKernelDirs := make([]string, 0, capacity.Add(len(BootDirs), len(ModuleDirs)))
 	allKernelDirs = append(allKernelDirs, BootDirs...)
 	allKernelDirs = append(allKernelDirs, ModuleDirs...)
 


### PR DESCRIPTION
Follow-up for #2317

When setting slice capacity, we usually try to anticipate this by using the length of another map/slice value. While these are usually closer to zero as opposed to `math.MaxInt`, we should still have a convenient way of doing this safely that doesn't involve copy-pasted boilerplate for each instance.