### PR TITLE
pipelines/go: add build-base dependency

### DIFF
--- a/pkg/build/pipelines/go/build.yaml
+++ b/pkg/build/pipelines/go/build.yaml
@@ -3,6 +3,7 @@ name: Run a build using the go compiler
 needs:
   packages:
     - ${{inputs.go-package}}
+    - build-base
     - busybox
     - ca-certificates-bundle
 

--- a/pkg/build/pipelines/go/install.yaml
+++ b/pkg/build/pipelines/go/install.yaml
@@ -4,6 +4,7 @@ needs:
   packages:
     - ${{inputs.go-package}}
     - busybox
+    - build-base
     - ca-certificates-bundle
     - git
 


### PR DESCRIPTION
If build-base dependency is added on the pipelines, this dependency
can be dropped from the non-fips go toolchain packages. This will
enable to create "slim" tags for go images which do not include gcc
toolchain; are much smaller in dependencies; and can only be used to
build CGO_ENABLED=0 projects native and cross. This avoids building a
separate duplicate toolchain to achieve the same effect.

This is a no-op change for the current toolchains.
