### PR TITLE
fix: Disable APK size limits during tests

### DIFF
--- a/pkg/build/test.go
+++ b/pkg/build/test.go
@@ -159,7 +159,14 @@ func (t *Test) BuildGuest(ctx context.Context, imgConfig apko_types.ImageConfigu
 		apko_build.WithExtraPackages(t.ExtraTestPackages),
 		apko_build.WithIgnoreSignatures(t.IgnoreSignatures),
 		apko_build.WithCache(t.ApkCacheDir, false, apk.NewCache(true)),
-		apko_build.WithTempDir(tmp))
+		apko_build.WithTempDir(tmp),
+		apko_build.WithSizeLimits(options.SizeLimits{
+			APKIndexDecompressedMaxSize: -1,
+			APKControlMaxSize:           -1,
+			APKDataMaxSize:              -1,
+			HTTPResponseMaxSize:         -1,
+		}),
+	)
 	if err != nil {
 		return "", fmt.Errorf("unable to create build context: %w", err)
 	}


### PR DESCRIPTION
Size limits were recently introduced in apko here:

https://github.com/chainguard-dev/apko/commit/2be3903fe194ad46351840f0569b35f5ac965f09

This is a very useful feature, but some of our packages are huge. Disable size limits for now matching prior behavior