### PR TITLE
melange: fix git-checkout pipeline

### DIFF
--- a/pkg/build/pipelines/git-checkout.yaml
+++ b/pkg/build/pipelines/git-checkout.yaml
@@ -94,7 +94,7 @@ pipeline:
   - runs: |
       #!/bin/sh
       # shellcheck shell=busybox
-      set -eu
+      set -e
 
       msg() { echo "[git checkout]" "$@"; }
       fail() { msg FAIL "$@"; exit 1; }


### PR DESCRIPTION
Adding `set -u` will cause the pipeline to fail when a variable is not set. And we often don't have the SOURCE_DATE_EPOCH variable set in some pipelines. In particular, the iamguarded-test pipeline.