### PR TITLE
test: strip sed integration test down to just git-checkout

### DIFF
--- a/pkg/build/testdata/build_configs/sed.yaml
+++ b/pkg/build/testdata/build_configs/sed.yaml
@@ -5,24 +5,16 @@ package:
   description: "GNU stream editor"
   copyright:
     - license: GPL-3.0-or-later
-  resources:
-    cpu: "7"
-    memory: 7Gi
 
 environment:
   contents:
     packages:
-      - autoconf
-      - automake
-      - build-base
       - busybox
       - ca-certificates-bundle
-      - coreutils
-      - gettext-dev
-      - rsync # for gnulib translations
-      - texinfo
-      - wget # for gnulib translations
 
+# This test exists to exercise git-checkout with recurse-submodules,
+# shallow-submodules, and submodule-jobs under set -u. We don't need
+# to actually build sed — just verify the checkout succeeds.
 pipeline:
   - uses: git-checkout
     with:
@@ -33,31 +25,12 @@ pipeline:
       shallow-submodules: true
       submodule-jobs: $(nproc)
 
-  # - name: git.savannah.gnu.org is flaky
-  #   runs: git submodule set-url gnulib https://github.com/coreutils/gnulib.git
-
-  - runs: echo ${{package.version}} >.tarball-version
-
-  - runs: ./bootstrap
-
-  - uses: autoconf/configure
-
-  - uses: autoconf/make
-
-  - uses: autoconf/make-install
-
   - runs: |
-      rm -f "${{targets.destdir}}"/usr/share/info/dir
-
-  - uses: strip
+      mkdir -p "${{targets.destdir}}"/usr/bin
+      echo "#!/bin/sh" > "${{targets.destdir}}"/usr/bin/sed
+      chmod +x "${{targets.destdir}}"/usr/bin/sed
 
 update:
   enabled: true
   release-monitor:
     identifier: 4789
-
-test:
-  pipeline:
-    - runs: |
-        sed --version
-        sed --help


### PR DESCRIPTION
The sed test was added to exercise git-checkout with recurse-submodules, shallow-submodules, and submodule-jobs under set -u. It didn't need to actually build sed (bootstrap, configure, make) which took ~555s under x86_64 emulation on ARM, causing the default 600s test timeout to be exceeded. Strip the pipeline to just the git-checkout step and a placeholder binary install. Test now completes in ~26s.