### PR TITLE
pipeline: execute them with set -eo pipefail

### DIFF
--- a/pkg/build/pipeline.go
+++ b/pkg/build/pipeline.go
@@ -181,11 +181,15 @@ func buildEvalRunCommand(_ *config.Pipeline, debugOption rune, workdir string, f
 	// Using go-shellquote library for robust shell escaping
 	safeWorkdir := quoteShellArg(workdir)
 
-	script := fmt.Sprintf(`set -e%c
+	xFlag := ""
+	if debugOption == 'x' {
+		xFlag = "x"
+	}
+	script := fmt.Sprintf(`set -e%so pipefail
 [ -d %s ] || mkdir -p %s
 cd %s
 %s
-exit 0`, debugOption, safeWorkdir, safeWorkdir, safeWorkdir, fragment)
+exit 0`, xFlag, safeWorkdir, safeWorkdir, safeWorkdir, fragment)
 	return []string{"/bin/sh", "-c", script}
 }
 

--- a/pkg/build/pipeline_test.go
+++ b/pkg/build/pipeline_test.go
@@ -149,7 +149,7 @@ func Test_buildEvalRunCommand(t *testing.T) {
 	command := buildEvalRunCommand(p, debugOption, workdir, fragment)
 	// Note: shellquote.Join() only adds quotes when necessary
 	// Simple paths like /bar don't need quotes, so they're returned unquoted
-	expected := []string{"/bin/sh", "-c", `set -ex
+	expected := []string{"/bin/sh", "-c", `set -exo pipefail
 [ -d /bar ] || mkdir -p /bar
 cd /bar
 baz


### PR DESCRIPTION
If a pipeline is 'cmd1 | cmd2' we want to fail the execution if cmd1 failed.

Previous to this patch, we had a raising number of pipelines that are manually encoding
'set -eo pipefail' on each instance.

Signed-off-by: Arturo Borrero Gonzalez <arturo.borrero@chainguard.dev>
