### PR TITLE
sbom: Emit CPE when available

### DIFF
--- a/pkg/build/sbom/spdx/spdx.go
+++ b/pkg/build/sbom/spdx/spdx.go
@@ -113,6 +113,11 @@ func (g *Generator) GenerateSPDX(ctx context.Context, gc *build.GeneratorContext
 	pkg := &gc.Configuration.Package
 	arch := gc.Arch
 
+	// Calculate Security CPE
+	cpe, err := pkg.CPEString()
+	if !pkg.CPE.IsZero() && err != nil {
+		return nil, fmt.Errorf("invalid package CPE %s: %w", pkg.Name, err)
+	}
 	// Add APK packages to their respective SBOMs
 	for _, sp := range gc.Configuration.Subpackages {
 		spSBOM := sg.Document(sp.Name)
@@ -126,6 +131,7 @@ func (g *Generator) GenerateSPDX(ctx context.Context, gc *build.GeneratorContext
 			Namespace:       gc.Namespace,
 			Arch:            arch,
 			PURL:            pkg.PackageURLForSubpackage(gc.Namespace, arch, sp.Name),
+			CPE:             cpe,
 			PrimaryPurpose:  "APPLICATION",
 		}
 		spSBOM.AddPackageAndSetDescribed(apkSubPkg)
@@ -157,6 +163,7 @@ func (g *Generator) GenerateSPDX(ctx context.Context, gc *build.GeneratorContext
 		Namespace:       gc.Namespace,
 		Arch:            arch,
 		PURL:            pkg.PackageURL(gc.Namespace, arch),
+		CPE:             cpe,
 		PrimaryPurpose:  "APPLICATION",
 	}
 	pSBOM.AddPackageAndSetDescribed(apkPkg)

--- a/pkg/build/testdata/build_configs/7zip-two-fetches.yaml
+++ b/pkg/build/testdata/build_configs/7zip-two-fetches.yaml
@@ -2,6 +2,9 @@ package:
   name: 7zip-two-fetches
   version: 2301
   epoch: 3
+  cpe:
+    vendor: "7-zip"
+    product: "7-zip"
   description: "File archiver with a high compression ratio"
   copyright:
     - license: LGPL-2.0-only

--- a/pkg/build/testdata/goldenfiles/sboms/7zip-two-fetches-2301-r3.spdx.json
+++ b/pkg/build/testdata/goldenfiles/sboms/7zip-two-fetches-2301-r3.spdx.json
@@ -45,6 +45,11 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceLocator": "pkg:apk/wolfi/7zip-two-fetches@2301-r3?arch=x86_64\u0026distro=wolfi",
           "referenceType": "purl"
+        },
+        {
+          "referenceCategory": "SECURITY",
+          "referenceLocator": "cpe:2.3:a:7-zip:7-zip:2301:*:*:*:*:*:*:*",
+          "referenceType": "cpe23Type"
         }
       ]
     },

--- a/pkg/sbom/package.go
+++ b/pkg/sbom/package.go
@@ -32,6 +32,11 @@ import (
 	"golang.org/x/text/language"
 )
 
+const (
+	ExtRefSecurity = "SECURITY"
+	ExtRefTypeCPE  = "cpe23Type"
+)
+
 // Package is a representation of an SBOM package specified by the build
 // process. It is later converted to an SPDX package, but it doesn't expose
 // fields that are invariant in the SPDX output.
@@ -81,6 +86,10 @@ type Package struct {
 	// should have only one PURL external ref.)
 	PURL *purl.PackageURL
 
+	// CPE string for upstream of this package, if any. If set, it
+	// will be added as an ExternalRef of type "cpe23Type" to the SPDX
+	// package.
+	CPE string
 	// The Download Location for this package, if any; It set this is generated
 	// alongside the PackageURL from fetch/git-checkout pipelines for upstream
 	// source locations; Leaving this empty will result in NOASSERTION being
@@ -182,6 +191,13 @@ func (p Package) getExternalRefs() []spdx.ExternalRef {
 			Category: spdx.ExtRefPackageManager,
 			Locator:  p.PURL.ToString(),
 			Type:     spdx.ExtRefTypePurl,
+		})
+	}
+	if p.CPE != "" {
+		result = append(result, spdx.ExternalRef{
+			Category: ExtRefSecurity,
+			Locator:  p.CPE,
+			Type:     ExtRefTypeCPE,
 		})
 	}
 


### PR DESCRIPTION
When upstream CPE information is available emit it as external
reference on the binary apk.
