### PR TITLE
FDO package metadata improvements

### DIFF
--- a/e2e-tests/test-fixtures/melange-created.lst
+++ b/e2e-tests/test-fixtures/melange-created.lst
@@ -141,6 +141,7 @@
 ./.config/clang-42/x86_64-unknown-linux-gnu-clang++.cfg
 ./.config/clang-42/x86_64-unknown-linux-gnu-clang.cfg
 ./.melange.clang.cfg
+./.melange.fdo.h
 ./.melange.gcc.spec
 ./create-git-repo
 ./melange-created.lst

--- a/pkg/build/compiler_config.go
+++ b/pkg/build/compiler_config.go
@@ -34,6 +34,38 @@ var gccLinkTemplate = `*link:
 var clangConfigTemplate = `-Xlinker --package-metadata='` + packageMetadataTemplate + `'
 `
 
+// fdoNoteTemplate is a C header, generated alongside the gcc spec file, that
+// projects can #include to embed the very same FDO packaging metadata that the
+// --package-metadata linker flag would emit. This is useful for statically
+// linked or vendored code (e.g. a bundled allocator), which leaves no trace in
+// the dynamic dependency graph and is therefore invisible to SBOM / CVE
+// scanners: the note travels with the object into the final binary regardless.
+//
+// The note layout (NT_FDO_PACKAGING_METADATA, owner "FDO") follows
+// https://systemd.io/COREDUMP_PACKAGE_METADATA/ . The %s is the C-string-escaped
+// metadata JSON, identical to what the linker flag carries.
+var fdoNoteTemplate = `#ifndef MELANGE_PACKAGE_NOTE_H
+#define MELANGE_PACKAGE_NOTE_H
+#if defined(__ELF__)
+#define MELANGE_PACKAGE_NOTE_JSON "%s"
+__attribute__((used, retain, section(".note.package"), aligned(4)))
+static const struct {
+	unsigned int namesz;
+	unsigned int descsz;
+	unsigned int type;
+	char name[4];
+	char desc[sizeof(MELANGE_PACKAGE_NOTE_JSON)];
+} melange_package_note = {
+	sizeof("FDO"),
+	sizeof(MELANGE_PACKAGE_NOTE_JSON),
+	0xcafe1a7e,
+	"FDO",
+	MELANGE_PACKAGE_NOTE_JSON
+};
+#endif
+#endif
+`
+
 // range of clang versions we may support in the foreseeable future
 var (
 	minClangVer  = 15
@@ -56,6 +88,37 @@ func (b *Build) createGccSpecFile() error {
 		return err
 	}
 	return nil
+}
+
+// renderPackageMetadata renders the package metadata JSON (the same payload
+// carried by the --package-metadata linker flag) for this build.
+func (b *Build) renderPackageMetadata() (string, error) {
+	var sb strings.Builder
+	tmpl := template.Must(template.New("packageMetadata").Parse(packageMetadataTemplate))
+	if err := tmpl.Execute(&sb, b); err != nil {
+		return "", err
+	}
+	return sb.String(), nil
+}
+
+// createFdoNoteHeader writes a C header next to the gcc spec file that projects
+// can #include to embed the FDO packaging metadata note themselves. See
+// fdoNoteTemplate for why this is useful for statically linked / vendored code.
+func (b *Build) createFdoNoteHeader() error {
+	metadata, err := b.renderPackageMetadata()
+	if err != nil {
+		return err
+	}
+
+	// Escape for embedding in a C string literal: backslash first so we don't
+	// double-escape the backslashes we introduce for the quotes.
+	escaped := strings.ReplaceAll(metadata, `\`, `\\`)
+	escaped = strings.ReplaceAll(escaped, `"`, `\"`)
+
+	content := fmt.Sprintf(fdoNoteTemplate, escaped)
+
+	// #nosec G306 -- header should be world-readable so builds can include it
+	return os.WriteFile(filepath.Join(b.WorkspaceDir, ".melange.fdo.h"), []byte(content), 0o644)
 }
 
 // create a clang config file that just includes other clang config files
@@ -128,6 +191,9 @@ func (b *Build) createClangConfigFiles(ctx context.Context) error {
 // In the future can control debug symbol generation, march/mtune, etc.
 func (b *Build) createCompilerConfigFiles(ctx context.Context) error {
 	if err := b.createGccSpecFile(); err != nil {
+		return err
+	}
+	if err := b.createFdoNoteHeader(); err != nil {
 		return err
 	}
 	if err := b.createClangConfigFiles(ctx); err != nil {

--- a/pkg/build/compiler_config.go
+++ b/pkg/build/compiler_config.go
@@ -28,7 +28,7 @@ import (
 var packageMetadataTemplate = `{"type":"apk","os":"{{.Namespace}}","name":"{{.Configuration.Package.Name}}","version":"{{.Configuration.Package.FullVersion}}","architecture":"{{.Arch.ToAPK}}"{{if .Configuration.Package.CPE.Vendor}},"appCpe":"{{.Configuration.Package.CPEString}}"{{end}}}`
 
 var gccLinkTemplate = `*link:
-+ --package-metadata=` + packageMetadataTemplate + `
++ %{!r:--package-metadata=` + packageMetadataTemplate + `}
 `
 
 var clangConfigTemplate = `-Xlinker --package-metadata='` + packageMetadataTemplate + `'

--- a/pkg/build/compiler_config.go
+++ b/pkg/build/compiler_config.go
@@ -42,7 +42,7 @@ var clangConfigTemplate = `-Xlinker --package-metadata='` + packageMetadataTempl
 // scanners: the note travels with the object into the final binary regardless.
 //
 // The note layout (NT_FDO_PACKAGING_METADATA, owner "FDO") follows
-// https://systemd.io/COREDUMP_PACKAGE_METADATA/ . The %s is the C-string-escaped
+// https://uapi-group.org/specifications/specs/package_metadata_for_executable_files/ . The %s is the C-string-escaped
 // metadata JSON, identical to what the linker flag carries.
 var fdoNoteTemplate = `#ifndef MELANGE_PACKAGE_NOTE_H
 #define MELANGE_PACKAGE_NOTE_H

--- a/pkg/build/compiler_config_test.go
+++ b/pkg/build/compiler_config_test.go
@@ -138,7 +138,7 @@ func TestCreateFdoNoteHeader(t *testing.T) {
 	assert.Contains(t, s, `__attribute__((used, retain, section(".note.package"), aligned(4)))`)
 	assert.Contains(t, s, "melange_package_note")
 	// 0xcafe1a7e is the NT_FDO_PACKAGING_METADATA note type defined by
-	// https://systemd.io/COREDUMP_PACKAGE_METADATA/ .
+	// https://uapi-group.org/specifications/specs/package_metadata_for_executable_files/ .
 	assert.Contains(t, s, "0xcafe1a7e")
 	assert.Contains(t, s, `"FDO"`)
 

--- a/pkg/build/compiler_config_test.go
+++ b/pkg/build/compiler_config_test.go
@@ -107,6 +107,52 @@ func TestCreateGccSpecFileError(t *testing.T) {
 	})
 }
 
+func TestCreateFdoNoteHeader(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	b := &Build{
+		WorkspaceDir: tmpDir,
+		Arch:         apko_types.ParseArchitecture("x86_64"),
+		Namespace:    "test",
+		Configuration: &config.Configuration{
+			Package: config.Package{
+				Name:    "test-package",
+				Version: "1.0.0",
+				Epoch:   0,
+			},
+		},
+	}
+
+	err := b.createFdoNoteHeader()
+	require.NoError(t, err)
+
+	headerPath := filepath.Join(tmpDir, ".melange.fdo.h")
+	assert.FileExists(t, headerPath)
+
+	content, err := os.ReadFile(headerPath)
+	require.NoError(t, err)
+	s := string(content)
+
+	// The generated header carries the note attribute and the well-known
+	// variable name, in the FDO .note.package section.
+	assert.Contains(t, s, `__attribute__((used, retain, section(".note.package"), aligned(4)))`)
+	assert.Contains(t, s, "melange_package_note")
+	assert.Contains(t, s, "0xcafe1a7e")
+	assert.Contains(t, s, `"FDO"`)
+
+	// The JSON payload matches --package-metadata, but escaped as a C string
+	// literal (quotes backslash-escaped).
+	assert.Contains(t, s, `\"type\":\"apk\"`)
+	assert.Contains(t, s, `\"name\":\"test-package\"`)
+	assert.Contains(t, s, `\"version\":\"1.0.0-r0\"`)
+	assert.Contains(t, s, `\"architecture\":\"x86_64\"`)
+
+	// World-readable so in-sandbox builds can include it.
+	info, err := os.Stat(headerPath)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o644), info.Mode().Perm())
+}
+
 func TestCreateClangConfigFile(t *testing.T) {
 	tests := []struct {
 		name         string

--- a/pkg/build/compiler_config_test.go
+++ b/pkg/build/compiler_config_test.go
@@ -72,8 +72,9 @@ func TestCreateGccSpecFile(t *testing.T) {
 			// Should start with *link:
 			assert.True(t, strings.HasPrefix(string(content), "*link:\n"))
 
-			// Should contain the package-metadata flag
-			assert.Contains(t, string(content), "+ --package-metadata=")
+			// Should contain the package-metadata flag, guarded so it is
+			// not emitted for relocatable (-r) links.
+			assert.Contains(t, string(content), "+ %{!r:--package-metadata=")
 		})
 	}
 }

--- a/pkg/build/compiler_config_test.go
+++ b/pkg/build/compiler_config_test.go
@@ -137,6 +137,8 @@ func TestCreateFdoNoteHeader(t *testing.T) {
 	// variable name, in the FDO .note.package section.
 	assert.Contains(t, s, `__attribute__((used, retain, section(".note.package"), aligned(4)))`)
 	assert.Contains(t, s, "melange_package_note")
+	// 0xcafe1a7e is the NT_FDO_PACKAGING_METADATA note type defined by
+	// https://systemd.io/COREDUMP_PACKAGE_METADATA/ .
 	assert.Contains(t, s, "0xcafe1a7e")
 	assert.Contains(t, s, `"FDO"`)
 


### PR DESCRIPTION
Relocatable links currently break with package-metadata, or result in duplicates, or result in false positives.

Also publish package-metadata integration for static translation units.

References:
- https://src.fedoraproject.org/rpms/package-notes/c/fc99dac13b7aba2053296be6b1166dbcaceda2df?branch=rawhide