### PR TITLE
feat(config): add commit_source and use_release fields to VersionDataSource

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1072,6 +1072,10 @@ type VersionDataSource struct {
 	Stream string `json:"stream" yaml:"stream"`
 	// A list of regex patterns to ignore when matching upstream versions
 	Ignore []string `json:"ignore,omitempty" yaml:"ignore,omitempty"`
+	// The source whose commits to use when multiple sources are configured
+	CommitSource string `json:"commit_source,omitempty" yaml:"commit_source,omitempty"`
+	// Whether to use GitHub releases as the tag source instead of git tags
+	UseRelease bool `json:"use_release,omitempty" yaml:"use_release,omitempty"`
 }
 
 // GetStripPrefix returns the prefix that should be stripped from the GitMonitor version.


### PR DESCRIPTION
Adds two optional fields to `VersionDataSource`:
- `commit_source`: specifies which source's commits to use when multiple sources are configured
- `use_release`: uses GitHub releases as the tag source instead of git tags (default)