### PR TITLE
chore: run dependabot daily

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: gomod
     directory: "/"
     schedule:
-      interval: weekly
+      interval: daily
     open-pull-requests-limit: 10
     groups:
       gomod:
@@ -13,7 +13,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: weekly
+      interval: daily
     open-pull-requests-limit: 10
     groups:
       actions:


### PR DESCRIPTION
We run Dependabot on a [daily](https://github.com/chainguard-dev/apko/blob/main/.github/dependabot.yml) basis for apko and with all of its recent releases, we've had to frequently run Dependabot here outside of the weekly schedule to pick these up (along with other routine updates) so that we can cut a new release with any fixes/changes.

This PR moves melange to daily Dependabot updates so that we don't have to wait a week or remember to run manual updates to pull in more urgent dependency updates.