### PR TITLE
Replace goparsify with recursive descent parser

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,6 @@ require (
 	github.com/google/go-cmp v0.7.0
 	github.com/google/go-containerregistry v0.21.2
 	github.com/google/licenseclassifier/v2 v2.0.0
-	github.com/ijt/goparsify v0.0.0-20221203142333-3a5276334b8d
 	github.com/in-toto/attestation v1.1.2
 	github.com/invopop/jsonschema v0.13.0
 	github.com/joho/godotenv v1.5.1
@@ -61,6 +60,7 @@ require (
 	github.com/google/martian/v3 v3.3.3 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.1.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.3 // indirect
+	github.com/ijt/goparsify v0.0.0-20221203142333-3a5276334b8d // indirect
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
 	github.com/pavlo-v-chernykh/keystore-go/v4 v4.5.0 // indirect
 	go.opencensus.io v0.24.0 // indirect

--- a/pkg/cond/parser.go
+++ b/pkg/cond/parser.go
@@ -16,41 +16,8 @@ package cond
 
 import (
 	"fmt"
-
-	"github.com/ijt/goparsify"
+	"strings"
 )
-
-func combineOp(n *goparsify.Result) {
-	switch n.Child[1].Token {
-	case "&&":
-		n.Result = n.Child[0].Result == true && n.Child[2].Result == true
-	case "||":
-		n.Result = n.Child[0].Result == true || n.Child[2].Result == true
-	default:
-		panic(fmt.Errorf("unrecognized op"))
-	}
-}
-
-func collapseOp(n *goparsify.Result) {
-	n.Result = true
-	for _, child := range n.Child {
-		if child.Result != true {
-			n.Result = false
-			return
-		}
-	}
-}
-
-func comparisonOp(n *goparsify.Result) {
-	switch n.Child[1].Token {
-	case "==":
-		n.Result = n.Child[0].Token == n.Child[2].Token
-	case "!=":
-		n.Result = n.Child[0].Token != n.Child[2].Token
-	default:
-		panic(fmt.Errorf("unrecognized op"))
-	}
-}
 
 // A VariableLookupFunction designates how variables should be
 // resolved when evaluating expressions.
@@ -61,6 +28,186 @@ type VariableLookupFunction func(key string) (string, error)
 // function used by Evaluate.
 func NullLookup(key string) (string, error) {
 	return "", nil
+}
+
+// parser is a simple recursive descent parser for condition expressions.
+type parser struct {
+	input    string
+	pos      int
+	lookupFn VariableLookupFunction
+}
+
+func isWhitespace(c byte) bool {
+	return c == ' ' || c == '\t' || c == '\n' || c == '\r'
+}
+
+func (p *parser) skipWhitespace() {
+	for p.pos < len(p.input) && isWhitespace(p.input[p.pos]) {
+		p.pos++
+	}
+}
+
+func (p *parser) peek(s string) bool {
+	p.skipWhitespace()
+	return p.pos+len(s) <= len(p.input) && p.input[p.pos:p.pos+len(s)] == s
+}
+
+func (p *parser) expect(s string) error {
+	p.skipWhitespace()
+	if p.pos+len(s) > len(p.input) || p.input[p.pos:p.pos+len(s)] != s {
+		return fmt.Errorf("expected %q at position %d", s, p.pos)
+	}
+	p.pos += len(s)
+	return nil
+}
+
+func isVarChar(c byte) bool {
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '.' || c == '-' || c == '_'
+}
+
+// parseValue parses a string literal ('...' or "...") or a variable (${{...}}).
+func (p *parser) parseValue() (string, error) {
+	p.skipWhitespace()
+	if p.pos >= len(p.input) {
+		return "", fmt.Errorf("unexpected end of input at position %d", p.pos)
+	}
+
+	// String literal
+	if p.input[p.pos] == '\'' || p.input[p.pos] == '"' {
+		quote := p.input[p.pos]
+		p.pos++
+		var b strings.Builder
+		for p.pos < len(p.input) && p.input[p.pos] != quote {
+			if p.input[p.pos] == '\\' && p.pos+1 < len(p.input) {
+				p.pos++ // skip backslash
+				switch p.input[p.pos] {
+				case '\\', '\'', '"':
+					b.WriteByte(p.input[p.pos])
+				case 'n':
+					b.WriteByte('\n')
+				case 't':
+					b.WriteByte('\t')
+				default:
+					// Preserve unknown escapes as-is.
+					b.WriteByte('\\')
+					b.WriteByte(p.input[p.pos])
+				}
+			} else {
+				b.WriteByte(p.input[p.pos])
+			}
+			p.pos++
+		}
+		if p.pos >= len(p.input) {
+			return "", fmt.Errorf("unterminated string literal at position %d", p.pos)
+		}
+		p.pos++ // consume closing quote
+		return b.String(), nil
+	}
+
+	// Variable: ${{name}}
+	if p.peek("${{") {
+		p.pos += 3 // consume ${{
+		p.skipWhitespace()
+		start := p.pos
+		for p.pos < len(p.input) && isVarChar(p.input[p.pos]) {
+			p.pos++
+		}
+		if p.pos == start {
+			return "", fmt.Errorf("empty variable name at position %d", p.pos)
+		}
+		name := p.input[start:p.pos]
+		p.skipWhitespace()
+		if err := p.expect("}}"); err != nil {
+			return "", fmt.Errorf("unterminated variable reference %q at position %d: %w", name, start, err)
+		}
+		resolved, err := p.lookupFn(name)
+		if err != nil {
+			return "", fmt.Errorf("error resolving variable %q at position %d: %w", name, start, err)
+		}
+		return resolved, nil
+	}
+
+	return "", fmt.Errorf("unexpected character %q at position %d", p.input[p.pos], p.pos)
+}
+
+// parseComparison parses: value ('==' | '!=') value
+func (p *parser) parseComparison() (bool, error) {
+	lhs, err := p.parseValue()
+	if err != nil {
+		return false, err
+	}
+
+	p.skipWhitespace()
+	if p.pos+2 > len(p.input) {
+		return false, fmt.Errorf("expected comparison operator at position %d", p.pos)
+	}
+
+	op := p.input[p.pos : p.pos+2]
+	if op != "==" && op != "!=" {
+		return false, fmt.Errorf("expected '==' or '!=' at position %d, got %q", p.pos, op)
+	}
+	p.pos += 2
+
+	rhs, err := p.parseValue()
+	if err != nil {
+		return false, err
+	}
+
+	if op == "==" {
+		return lhs == rhs, nil
+	}
+	return lhs != rhs, nil
+}
+
+// parseAtom parses a grouped expression or a comparison.
+func (p *parser) parseAtom() (bool, error) {
+	p.skipWhitespace()
+	if p.pos < len(p.input) && p.input[p.pos] == '(' {
+		p.pos++ // consume '('
+		result, err := p.parseExpr()
+		if err != nil {
+			return false, err
+		}
+		if err := p.expect(")"); err != nil {
+			return false, fmt.Errorf("expected ')' at position %d: %w", p.pos, err)
+		}
+		return result, nil
+	}
+	return p.parseComparison()
+}
+
+// parseExpr parses atoms chained with && and ||.
+func (p *parser) parseExpr() (bool, error) {
+	result, err := p.parseAtom()
+	if err != nil {
+		return false, err
+	}
+
+	for {
+		p.skipWhitespace()
+		if p.pos+2 > len(p.input) {
+			break
+		}
+		op := p.input[p.pos : p.pos+2]
+		if op != "&&" && op != "||" {
+			break
+		}
+		p.pos += 2
+
+		rhs, err := p.parseAtom()
+		if err != nil {
+			return false, err
+		}
+
+		switch op {
+		case "&&":
+			result = result && rhs
+		case "||":
+			result = result || rhs
+		}
+	}
+
+	return result, nil
 }
 
 // Evaluate evaluates an input expression.
@@ -76,44 +223,21 @@ func Evaluate(inputExpr string, lookupFns ...VariableLookupFunction) (bool, erro
 		lookupFn = lookupFns[0]
 	}
 
-	equal := goparsify.Exact("==")
-	unequal := goparsify.Exact("!=")
-	comps := goparsify.Any(equal, unequal)
+	p := &parser{
+		input:    inputExpr,
+		pos:      0,
+		lookupFn: lookupFn,
+	}
 
-	variableName := goparsify.Chars("a-zA-Z0-9.\\-_")
-	variable := goparsify.Seq("${{", variableName, "}}").Map(func(n *goparsify.Result) {
-		if resolved, err := lookupFn(n.Child[1].Token); err == nil {
-			n.Token = resolved
-			n.Result = resolved
-		}
-	})
-
-	value := goparsify.Any(goparsify.StringLit("'\""), variable)
-	expr := goparsify.Seq(value, comps, value).Map(comparisonOp)
-
-	and := goparsify.Exact("&&")
-	or := goparsify.Exact("||")
-	chain := goparsify.Any(and, or)
-	combinedExpr := goparsify.Seq(expr, chain, expr).Map(combineOp)
-
-	exprChain := goparsify.Some(goparsify.Any(combinedExpr, expr), chain).Map(collapseOp)
-
-	group := goparsify.Seq("(", goparsify.Cut(), exprChain, ")").Map(func(n *goparsify.Result) {
-		n.Result = n.Child[2].Result
-	})
-	groupOrExpr := goparsify.Any(group, exprChain)
-	combinedGroup := goparsify.Seq(groupOrExpr, chain, groupOrExpr).Map(combineOp)
-
-	groupChain := goparsify.Some(goparsify.Any(combinedGroup, groupOrExpr), chain).Map(collapseOp)
-
-	result, _, err := goparsify.Run(groupChain, inputExpr, goparsify.UnicodeWhitespace)
+	result, err := p.parseExpr()
 	if err != nil {
 		return false, err
 	}
 
-	if rbool, ok := result.(bool); ok {
-		return rbool, nil
+	p.skipWhitespace()
+	if p.pos != len(p.input) {
+		return false, fmt.Errorf("unexpected trailing input at position %d: %q", p.pos, p.input[p.pos:])
 	}
 
-	return false, fmt.Errorf("got non-boolean result from parser")
+	return result, nil
 }

--- a/pkg/cond/parser_test.go
+++ b/pkg/cond/parser_test.go
@@ -76,6 +76,80 @@ func TestVariableLookup(t *testing.T) {
 	require.Equal(t, true, result, "${{foo.bar}} definitely equals baz")
 }
 
+func TestEvaluateUnterminatedVariable(t *testing.T) {
+	_, err := Evaluate("${{foo.bar} == 'baz'", placeholderLookup)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unterminated variable reference")
+	require.Contains(t, err.Error(), "foo.bar")
+}
+
+func TestStringLiteralEscapes(t *testing.T) {
+	// Escaped double quote inside double-quoted string.
+	result, err := Evaluate(`"hello \"world\"" == "hello \"world\""`)
+	require.NoError(t, err)
+	require.True(t, result)
+
+	// Escaped backslash.
+	result, err = Evaluate(`"a\\b" == "a\\b"`)
+	require.NoError(t, err)
+	require.True(t, result)
+
+	// Escaped single quote inside single-quoted string.
+	result, err = Evaluate(`'it\'s' == 'it\'s'`)
+	require.NoError(t, err)
+	require.True(t, result)
+
+	// Newline and tab escapes.
+	result, err = Evaluate(`"line1\nline2" == "line1\nline2"`)
+	require.NoError(t, err)
+	require.True(t, result)
+
+	// Mismatch: escaped vs literal.
+	result, err = Evaluate(`"a\\b" == "ab"`)
+	require.NoError(t, err)
+	require.False(t, result)
+}
+
+func FuzzEvaluate(f *testing.F) {
+	// Seed with valid and interesting expressions.
+	f.Add("'foo' == 'foo'")
+	f.Add("'foo' != 'bar'")
+	f.Add("${{foo.bar}} == 'baz'")
+	f.Add("${{ foo.bar }} == 'baz'")
+	f.Add(`"hello \"world\"" == "hello \"world\""`)
+	f.Add(`"a\\b" == "a\\b"`)
+	f.Add("('a' == 'a' && 'b' == 'b') || 'c' == 'd'")
+	f.Add("${{")
+	f.Add("${{ }}")
+	f.Add("'unterminated")
+	f.Add("")
+
+	f.Fuzz(func(t *testing.T, input string) {
+		// Evaluate must never panic regardless of input.
+		Evaluate(input, func(key string) (string, error) { //nolint:errcheck
+			return "x", nil
+		})
+	})
+}
+
+func FuzzSubst(f *testing.F) {
+	f.Add("Hello ${{foo.bar}}!")
+	f.Add("${{foo}} ${{bar}}")
+	f.Add("${{ foo.bar }}")
+	f.Add("no variables here")
+	f.Add("${{")
+	f.Add("${{ }}")
+	f.Add("${{foo.bar}")
+	f.Add("")
+
+	f.Fuzz(func(t *testing.T, input string) {
+		// Subst must never panic regardless of input.
+		Subst(input, func(key string) (string, error) { //nolint:errcheck
+			return "x", nil
+		})
+	})
+}
+
 func TestVariableLookupWhitespace(t *testing.T) {
 	result, err := Evaluate("${{ foo.bar }} == 'baz'", placeholderLookup)
 	require.NoErrorf(t, err, "got error: %v", err)
@@ -84,4 +158,13 @@ func TestVariableLookupWhitespace(t *testing.T) {
 	result, err = Evaluate("'baz' == ${{ foo.bar }}", placeholderLookup)
 	require.NoErrorf(t, err, "got error: %v", err)
 	require.Equal(t, true, result, "${{ foo.bar }} definitely equals baz")
+
+	// Tabs and newlines inside braces.
+	result, err = Evaluate("${{\tfoo.bar\t}} == 'baz'", placeholderLookup)
+	require.NoErrorf(t, err, "got error: %v", err)
+	require.Equal(t, true, result, "tabs inside variable braces should be accepted")
+
+	result, err = Evaluate("${{\n foo.bar \n}} == 'baz'", placeholderLookup)
+	require.NoErrorf(t, err, "got error: %v", err)
+	require.Equal(t, true, result, "newlines inside variable braces should be accepted")
 }

--- a/pkg/cond/subst.go
+++ b/pkg/cond/subst.go
@@ -18,8 +18,6 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-
-	"github.com/ijt/goparsify"
 )
 
 func Subst(inputExpr string, lookupFns ...VariableLookupFunction) (string, error) {
@@ -29,43 +27,64 @@ func Subst(inputExpr string, lookupFns ...VariableLookupFunction) (string, error
 		lookupFn = lookupFns[0]
 	}
 
-	whiteSpace := goparsify.Many(goparsify.Exact(" "))
-	variableName := goparsify.Chars("a-zA-Z0-9.\\-_")
-	errs := []error{}
-	variable := goparsify.Seq("${{", whiteSpace, variableName, whiteSpace, "}}").Map(func(n *goparsify.Result) {
-		if resolved, err := lookupFn(n.Child[2].Token); err == nil {
-			n.Token = resolved
-			n.Result = resolved
-		} else {
+	var b strings.Builder
+	b.Grow(len(inputExpr))
+
+	var errs []error
+	i := 0
+	for i < len(inputExpr) {
+		// Look for the next ${{ marker.
+		idx := strings.Index(inputExpr[i:], "${{")
+		if idx < 0 {
+			// No more variables, write the rest.
+			b.WriteString(inputExpr[i:])
+			break
+		}
+
+		// Write text before the variable.
+		b.WriteString(inputExpr[i : i+idx])
+		i += idx + 3 // skip past ${{
+
+		// Skip whitespace inside braces.
+		for i < len(inputExpr) && isWhitespace(inputExpr[i]) {
+			i++
+		}
+
+		// Read variable name.
+		start := i
+		for i < len(inputExpr) && isVarChar(inputExpr[i]) {
+			i++
+		}
+		name := inputExpr[start:i]
+
+		if name == "" {
+			errs = append(errs, fmt.Errorf("empty variable name at position %d", start))
+			continue
+		}
+
+		// Skip whitespace before }}.
+		for i < len(inputExpr) && isWhitespace(inputExpr[i]) {
+			i++
+		}
+
+		// Expect }}.
+		if i+2 > len(inputExpr) || inputExpr[i:i+2] != "}}" {
+			errs = append(errs, fmt.Errorf("unterminated variable reference %q at position %d", name, start))
+			continue
+		}
+		i += 2
+
+		resolved, err := lookupFn(name)
+		if err != nil {
 			errs = append(errs, err)
-			n.Token = ""
-			n.Result = ""
+		} else {
+			b.WriteString(resolved)
 		}
-	})
-
-	text := goparsify.Until("${{")
-	node := goparsify.Any(text, variable)
-
-	document := goparsify.Many(node).Map(func(n *goparsify.Result) {
-		tokens := make([]string, 0, len(n.Child))
-		for _, tok := range n.Child {
-			tokens = append(tokens, tok.Token)
-		}
-		n.Result = strings.Join(tokens, "")
-	})
-
-	result, _, err := goparsify.Run(document, inputExpr, goparsify.NoWhitespace)
-	if err != nil {
-		return "", fmt.Errorf("parser error: %w", err)
 	}
 
 	if err := errors.Join(errs...); err != nil {
 		return "", err
 	}
 
-	if rstr, ok := result.(string); ok {
-		return rstr, nil
-	}
-
-	return "", fmt.Errorf("got non-string result from parser")
+	return b.String(), nil
 }

--- a/pkg/cond/subst_test.go
+++ b/pkg/cond/subst_test.go
@@ -47,6 +47,15 @@ func TestSubstVarWhitespace(t *testing.T) {
 	require.Equal(t, expected, result, "result does not match expected result")
 }
 
+func TestSubstVarWhitespaceTabsNewlines(t *testing.T) {
+	doc := "Hello ${{\tfoo.bar\t}} ${{\nfoo.bar\n}}!"
+	expected := "Hello baz baz!"
+	result, err := Subst(doc, placeholderLookup)
+
+	require.NoErrorf(t, err, "got error: %v", err)
+	require.Equal(t, expected, result, "result does not match expected result")
+}
+
 func TestSubstVarUnderscore(t *testing.T) {
 	doc := "Hello ${{foo.BAR_BAZ}}!"
 	expected := "Hello bar-baz!"
@@ -88,6 +97,30 @@ func TestSubstVarWhitespaceExactWhitespace(t *testing.T) {
 
 	require.NoErrorf(t, err, "got error: %v", err)
 	require.Equal(t, expected, result, "result does not match expected result")
+}
+
+func TestSubstMissingClosingBraces(t *testing.T) {
+	doc := "Hello ${{foo.bar}!"
+	_, err := Subst(doc, placeholderLookup)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unterminated variable reference")
+}
+
+func TestSubstEmptyVarName(t *testing.T) {
+	doc := "Hello ${{ }}!"
+	_, err := Subst(doc, placeholderLookup)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "empty variable name")
+}
+
+func TestSubstTrailingMarker(t *testing.T) {
+	_, err := Subst("hello ${{", placeholderLookup)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "empty variable name")
+
+	_, err = Subst("hello ${{foo", placeholderLookup)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unterminated variable reference")
 }
 
 func TestSubstVarShellFragment(t *testing.T) {


### PR DESCRIPTION
Replace the goparsify parser combinator library with a purpose-built recursive descent parser for condition evaluation and a simple string scanner for variable substitution. This avoids the overhead of goparsify's general-purpose combinator machinery (allocation-heavy Result trees, backtracking, repeated closure dispatch) in favor of direct index-based scanning over the input string.

Benchmarking against all melange package configs shows this is ~1.5x faster to parse.

I've also verified this against all our melange configs to confirm that the results are equivalent.