### PR TITLE
qemu: Also select on logCtx done channel

### DIFF
--- a/pkg/container/qemu_runner.go
+++ b/pkg/container/qemu_runner.go
@@ -938,6 +938,11 @@ func createMicroVM(ctx context.Context, cfg *Config) error {
 		defer os.Remove(cfg.Disk)
 		defer stopVirtiofsd(ctx, cfg)
 		return fmt.Errorf("qemu: VM exited unexpectedly: %w", err)
+	case <-logCtx.Done():
+		defer os.Remove(cfg.ImgRef)
+		defer os.Remove(cfg.Disk)
+		defer stopVirtiofsd(ctx, cfg)
+		return fmt.Errorf("qemu: %w", context.Cause(logCtx))
 	case <-ctx.Done():
 		defer os.Remove(cfg.ImgRef)
 		defer os.Remove(cfg.Disk)


### PR DESCRIPTION
After 60s of polling for the ssh server, we call cancel():

> cancel(fmt.Errorf("ssh server never came up"))

In the main thread, we're waiting for ctx.Done():

> case <-ctx.Done():

But that cancel is actually derive from the logCtx creation, not the parent ctx, so we also need to select on the logCtx, otherwise we'll just wait forever in that select and never exit.
