### PR TITLE
feat: Support multiple --env-file options

### DIFF
--- a/docs/md/melange_build.md
+++ b/docs/md/melange_build.md
@@ -43,7 +43,7 @@ melange build [flags]
       --dependency-log string                                   log dependencies to a specified file
       --disk string                                             disk size to use for builds
       --empty-workspace                                         whether the build workspace should be empty
-      --env-file string                                         file to use for preloaded environment variables
+      --env-file strings                                        files to use for preloaded environment variables
       --generate-index                                          whether to generate APKINDEX.tar.gz (default true)
       --generate-provenance                                     generate SLSA provenance for builds (included in a separate .attest.tar.gz file next to the APK)
       --git-commit string                                       commit hash of the git repository containing the build config file (defaults to detecting HEAD)

--- a/docs/md/melange_compile.md
+++ b/docs/md/melange_compile.md
@@ -40,7 +40,7 @@ melange compile [flags]
       --debug-runner                when enabled, the builder pod will persist after the build succeeds or fails
       --dependency-log string       log dependencies to a specified file
       --empty-workspace             whether the build workspace should be empty
-      --env-file string             file to use for preloaded environment variables
+      --env-file strings            files to use for preloaded environment variables
       --fail-on-lint-warning        turns linter warnings into failures
       --generate-index              whether to generate APKINDEX.tar.gz (default true)
       --generate-provenance         generate SLSA provenance for builds (included in a separate .attest.tar.gz file next to the APK)

--- a/docs/md/melange_test.md
+++ b/docs/md/melange_test.md
@@ -37,7 +37,7 @@ melange test [flags]
       --debug                         enables debug logging of test pipelines (sets -x for steps)
       --debug-runner                  when enabled, the builder pod will persist after the build succeeds or fails
       --disk string                   disk size to use for tests
-      --env-file string               file to use for preloaded environment variables
+      --env-file strings              files to use for preloaded environment variables
   -h, --help                          help for test
       --ignore-signatures             ignore repository signature verification
   -i, --interactive                   when enabled, attaches stdin with a tty to the pod on failure

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -125,7 +125,7 @@ type Build struct {
 	ApkCacheDir           string
 	CacheSource           string
 	StripOriginName       bool
-	EnvFile               string
+	EnvFiles              []string
 	VarsFile              string
 	Runner                container.Runner
 	containerConfig       *container.Config
@@ -234,7 +234,7 @@ func New(ctx context.Context, opts ...Option) (*Build, error) {
 	if b.Configuration == nil {
 		parsedCfg, err := config.ParseConfiguration(ctx,
 			b.ConfigFile,
-			config.WithEnvFileForParsing(b.EnvFile),
+			config.WithEnvFilesForParsing(b.EnvFiles),
 			config.WithVarsFileForParsing(b.VarsFile),
 			config.WithDefaultCPU(b.DefaultCPU),
 			config.WithDefaultCPUModel(b.DefaultCPUModel),

--- a/pkg/build/build_test.go
+++ b/pkg/build/build_test.go
@@ -231,7 +231,7 @@ func TestConfiguration_Load(t *testing.T) {
 
 			cfg, err := config.ParseConfiguration(ctx,
 				bctx.ConfigFile,
-				config.WithEnvFileForParsing(bctx.EnvFile),
+				config.WithEnvFilesForParsing(bctx.EnvFiles),
 				config.WithVarsFileForParsing(bctx.VarsFile))
 			tt.requireErr(t, err)
 
@@ -319,7 +319,7 @@ package:
 	}
 	cfg, err := config.ParseConfiguration(ctx,
 		bctx.ConfigFile,
-		config.WithEnvFileForParsing(bctx.EnvFile),
+		config.WithEnvFilesForParsing(bctx.EnvFiles),
 		config.WithVarsFileForParsing(bctx.VarsFile))
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/build/options.go
+++ b/pkg/build/options.go
@@ -248,13 +248,17 @@ func WithStripOriginName(stripOriginName bool) Option {
 	}
 }
 
-// WithEnvFile specifies an environment file to use to preload the build
+// WithEnvFiles specifies environment files to use to preload the build
 // environment.  It should contain the CFLAGS and LDFLAGS used by the C
 // toolchain as well as any other desired environment settings for the
 // build environment.
-func WithEnvFile(envFile string) Option {
+func WithEnvFiles(envFiles []string) Option {
 	return func(b *Build) error {
-		b.EnvFile = envFile
+		for _, envFile := range envFiles {
+			if envFile != "" {
+				b.EnvFiles = append(b.EnvFiles, envFile)
+			}
+		}
 		return nil
 	}
 }

--- a/pkg/build/test.go
+++ b/pkg/build/test.go
@@ -59,7 +59,7 @@ type Test struct {
 	CacheDir          string
 	ApkCacheDir       string
 	CacheSource       string
-	EnvFile           string
+	EnvFiles          []string
 	Runner            container.Runner
 	Debug             bool
 	DebugRunner       bool
@@ -111,7 +111,7 @@ func NewTest(ctx context.Context, opts ...TestOption) (*Test, error) {
 	}
 
 	parsedCfg, err := config.ParseConfiguration(ctx, t.ConfigFile,
-		config.WithEnvFileForParsing(t.EnvFile),
+		config.WithEnvFilesForParsing(t.EnvFiles),
 		config.WithDefaultCPU(t.DefaultCPU),
 		config.WithDefaultCPUModel(t.DefaultCPUModel),
 		config.WithDefaultDisk(t.DefaultDisk),

--- a/pkg/build/test_options.go
+++ b/pkg/build/test_options.go
@@ -171,13 +171,17 @@ func WithExtraTestPackages(extraTestPackages []string) TestOption {
 	}
 }
 
-// WithTestEnvFile specifies an environment file to use to preload the build
+// WithTestEnvFiles specifies environment files to use to preload the build
 // environment.  It should contain the CFLAGS and LDFLAGS used by the C
 // toolchain as well as any other desired environment settings for the
 // build environment.
-func WithTestEnvFile(envFile string) TestOption {
+func WithTestEnvFiles(envFiles []string) TestOption {
 	return func(t *Test) error {
-		t.EnvFile = envFile
+		for _, envFile := range envFiles {
+			if envFile != "" {
+				t.EnvFiles = append(t.EnvFiles, envFile)
+			}
+		}
 		return nil
 	}
 }

--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -53,7 +53,7 @@ func addBuildFlags(fs *pflag.FlagSet, flags *BuildFlags) {
 	fs.StringVar(&flags.CacheSource, "cache-source", "", "directory or bucket used for preloading the cache")
 	fs.StringVar(&flags.ApkCacheDir, "apk-cache-dir", "", "directory used for cached apk packages (default is system-defined cache directory)")
 	fs.StringVar(&flags.SigningKey, "signing-key", "", "key to use for signing")
-	fs.StringVar(&flags.EnvFile, "env-file", "", "file to use for preloaded environment variables")
+	fs.StringSliceVar(&flags.EnvFiles, "env-file", []string{}, "files to use for preloaded environment variables")
 	fs.StringVar(&flags.VarsFile, "vars-file", "", "file to use for preloaded build configuration variables")
 	fs.BoolVar(&flags.GenerateIndex, "generate-index", true, "whether to generate APKINDEX.tar.gz")
 	fs.BoolVar(&flags.EmptyWorkspace, "empty-workspace", false, "whether the build workspace should be empty")
@@ -112,7 +112,7 @@ type BuildFlags struct {
 	ExtraKeys            []string
 	ExtraRepos           []string
 	DependencyLog        string
-	EnvFile              string
+	EnvFiles             []string
 	VarsFile             string
 	PurlNamespace        string
 	BuildOption          []string
@@ -209,7 +209,7 @@ func (flags *BuildFlags) BuildOptions(ctx context.Context, args ...string) ([]bu
 		build.WithExtraPackages(flags.ExtraPackages),
 		build.WithDependencyLog(flags.DependencyLog),
 		build.WithStripOriginName(flags.StripOriginName),
-		build.WithEnvFile(flags.EnvFile),
+		build.WithEnvFiles(flags.EnvFiles),
 		build.WithVarsFile(flags.VarsFile),
 		build.WithNamespace(flags.PurlNamespace),
 		build.WithEnabledBuildOptions(flags.BuildOption),

--- a/pkg/cli/compile.go
+++ b/pkg/cli/compile.go
@@ -48,7 +48,7 @@ func compile() *cobra.Command {
 	var extraKeys []string
 	var extraRepos []string
 	var dependencyLog string
-	var envFile string
+	var envFiles []string
 	var varsFile string
 	var purlNamespace string
 	var buildOption []string
@@ -123,7 +123,7 @@ func compile() *cobra.Command {
 				build.WithExtraPackages(extraPackages),
 				build.WithDependencyLog(dependencyLog),
 				build.WithStripOriginName(stripOriginName),
-				build.WithEnvFile(envFile),
+				build.WithEnvFiles(envFiles),
 				build.WithVarsFile(varsFile),
 				build.WithNamespace(purlNamespace),
 				build.WithEnabledBuildOptions(buildOption),
@@ -181,7 +181,7 @@ func compile() *cobra.Command {
 	cmd.Flags().StringVar(&cacheSource, "cache-source", "", "directory or bucket used for preloading the cache")
 	cmd.Flags().StringVar(&apkCacheDir, "apk-cache-dir", "", "directory used for cached apk packages (default is system-defined cache directory)")
 	cmd.Flags().StringVar(&signingKey, "signing-key", "", "key to use for signing")
-	cmd.Flags().StringVar(&envFile, "env-file", "", "file to use for preloaded environment variables")
+	cmd.Flags().StringSliceVar(&envFiles, "env-file", []string{}, "files to use for preloaded environment variables")
 	cmd.Flags().StringVar(&varsFile, "vars-file", "", "file to use for preloaded build configuration variables")
 	cmd.Flags().BoolVar(&generateIndex, "generate-index", true, "whether to generate APKINDEX.tar.gz")
 	cmd.Flags().BoolVar(&emptyWorkspace, "empty-workspace", false, "whether the build workspace should be empty")

--- a/pkg/cli/test.go
+++ b/pkg/cli/test.go
@@ -44,7 +44,7 @@ func addTestFlags(fs *pflag.FlagSet, flags *TestFlags) {
 	fs.StringSliceVar(&flags.TestOption, "test-option", []string{}, "build options to enable")
 	fs.StringVar(&flags.Runner, "runner", "", fmt.Sprintf("which runner to use to enable running commands, default is based on your platform. Options are %q", build.GetAllRunners()))
 	fs.StringSliceVarP(&flags.ExtraKeys, "keyring-append", "k", []string{}, "path to extra keys to include in the build environment keyring")
-	fs.StringVar(&flags.EnvFile, "env-file", "", "file to use for preloaded environment variables")
+	fs.StringSliceVar(&flags.EnvFiles, "env-file", []string{}, "files to use for preloaded environment variables")
 	fs.BoolVar(&flags.Debug, "debug", false, "enables debug logging of test pipelines (sets -x for steps)")
 	fs.BoolVar(&flags.DebugRunner, "debug-runner", false, "when enabled, the builder pod will persist after the build succeeds or fails")
 	fs.BoolVarP(&flags.Interactive, "interactive", "i", false, "when enabled, attaches stdin with a tty to the pod on failure")
@@ -70,7 +70,7 @@ type TestFlags struct {
 	PipelineDirs      []string
 	ExtraKeys         []string
 	ExtraRepos        []string
-	EnvFile           string
+	EnvFiles          []string
 	TestOption        []string
 	Debug             bool
 	DebugRunner       bool
@@ -117,7 +117,7 @@ func (flags *TestFlags) TestOptions(ctx context.Context, args ...string) ([]buil
 		build.WithTestExtraRepos(flags.ExtraRepos),
 		build.WithExtraTestPackages(flags.ExtraTestPackages),
 		build.WithTestRunner(r),
-		build.WithTestEnvFile(flags.EnvFile),
+		build.WithTestEnvFiles(flags.EnvFiles),
 		build.WithTestDebug(flags.Debug),
 		build.WithTestDebugRunner(flags.DebugRunner),
 		build.WithTestInteractive(flags.Interactive),

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1180,7 +1180,7 @@ type ConfigurationParsingOption func(*configOptions)
 
 type configOptions struct {
 	filesystem                  fs.FS
-	envFilePath                 string
+	envFilePaths                []string
 	cpu, cpumodel, memory, disk string
 	timeout                     time.Duration
 	commit                      string
@@ -1241,10 +1241,14 @@ func WithCommit(hash string) ConfigurationParsingOption {
 	}
 }
 
-// WithEnvFileForParsing set the paths from which to read an environment file.
-func WithEnvFileForParsing(path string) ConfigurationParsingOption {
+// WithEnvFilesForParsing set the paths from which to read environment files.
+func WithEnvFilesForParsing(paths []string) ConfigurationParsingOption {
 	return func(options *configOptions) {
-		options.envFilePath = path
+		for _, path := range paths {
+			if path != "" {
+				options.envFilePaths = append(options.envFilePaths, path)
+			}
+		}
 	}
 }
 
@@ -1681,7 +1685,7 @@ func ParseConfiguration(ctx context.Context, configurationFilePath string, opts 
 	}
 
 	// Merge environment file if needed.
-	if envFile := options.envFilePath; envFile != "" {
+	for _, envFile := range options.envFilePaths {
 		envMap, err := godotenv.Read(envFile)
 		if err != nil {
 			return nil, fmt.Errorf("loading environment file: %w", err)


### PR DESCRIPTION
I need a way to inject more environment variables into the build.
melange supports a --env-file for specifying environment variables.
Wolfi builds already use this parameter to pass static, arch-specific
variables in. Specifying a second --env-file nullifies the first.
Let's allow multiple --env-file options, with each subsequent --env-file
overlaying values on top of the previous ones.

Note that if any users were relying on the previous behavior of subsequent
`--env-file` options nullifying all earlier ones, this would break that
use case.

Signed-off-by: dann frazier <dann.frazier@chainguard.dev>
