### PR TITLE
chore(config/sbom): Append digest to non-SPDX license IDs

### DIFF
--- a/pkg/build/sbom/spdx/spdx_test.go
+++ b/pkg/build/sbom/spdx/spdx_test.go
@@ -352,7 +352,7 @@ func TestSBOMGenerationWithNonSPDXLicense(t *testing.T) {
 				Version:          "1.0.0-r0",
 				FilesAnalyzed:    false,
 				LicenseConcluded: "NOASSERTION",
-				LicenseDeclared:  "LicenseRef-PROPRIETARY",
+				LicenseDeclared:  "LicenseRef-PROPRIETARY-39e07780af77f5dd",
 				DownloadLocation: "NOASSERTION",
 				Originator:       "Organization: Test-Ns",
 				Supplier:         "Organization: Test-Ns",
@@ -368,7 +368,7 @@ func TestSBOMGenerationWithNonSPDXLicense(t *testing.T) {
 		},
 		LicensingInfos: []spdx.LicensingInfo{
 			{
-				LicenseID:     "LicenseRef-PROPRIETARY",
+				LicenseID:     "LicenseRef-PROPRIETARY-39e07780af77f5dd",
 				ExtractedText: licenseContent,
 			},
 		},


### PR DESCRIPTION
If a license path is specified for a given license reference, a content-addressable digest (generated by evaluating the checksum of the first 8 bytes of the license text) is appeneded to the license ID

This ensures that commonly used non-SPDX references, such as LicenseRef-PROPRIETARY, have a digest appended that reflects the content of the license such that any license with unique content had a unique ID