### PR TITLE
Limit architectures specified in example

### DIFF
--- a/examples/gnu-hello.yaml
+++ b/examples/gnu-hello.yaml
@@ -3,6 +3,9 @@ package:
   version: 2.12
   epoch: 0
   description: "the GNU hello world program"
+  target-architecture:
+    - x86_64
+    - arm64
   copyright:
     - attestation: |
         Copyright 1992, 1995, 1996, 1997, 1998, 1999, 2000, 2001, 2002, 2005,


### PR DESCRIPTION
## Melange Pull Request Template

This limits the architectures specified in the example to just arm64 and x86_64. This speeds up the build and removes arches not supported by wolfi.

Fixes https://github.com/chainguard-dev/melange/issues/2329

<!--
*** PULL REQUEST CHECKLIST: PLEASE START HERE ***

The single most important feature of melange is that we can build Wolfi.

Many changes to melange introduce a risk of breaking the build, and sometimes
these are not flushed out until a package is changed (much) later.  This
pertains to basic execution, SCA changes, linter changes, and more.
-->

### Functional Changes

- [x] This change can build all of Wolfi without errors (describe results in notes)

Notes:

### SCA Changes

- [ ] Examining several representative APKs show no regression / the desired effect (details in notes)

Notes:

### Linter

- [ ] The new check is clean across Wolfi
- [ ] The new check is opt-in or a warning

Notes:
