### PR TITLE
ci: Make verify failures more obvious

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -36,6 +36,9 @@ jobs:
 
       - run: |
           make docs-repo
+          git diff --exit-code
+
+      - run: |
           make docs-pipeline
           git diff --exit-code
 


### PR DESCRIPTION
Currently when looking at the logs, if `make docs-pipeline` fails, it looks like it's `make docs-repo` failing, which is very confusing.
