### PR TITLE
chore: pin wolfictl to last working version

### DIFF
--- a/.github/workflows/wolfi-presubmit.yaml
+++ b/.github/workflows/wolfi-presubmit.yaml
@@ -108,7 +108,7 @@ jobs:
       - uses: docker/setup-docker-action@e43656e248c0bd0647d3f5c195d116aacf6fcaf4 # v4.7.0
 
       # this need to point to main to always get the latest action
-      - uses: wolfi-dev/actions/install-wolfictl@main # main
+      - uses: wolfi-dev/actions/install-wolfictl@d8faf0b2bf2a7c6eefc571567ef370faae5baed2 # last commit that had the scan command
 
       - run: |
           wolfictl bump ${{ matrix.package }}


### PR DESCRIPTION
The latest `wolfictl` release doesn't have the `scan` command which we still use to check for CVEs in CI.

This will by us some time to migrate to an alternative. The `hello-wolfi` failures are expected given the recent `glibc` update.