### PR TITLE
fix(build): guard against nil runner in NewTest

### DIFF
--- a/pkg/build/test.go
+++ b/pkg/build/test.go
@@ -102,7 +102,7 @@ func NewTest(ctx context.Context, opts ...TestOption) (*Test, error) {
 		}
 
 		t.WorkspaceDir = absdir
-	} else {
+	} else if t.Runner != nil {
 		tmpdir, err := os.MkdirTemp(t.Runner.TempDir(), "melange-workspace-*")
 		if err != nil {
 			return nil, fmt.Errorf("unable to create workspace dir: %w", err)
@@ -125,7 +125,7 @@ func NewTest(ctx context.Context, opts ...TestOption) (*Test, error) {
 	t.Configuration = *parsedCfg
 
 	// Check that we actually can run things in containers.
-	if !t.Runner.TestUsability(ctx) {
+	if t.Runner != nil && !t.Runner.TestUsability(ctx) {
 		return nil, fmt.Errorf("unable to run containers using %s, specify --runner and one of %s", t.Runner.Name(), GetAllRunners())
 	}
 

--- a/pkg/build/test_test.go
+++ b/pkg/build/test_test.go
@@ -152,6 +152,17 @@ func TestBuildWorkspaceConfig(t *testing.T) {
 	}
 }
 
+func TestNewTestWithoutRunner(t *testing.T) {
+	ctx := slogtest.Context(t)
+	_, err := NewTest(ctx,
+		WithTestConfig(filepath.Join("testdata", "test_configuration_load", "py3-pandas.melange.yaml")),
+		WithTestWorkspaceDir(t.TempDir()),
+	)
+	if err != nil {
+		t.Fatalf("NewTest without runner should succeed for compile-only use: %v", err)
+	}
+}
+
 // TestConfigurationLoad is the main set of tests for loading a configuration
 // file for tests. When in doubt, add your test here.
 func TestConfigurationLoad(t *testing.T) {


### PR DESCRIPTION
`build.NewTest` panicked when called without a runner, unlike `build.New` which handles a nil runner gracefully. Add the same nil checks so NewTest.

A practical use case that does not need a runner is pkg/build's `Test.Compile` like `Build.Compile` for compile-only workflows without requiring a container runner.

## Melange Pull Request Template

<!--
*** PULL REQUEST CHECKLIST: PLEASE START HERE ***

The single most important feature of melange is that we can build Wolfi.

Many changes to melange introduce a risk of breaking the build, and sometimes
these are not flushed out until a package is changed (much) later.  This
pertains to basic execution, SCA changes, linter changes, and more.
-->

### Functional Changes

- [ ] This change can build all of Wolfi without errors (describe results in notes)

Notes:

### SCA Changes

- [ ] Examining several representative APKs show no regression / the desired effect (details in notes)

Notes:

### Linter

- [x] The new check is clean across Wolfi
- [x] The new check is opt-in or a warning

Notes:
