### PR TITLE
feat: optimize QEMU microVM startup time and resource usage

### DIFF
--- a/pkg/container/qemu_runner.go
+++ b/pkg/container/qemu_runner.go
@@ -786,7 +786,7 @@ func createMicroVM(ctx context.Context, cfg *Config) error {
 	sshkey := base64.StdEncoding.EncodeToString(pubKey)
 
 	// Build kernel command line arguments
-	kernelArgs := kernelConsole + " nomodeset random.trust_cpu=on tsc=reliable no_timer_check cryptomgr.notests rcupdate.rcu_expedited=1 panic=-1 " + cmdlineVar + " sshkey=" + sshkey + " melange_qemu_runner=1"
+	kernelArgs := kernelConsole + " nomodeset random.trust_cpu=on no_timer_check cryptomgr.notests rcupdate.rcu_expedited=1 panic=-1 " + cmdlineVar + " sshkey=" + sshkey + " melange_qemu_runner=1"
 
 	// Check for TESTING environment variable and pass it to microvm-init
 	// TESTING must be a number (0 for disabled, non-zero for enabled)


### PR DESCRIPTION
- Disable virtio console and serial output in non-debug builds to reduce boot time and memory overhead
- Add x-option-roms=off to microvm machine type to skip option ROM loading
- Add kernel boot optimizations: tsc=reliable, no_timer_check, cryptomgr.notests, rcupdate.rcu_expedited=1
- Simplify disk drive config to use aio=threads uniformly across platforms

This improves boot time for the microvm

Ref OS-251