### PR TITLE
chore(config): Support var substitutions for update monitors

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1419,6 +1419,43 @@ func replaceTest(r *strings.Replacer, in *Test) *Test {
 	}
 }
 
+func replaceUpdate(r *strings.Replacer, in Update) Update {
+	out := in
+
+	if in.ReleaseMonitor != nil {
+		out.ReleaseMonitor = &ReleaseMonitor{
+			Identifier:            in.ReleaseMonitor.Identifier,
+			StripPrefix:           in.ReleaseMonitor.StripPrefix,
+			StripSuffix:           in.ReleaseMonitor.StripSuffix,
+			VersionFilterContains: r.Replace(in.ReleaseMonitor.VersionFilterContains),
+			VersionFilterPrefix:   r.Replace(in.ReleaseMonitor.VersionFilterPrefix),
+		}
+	}
+
+	if in.GitHubMonitor != nil {
+		out.GitHubMonitor = &GitHubMonitor{
+			Identifier:        r.Replace(in.GitHubMonitor.Identifier),
+			StripPrefix:       in.GitHubMonitor.StripPrefix,
+			StripSuffix:       in.GitHubMonitor.StripSuffix,
+			TagFilter:         r.Replace(in.GitHubMonitor.TagFilter),
+			TagFilterPrefix:   r.Replace(in.GitHubMonitor.TagFilterPrefix),
+			TagFilterContains: r.Replace(in.GitHubMonitor.TagFilterContains),
+			UseTags:           in.GitHubMonitor.UseTags,
+		}
+	}
+
+	if in.GitMonitor != nil {
+		out.GitMonitor = &GitMonitor{
+			StripPrefix:       in.GitMonitor.StripPrefix,
+			StripSuffix:       in.GitMonitor.StripSuffix,
+			TagFilterPrefix:   r.Replace(in.GitMonitor.TagFilterPrefix),
+			TagFilterContains: r.Replace(in.GitMonitor.TagFilterContains),
+		}
+	}
+
+	return out
+}
+
 func replaceScriptlets(r *strings.Replacer, in *Scriptlets) *Scriptlets {
 	if in == nil {
 		return nil
@@ -1659,6 +1696,8 @@ func ParseConfiguration(ctx context.Context, configurationFilePath string, opts 
 	cfg.Environment = replaceImageConfig(replacer, cfg.Environment)
 
 	cfg.Test = replaceTest(replacer, cfg.Test)
+
+	cfg.Update = replaceUpdate(replacer, cfg.Update)
 
 	cfg.Data = nil // TODO: zero this out or not?
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -185,6 +185,71 @@ test:
 	require.Equal(t, "/usr/local/FOO", cfg.Test.Environment.Environment["LD_LIBRARY_PATH"])
 }
 
+func Test_updateBlockVarSubstitution(t *testing.T) {
+	ctx := slogtest.Context(t)
+
+	fp := filepath.Join(os.TempDir(), "melange-test-updateBlockVarSubstitution")
+	if err := os.WriteFile(fp, []byte(`
+package:
+  name: test-update-vars
+  version: 1.2.3
+  epoch: 0
+  description: test variable substitution in update block
+
+vars:
+  stream: "1.2"
+
+update:
+  enabled: true
+  github:
+    identifier: myorg/${{package.name}}
+    tag-filter-prefix: v${{vars.stream}}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := ParseConfiguration(ctx, fp)
+	if err != nil {
+		t.Fatalf("failed to parse configuration: %s", err)
+	}
+
+	require.True(t, cfg.Update.Enabled)
+
+	// GitHub monitor fields should have vars resolved
+	require.NotNil(t, cfg.Update.GitHubMonitor)
+	require.Equal(t, "myorg/test-update-vars", cfg.Update.GitHubMonitor.Identifier)
+	require.Equal(t, "v1.2", cfg.Update.GitHubMonitor.TagFilterPrefix)
+}
+
+func Test_updateBlockVarSubstitutionGitMonitor(t *testing.T) {
+	ctx := slogtest.Context(t)
+
+	fp := filepath.Join(os.TempDir(), "melange-test-updateBlockVarSubstitutionGit")
+	if err := os.WriteFile(fp, []byte(`
+package:
+  name: test-update-vars-git
+  version: 5.0.0
+  epoch: 0
+  description: test variable substitution in update block with git monitor
+
+vars:
+  prefix: release-
+
+update:
+  enabled: true
+  git:
+    tag-filter-prefix: ${{vars.prefix}}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := ParseConfiguration(ctx, fp)
+	if err != nil {
+		t.Fatalf("failed to parse configuration: %s", err)
+	}
+
+	require.NotNil(t, cfg.Update.GitMonitor)
+	require.Equal(t, "release-", cfg.Update.GitMonitor.TagFilterPrefix)
+}
+
 func Test_rangeSubstitutions(t *testing.T) {
 	ctx := slogtest.Context(t)
 


### PR DESCRIPTION
I've wanted this for a while now for version streamed packages. This adds support for using variables for tag/version filters, and gh identifiers

This is especially useful for projects like OpenJDK that have streamed releases and repositories

In the future, at least for gh identifiers, we could just infer it from the repo passed to git-checkout... (thinking out loud)