### PR TITLE
chore(dependabot): allow for minor gomod updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,7 @@ updates:
     groups:
       gomod:
         update-types:
+          - "minor"
           - "patch"
 
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
I just noticed that we don't allow for minor updates when running Dependabot which isn't consistent with what we do elsewhere.