### PR TITLE
qemu: set conservative guest MTU to prevent hangs in nested environments

### DIFF
--- a/pkg/container/qemu_runner.go
+++ b/pkg/container/qemu_runner.go
@@ -742,7 +742,12 @@ func createMicroVM(ctx context.Context, cfg *Config) error {
 	baseargs = append(baseargs, serialArgs...)
 	// use -netdev + -device instead of -nic, as this is better supported by microvm machine type
 	baseargs = append(baseargs, "-netdev", "user,id=id1,hostfwd=tcp:"+cfg.SSHAddress+"-:22,hostfwd=tcp:"+cfg.SSHControlAddress+"-:2223")
-	baseargs = append(baseargs, "-device", "virtio-net-pci,netdev=id1,romfile=")
+	// Set host_mtu to avoid silent packet drops in nested environments (e.g.,
+	// QEMU inside GKE pods). SLIRP defaults to 1500 MTU but the host path MTU
+	// may be lower due to encapsulation (GCP VPC uses 1460, pod networks can be
+	// lower). The guest kernel picks up host_mtu via virtio feature negotiation
+	// and configures the interface MTU automatically at boot.
+	baseargs = append(baseargs, "-device", "virtio-net-pci,netdev=id1,romfile=,host_mtu=1400")
 	// add random generator via pci, improve ssh startup time
 	baseargs = append(baseargs, "-device", "virtio-rng-pci,rng=rng0", "-object", "rng-random,filename=/dev/urandom,id=rng0")
 	// panic=-1 ensures that if the init fails, we immediately exit the machine


### PR DESCRIPTION
https://docs.cloud.google.com/vpc/docs/mtu

QEMU's SLIRP networking defaults to 1500 MTU inside the guest, but when running inside GKE pods on GCP the effective path MTU is lower (GCP VPC uses 1460, pod networks can be even lower). Large packets get silently dropped and PMTU discovery fails because ICMP is often filtered, causing SSH sessions to hang indefinitely on bulk data transfer.

Set MTU to 1400 on all non-loopback guest interfaces after SSH is established, providing 60 bytes of headroom below GCP's 1460 MTU.