### PR TITLE
tarball: switch from crypto/sha1 to sha1cd

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -140,7 +140,7 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/pierrec/lz4/v4 v4.1.22 // indirect
-	github.com/pjbgf/sha1cd v0.4.0 // indirect
+	github.com/pjbgf/sha1cd v0.4.0
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_golang v1.23.2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect

--- a/pkg/tarball/write.go
+++ b/pkg/tarball/write.go
@@ -18,12 +18,6 @@ import (
 	"archive/tar"
 	"compress/gzip"
 	"context"
-
-	// SHA1 is required by the APK package format specification for file checksums.
-	// This is not used for cryptographic security but for integrity verification
-	// as mandated by apk-tools. Cannot be replaced with stronger algorithms without
-	// breaking APK package compatibility.
-	"crypto/sha1" // #nosec G505 - Required by APK format specification
 	"encoding/hex"
 	"fmt"
 	"io"
@@ -36,6 +30,12 @@ import (
 
 	apkfs "chainguard.dev/apko/pkg/apk/fs"
 	"chainguard.dev/apko/pkg/passwd"
+
+	// SHA1 is required by the APK package format specification for file checksums.
+	// This is not used for cryptographic security but for integrity verification
+	// as mandated by apk-tools. Cannot be replaced with stronger algorithms without
+	// breaking APK package compatibility. Autentication is performed with the sha256 datahash.
+	"github.com/pjbgf/sha1cd"
 )
 
 const xattrTarPAXRecordsPrefix = "SCHILY.xattr."
@@ -232,7 +232,10 @@ func (c *Context) writeTar(ctx context.Context, tw *tar.Writer, fsys fs.FS, user
 		if c.UseChecksums {
 			if link != "" {
 				// SHA1 required by APK format (apk-tools expects this specific algorithm)
-				linkDigest := sha1.Sum([]byte(link)) // #nosec G401 - APK format requirement
+				linkDigest, collision := sha1cd.Sum([]byte(link))
+				if collision {
+					return fmt.Errorf("sha1cd collision detected")
+				}
 				linkChecksum := hex.EncodeToString(linkDigest[:])
 				header.PAXRecords["APK-TOOLS.checksum.SHA1"] = linkChecksum
 			} else if info.Mode().IsRegular() {
@@ -243,12 +246,16 @@ func (c *Context) writeTar(ctx context.Context, tw *tar.Writer, fsys fs.FS, user
 				defer data.Close()
 
 				// SHA1 required by APK format (apk-tools expects this specific algorithm)
-				fileDigest := sha1.New() // #nosec G401 - APK format requirement
+				fileDigest := sha1cd.New().(sha1cd.CollisionResistantHash)
 				if _, err := io.CopyBuffer(fileDigest, data, buf); err != nil {
 					return err
 				}
 
-				fileChecksum := hex.EncodeToString(fileDigest.Sum(nil))
+				fileSum, collision := fileDigest.CollisionResistantSum(nil)
+				if collision {
+					return fmt.Errorf("sha1cd collision detected")
+				}
+				fileChecksum := hex.EncodeToString(fileSum)
 				header.PAXRecords["APK-TOOLS.checksum.SHA1"] = fileChecksum
 			}
 		}


### PR DESCRIPTION
Switch from cryto/sha1 to sha1cd (with collision detection) like
git. This is a safer way to hash potentially untrusted files.
