### PR TITLE
Use namespace instead of ReleaseData for SBOM generation.

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -725,18 +725,6 @@ func (b *Build) BuildPackage(ctx context.Context) error {
 	log.Infof("retrieving workspace from builder: %s", cfg.PodID)
 	b.WorkspaceDirFS = apkofs.DirFS(ctx, b.WorkspaceDir)
 
-	// Retrieve the os-release information from the runner
-	releaseData, err := b.Runner.GetReleaseData(ctx, cfg)
-	if err != nil {
-		log.Warnf("failed to retrieve release data from runner, OS section will be unknown: %v", err)
-		// If we can't retrieve the release data, we will use a default 'unknown' one similar to apko.
-		releaseData = &apko_build.ReleaseData{
-			ID:        "unknown",
-			Name:      "melange-generated package",
-			VersionID: "unknown",
-		}
-	}
-
 	// Apply xattrs to files in the new in-memory filesystem
 	for path, attrs := range xattrs {
 		for attr, data := range attrs {
@@ -857,7 +845,6 @@ func (b *Build) BuildPackage(ctx context.Context) error {
 			License:       b.ConfigFileLicense,
 			PURL:          buildConfigPURL,
 		},
-		ReleaseData: releaseData,
 	}
 
 	if err := b.SBOMGenerator.GenerateSBOM(ctx, genCtx); err != nil {

--- a/pkg/build/sbom/generator.go
+++ b/pkg/build/sbom/generator.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	apkofs "chainguard.dev/apko/pkg/apk/fs"
-	apko_build "chainguard.dev/apko/pkg/build"
 	purl "github.com/package-url/packageurl-go"
 
 	"chainguard.dev/melange/pkg/config"
@@ -54,9 +53,6 @@ type GeneratorContext struct {
 
 	// Information about the build configuration file
 	ConfigFile *ConfigFile
-
-	// OS release data from the build container
-	ReleaseData *apko_build.ReleaseData
 }
 
 type ConfigFile struct {

--- a/pkg/build/sbom/spdx/spdx.go
+++ b/pkg/build/sbom/spdx/spdx.go
@@ -24,6 +24,7 @@ import (
 	"strconv"
 	"time"
 
+	apko_build "chainguard.dev/apko/pkg/build"
 	"chainguard.dev/apko/pkg/sbom/generator/spdx"
 	"github.com/spdx/tools-golang/spdx/v2/common"
 
@@ -200,12 +201,16 @@ func (g *Generator) GenerateSPDX(ctx context.Context, gc *build.GeneratorContext
 
 	out := make(map[string]spdx.Document)
 
-	// Convert the SBOMs to SPDX and write them
-	for _, sp := range gc.Configuration.Subpackages {
-		out[sp.Name] = sg.Document(sp.Name).ToSPDX(ctx, gc.ReleaseData)
+	releaseData := &apko_build.ReleaseData{
+		ID: gc.Namespace,
 	}
 
-	out[pkg.Name] = pSBOM.ToSPDX(ctx, gc.ReleaseData)
+	// Convert the SBOMs to SPDX and write them
+	for _, sp := range gc.Configuration.Subpackages {
+		out[sp.Name] = sg.Document(sp.Name).ToSPDX(ctx, releaseData)
+	}
+
+	out[pkg.Name] = pSBOM.ToSPDX(ctx, releaseData)
 	return out, nil
 }
 

--- a/pkg/build/sbom/spdx/spdx_test.go
+++ b/pkg/build/sbom/spdx/spdx_test.go
@@ -24,7 +24,6 @@ import (
 	"time"
 
 	apkofs "chainguard.dev/apko/pkg/apk/fs"
-	apko_build "chainguard.dev/apko/pkg/build"
 	"chainguard.dev/apko/pkg/sbom/generator/spdx"
 	"github.com/google/go-cmp/cmp"
 	purl "github.com/package-url/packageurl-go"
@@ -76,10 +75,6 @@ func TestSBOMGeneration(t *testing.T) {
 			License: "Apache-2.0",
 			PURL:    &testPURL,
 		},
-		ReleaseData: &apko_build.ReleaseData{
-			ID:        "test-os",
-			VersionID: "1.0",
-		},
 	}
 
 	gen := &Generator{}
@@ -104,8 +99,7 @@ func TestSBOMGeneration(t *testing.T) {
 			Packages: []spdx.Package{
 				{
 					ID:               "SPDXRef-OperatingSystem",
-					Name:             "test-os",
-					Version:          "1.0",
+					Name:             "test-ns",
 					FilesAnalyzed:    false,
 					LicenseConcluded: "NOASSERTION",
 					LicenseDeclared:  "NOASSERTION",
@@ -176,8 +170,7 @@ func TestSBOMGeneration(t *testing.T) {
 			Packages: []spdx.Package{
 				{
 					ID:               "SPDXRef-OperatingSystem",
-					Name:             "test-os",
-					Version:          "1.0",
+					Name:             "test-ns",
 					FilesAnalyzed:    false,
 					LicenseConcluded: "NOASSERTION",
 					LicenseDeclared:  "NOASSERTION",
@@ -296,10 +289,6 @@ func TestSBOMGenerationWithNonSPDXLicense(t *testing.T) {
 		SourceDateEpoch: testTime,
 		Namespace:       "test-ns",
 		Arch:            "x86_64",
-		ReleaseData: &apko_build.ReleaseData{
-			ID:        "test-os",
-			VersionID: "1.0",
-		},
 	}
 
 	gen := &Generator{}
@@ -335,8 +324,7 @@ func TestSBOMGenerationWithNonSPDXLicense(t *testing.T) {
 		Packages: []spdx.Package{
 			{
 				ID:               "SPDXRef-OperatingSystem",
-				Name:             "test-os",
-				Version:          "1.0",
+				Name:             "test-ns",
 				FilesAnalyzed:    false,
 				LicenseConcluded: "NOASSERTION",
 				LicenseDeclared:  "NOASSERTION",
@@ -407,10 +395,6 @@ func TestSBOMGenerationWithMixedLicenses(t *testing.T) {
 		SourceDateEpoch: testTime,
 		Namespace:       "test-ns",
 		Arch:            "x86_64",
-		ReleaseData: &apko_build.ReleaseData{
-			ID:        "test-os",
-			VersionID: "1.0",
-		},
 	}
 
 	gen := &Generator{}
@@ -446,8 +430,7 @@ func TestSBOMGenerationWithMixedLicenses(t *testing.T) {
 		Packages: []spdx.Package{
 			{
 				ID:               "SPDXRef-OperatingSystem",
-				Name:             "test-os",
-				Version:          "1.0",
+				Name:             "test-ns",
 				FilesAnalyzed:    false,
 				LicenseConcluded: "NOASSERTION",
 				LicenseDeclared:  "NOASSERTION",
@@ -552,10 +535,6 @@ func TestSBOMGenerationWithSubpackageGitCheckout(t *testing.T) {
 		SourceDateEpoch: testTime,
 		Namespace:       "test-ns",
 		Arch:            "x86_64",
-		ReleaseData: &apko_build.ReleaseData{
-			ID:        "test-os",
-			VersionID: "1.0",
-		},
 	}
 
 	gen := &Generator{}
@@ -592,8 +571,7 @@ func TestSBOMGenerationWithSubpackageGitCheckout(t *testing.T) {
 			Packages: []spdx.Package{
 				{
 					ID:               "SPDXRef-OperatingSystem",
-					Name:             "test-os",
-					Version:          "1.0",
+					Name:             "test-ns",
 					FilesAnalyzed:    false,
 					LicenseConcluded: "NOASSERTION",
 					LicenseDeclared:  "NOASSERTION",
@@ -664,8 +642,7 @@ func TestSBOMGenerationWithSubpackageGitCheckout(t *testing.T) {
 			Packages: []spdx.Package{
 				{
 					ID:               "SPDXRef-OperatingSystem",
-					Name:             "test-os",
-					Version:          "1.0",
+					Name:             "test-ns",
 					FilesAnalyzed:    false,
 					LicenseConcluded: "NOASSERTION",
 					LicenseDeclared:  "NOASSERTION",
@@ -759,8 +736,7 @@ func TestSBOMGenerationWithSubpackageGitCheckout(t *testing.T) {
 			Packages: []spdx.Package{
 				{
 					ID:               "SPDXRef-OperatingSystem",
-					Name:             "test-os",
-					Version:          "1.0",
+					Name:             "test-ns",
 					FilesAnalyzed:    false,
 					LicenseConcluded: "NOASSERTION",
 					LicenseDeclared:  "NOASSERTION",

--- a/pkg/build/testdata/goldenfiles/sboms/7zip-two-fetches-2301-r3.spdx.json
+++ b/pkg/build/testdata/goldenfiles/sboms/7zip-two-fetches-2301-r3.spdx.json
@@ -19,7 +19,6 @@
     {
       "SPDXID": "SPDXRef-OperatingSystem",
       "name": "wolfi",
-      "versionInfo": "20230201",
       "filesAnalyzed": false,
       "licenseConcluded": "NOASSERTION",
       "licenseDeclared": "NOASSERTION",

--- a/pkg/build/testdata/goldenfiles/sboms/crane-0.20.2-r1.spdx.json
+++ b/pkg/build/testdata/goldenfiles/sboms/crane-0.20.2-r1.spdx.json
@@ -19,7 +19,6 @@
     {
       "SPDXID": "SPDXRef-OperatingSystem",
       "name": "wolfi",
-      "versionInfo": "20230201",
       "filesAnalyzed": false,
       "licenseConcluded": "NOASSERTION",
       "licenseDeclared": "NOASSERTION",

--- a/pkg/sbom/document.go
+++ b/pkg/sbom/document.go
@@ -9,7 +9,6 @@ import (
 
 	apko_build "chainguard.dev/apko/pkg/build"
 	"chainguard.dev/apko/pkg/sbom/generator/spdx"
-	"github.com/chainguard-dev/clog"
 	"github.com/spdx/tools-golang/spdx/v2/common"
 	"sigs.k8s.io/release-utils/version"
 )
@@ -44,13 +43,8 @@ func NewDocument() *Document {
 func (d Document) ToSPDX(ctx context.Context, releaseData *apko_build.ReleaseData) spdx.Document {
 	spdxPkgs := make([]spdx.Package, 0, len(d.Packages))
 
-	// Start off by adding the OperatingSystem package to the list of packages.
-	if releaseData != nil {
-		spdxPkgs = append(spdxPkgs, d.createOperatingSystemPackage(releaseData))
-	} else {
-		log := clog.FromContext(ctx)
-		log.Warn("No release data provided, not adding OperatingSystem package to SPDX document")
-	}
+	// Add the OperatingSystem package to the list of packages.
+	spdxPkgs = append(spdxPkgs, d.createOperatingSystemPackage(releaseData))
 
 	for _, p := range d.Packages {
 		spdxPkgs = append(spdxPkgs, p.ToSPDX(ctx))


### PR DESCRIPTION
This was noticed in some packages - we were using `/etc/os-release` to populate the `SPDXRef-OperatingSystem` package, but these do not have to match since this is pulling the host OS release data, but we want to populate the intended target namespace OS info.