### PR TITLE
feat(config): point CARGO_HOME to /var/cache/melange/cargo

### DIFF
--- a/docs/BUILD-CACHE.md
+++ b/docs/BUILD-CACHE.md
@@ -203,6 +203,45 @@ pipeline:
 
 This caching support helps significantly speed up Node.js builds by avoiding repeated downloads of packages across builds.
 
+### Example: Rust/Cargo
+
+If you're using Melange to build a Rust project with [Cargo](https://doc.rust-lang.org/cargo/), you can take advantage of melange's built-in Cargo cache support to speed up your builds.
+
+Melange automatically sets the `CARGO_HOME` environment variable to `/var/cache/melange/cargo` by default. This tells Cargo to store its registry index, downloaded crates, and git checkouts under the melange cache mount. You can use the `--cache-dir` flag to mount a local directory that will be used as the Cargo cache:
+
+```shell
+melange build --cache-dir /path/to/your/cache ...
+```
+
+When using a dedicated Cargo cache directory on your host, you can mount it directly:
+
+```shell
+# Create a cache directory
+mkdir -p ~/.cache/melange
+
+# Run melange with the cache directory
+melange build --cache-dir ~/.cache/melange ...
+```
+
+The Cargo cache will be stored under `/var/cache/melange/cargo` inside the build environment. If you want to customize this path, you can override it in your Melange config:
+
+```yaml
+environment:
+  environment:
+    CARGO_HOME: '/var/cache/melange/cargo'   # This is the default
+```
+
+Or set it within a pipeline step:
+
+```yaml
+pipeline:
+  - runs: |
+      CARGO_HOME="/var/cache/melange/cargo"
+      cargo build --release
+```
+
+This caching support helps significantly speed up Rust builds by avoiding repeated downloads of crate dependencies across builds.
+
 ### Example: Maven Dependencies
 
 Maven caching is automatically enabled when using the `maven/configure-mirror` or `maven/pombump` pipelines. When a cache directory is mounted at `/var/cache/melange`, the pipelines automatically configure Maven to use `/var/cache/melange/m2repository` as the local repository.

--- a/pkg/build/build_test.go
+++ b/pkg/build/build_test.go
@@ -210,6 +210,7 @@ func TestConfiguration_Load(t *testing.T) {
 						"PIP_CACHE_DIR":      "/var/cache/melange/pip",
 						"COMPOSER_CACHE_DIR": "/var/cache/melange/composer",
 						"npm_config_cache":   "/var/cache/melange/npm",
+						"CARGO_HOME":         "/var/cache/melange/cargo",
 					},
 					Accounts: apko_types.ImageAccounts{
 						Users:  []apko_types.User{{UserName: buildUser, UID: 1000, GID: apko_types.GID(&gid1000)}},
@@ -305,6 +306,7 @@ package:
 		"PIP_CACHE_DIR":      "/var/cache/melange/pip",
 		"COMPOSER_CACHE_DIR": "/var/cache/melange/composer",
 		"npm_config_cache":   "/var/cache/melange/npm",
+		"CARGO_HOME":         "/var/cache/melange/cargo",
 	}
 
 	f := filepath.Join(t.TempDir(), "config")

--- a/pkg/build/pipelines/cargo/build.yaml
+++ b/pkg/build/pipelines/cargo/build.yaml
@@ -67,6 +67,9 @@ pipeline:
         jobs_flag="--jobs ${{inputs.jobs}}"
       fi
 
+      # Ensure Cargo uses the melange cache directory
+      export CARGO_HOME="${CARGO_HOME:-/var/cache/melange/cargo}"
+
       # Build and install package(s)
       RUSTFLAGS="${{inputs.rustflags}}" cargo auditable build --target-dir target ${{inputs.opts}} $jobs_flag
       if [[ ! -z "${{inputs.output}}" ]]; then

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1705,6 +1705,7 @@ func ParseConfiguration(ctx context.Context, configurationFilePath string, opts 
 		defaultEnvVarPIPCACHEDIR      = "/var/cache/melange/pip"
 		defaultEnvVarCOMPOSERCACHEDIR = "/var/cache/melange/composer"
 		defaultEnvVarNPMCACHE         = "/var/cache/melange/npm"
+		defaultEnvVarCARGOHOME        = "/var/cache/melange/cargo"
 	)
 
 	setIfEmpty := func(key, value string) {
@@ -1720,6 +1721,7 @@ func ParseConfiguration(ctx context.Context, configurationFilePath string, opts 
 	setIfEmpty("PIP_CACHE_DIR", defaultEnvVarPIPCACHEDIR)
 	setIfEmpty("COMPOSER_CACHE_DIR", defaultEnvVarCOMPOSERCACHEDIR)
 	setIfEmpty("npm_config_cache", defaultEnvVarNPMCACHE)
+	setIfEmpty("CARGO_HOME", defaultEnvVarCARGOHOME)
 
 	if err := cfg.applySubstitutionsForProvides(); err != nil {
 		return nil, err

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1938,6 +1938,7 @@ package:
 				"PIP_CACHE_DIR":      "/var/cache/melange/pip",
 				"COMPOSER_CACHE_DIR": "/var/cache/melange/composer",
 				"npm_config_cache":   "/var/cache/melange/npm",
+				"CARGO_HOME":         "/var/cache/melange/cargo",
 			},
 		},
 		{
@@ -1959,6 +1960,7 @@ environment:
 				"PIP_CACHE_DIR":      "/var/cache/melange/pip",
 				"COMPOSER_CACHE_DIR": "/var/cache/melange/composer",
 				"npm_config_cache":   "/var/cache/melange/npm",
+				"CARGO_HOME":         "/var/cache/melange/cargo",
 			},
 		},
 		{
@@ -1977,6 +1979,7 @@ environment:
     PIP_CACHE_DIR: '/custom/pip'
     COMPOSER_CACHE_DIR: '/custom/composer'
     npm_config_cache: '/custom/npm'
+    CARGO_HOME: '/custom/cargo'
 `,
 			expectedEnv: map[string]string{
 				"HOME":               "/custom/home",
@@ -1986,6 +1989,7 @@ environment:
 				"PIP_CACHE_DIR":      "/custom/pip",
 				"COMPOSER_CACHE_DIR": "/custom/composer",
 				"npm_config_cache":   "/custom/npm",
+				"CARGO_HOME":         "/custom/cargo",
 			},
 		},
 		{
@@ -2007,6 +2011,7 @@ environment:
 				"PIP_CACHE_DIR":      "/var/cache/melange/pip",
 				"COMPOSER_CACHE_DIR": "/var/cache/melange/composer",
 				"npm_config_cache":   "/var/cache/melange/npm",
+				"CARGO_HOME":         "/var/cache/melange/cargo",
 				"MY_CUSTOM_VAR":      "custom_value",
 			},
 		},


### PR DESCRIPTION
Similar to what's done for the GOMODCACHE env variable, set CARGO_HOME so whenever cargo is used, the default
melange cache dir is used and the cache can be used for iterating over a package that uses cargo to speed-up builds.

