### PR TITLE
fix(maven): use symlink instead of settings.xml for cache localRepository

### DIFF
--- a/docs/BUILD-CACHE.md
+++ b/docs/BUILD-CACHE.md
@@ -244,7 +244,7 @@ This caching support helps significantly speed up Rust builds by avoiding repeat
 
 ### Example: Maven Dependencies
 
-Maven caching is automatically enabled when using the `maven/configure-mirror` or `maven/pombump` pipelines. When a cache directory is mounted at `/var/cache/melange`, the pipelines automatically configure Maven to use `/var/cache/melange/m2repository` as the local repository.
+Maven caching is automatically enabled when using the `maven/configure-mirror` or `maven/pombump` pipelines. When a cache directory is mounted at `/var/cache/melange`, the pipelines automatically symlink `~/.m2/repository` to `/var/cache/melange/m2repository` so that Maven's default local repository is backed by the cache.
 
 To use Maven caching, simply provide a cache directory:
 
@@ -252,7 +252,7 @@ To use Maven caching, simply provide a cache directory:
 melange build --cache-dir /path/to/my/cache ...
 ```
 
-No additional configuration is required in your Melange config. The Maven pipelines detect the mounted cache directory and configure the local repository path automatically. This is useful for Java projects with many dependencies (e.g., apicurio-registry requires over 1 GB of dependencies).
+No additional configuration is required in your Melange config. The Maven pipelines detect the mounted cache directory and set up the symlink automatically. This is useful for Java projects with many dependencies (e.g., apicurio-registry requires over 1 GB of dependencies).
 
 On subsequent builds, Maven will reuse the downloaded dependencies from the cache, avoiding redundant downloads.
 

--- a/pkg/build/pipelines/maven/configure-mirror.yaml
+++ b/pkg/build/pipelines/maven/configure-mirror.yaml
@@ -4,19 +4,27 @@ needs:
     - busybox
 pipeline:
   - runs: |
-      # Use melange's build cache for downloaded dependencies if mounted from host
-      MAVEN_LOCAL_REPO="/var/cache/melange/m2repository"
-      LOCAL_REPO_CONFIG=""
+      # Point Maven's default local repository to the melange cache so
+      # downloaded dependencies can be reused across builds.  Uses a symlink
+      # instead of settings.xml <localRepository> so that builds which
+      # hardcode ~/.m2/repository paths keep working.
+      # Symlink both /root/.m2/repository (used by qemu runner where the
+      # build user is root) and $HOME/.m2/repository (used by bubblewrap/
+      # docker where HOME=/home/build).
       if [ -d "/var/cache/melange" ]; then
-        mkdir -p "$MAVEN_LOCAL_REPO"
-        LOCAL_REPO_CONFIG="<localRepository>${MAVEN_LOCAL_REPO}</localRepository>"
+        mkdir -p /var/cache/melange/m2repository
+        for m2dir in /root/.m2 "$HOME/.m2"; do
+          mkdir -p "$m2dir"
+          if [ ! -e "$m2dir/repository" ]; then
+            ln -s /var/cache/melange/m2repository "$m2dir/repository"
+          fi
+        done
       fi
 
       # Maven checks $USER/.m2, we set $HOME to /home/build but it hardcodes $USER somehow
       mkdir -p /root/.m2
       cat > /root/.m2/settings.xml <<EOF
         <settings>
-          ${LOCAL_REPO_CONFIG}
           <mirrors>
             <mirror>
               <id>google-maven-central</id>

--- a/pkg/build/pipelines/maven/pombump.yaml
+++ b/pkg/build/pipelines/maven/pombump.yaml
@@ -33,16 +33,22 @@ inputs:
 
 pipeline:
   - runs: |
-      # Use melange's build cache for downloaded dependencies if mounted from host
-      MAVEN_LOCAL_REPO="/var/cache/melange/m2repository"
+      # Point Maven's default local repository to the melange cache so
+      # downloaded dependencies can be reused across builds.  Uses a symlink
+      # instead of settings.xml <localRepository> so that builds which
+      # hardcode ~/.m2/repository paths (e.g. Cassandra's build-resolver.xml)
+      # keep working.
+      # Symlink both /root/.m2/repository (used by qemu runner where the
+      # build user is root) and $HOME/.m2/repository (used by bubblewrap/
+      # docker where HOME=/home/build).
       if [ -d "/var/cache/melange" ]; then
-        mkdir -p "$MAVEN_LOCAL_REPO"
-        mkdir -p /root/.m2
-        cat > /root/.m2/settings.xml <<EOF
-      <settings>
-        <localRepository>${MAVEN_LOCAL_REPO}</localRepository>
-      </settings>
-      EOF
+        mkdir -p /var/cache/melange/m2repository
+        for m2dir in /root/.m2 "$HOME/.m2"; do
+          mkdir -p "$m2dir"
+          if [ ! -e "$m2dir/repository" ]; then
+            ln -s /var/cache/melange/m2repository "$m2dir/repository"
+          fi
+        done
       fi
 
       PATCH_FILE_FLAG=""


### PR DESCRIPTION
## Summary

- Replace `settings.xml` `<localRepository>` override with a symlink from `~/.m2/repository` to `/var/cache/melange/m2repository`
- Symlink is created at both `/root/.m2/repository` (qemu) and `$HOME/.m2/repository` (bubblewrap/docker)
- Update docs to reflect the symlink approach

## Problem

The `pombump.yaml` pipeline (added in #2304) unconditionally created `/root/.m2/settings.xml` with `<localRepository>/var/cache/melange/m2repository</localRepository>` whenever `/var/cache/melange` existed. This redirected where the Maven Resolver cached downloaded jars, but builds that hardcode `~/.m2/repository` paths broke because jars were no longer at the expected location.

Specifically, Cassandra's `build-resolver.xml` expects jars at `/root/.m2/repository/org/jacoco/org.jacoco.agent/0.8.8/org.jacoco.agent-0.8.8.jar` and failed with `BUILD FAILED: src '...' doesn't exist`.

## Fix

Use a symlink instead: `~/.m2/repository` → `/var/cache/melange/m2repository`. This way:
- Maven's default local repository transparently points to the cache
- Builds referencing `~/.m2/repository` paths follow the symlink and find jars
- Cache persistence still works (virtiofs writes go to host)

## Testing

Verified locally with cassandra-5.0 build:
- **bubblewrap**: `BUILD SUCCESSFUL`, symlink at `$HOME/.m2/repository`
- **qemu + virtiofs**: `BUILD SUCCESSFUL`, symlink at `/root/.m2/repository`, 139MB cache persisted to host