### PR TITLE
git-chekcout: Fail when expected-commit is empty

### DIFF
--- a/pkg/build/pipelines/git-checkout.yaml
+++ b/pkg/build/pipelines/git-checkout.yaml
@@ -253,7 +253,7 @@ pipeline:
           fi
 
           [ -n "$expcommit" ] ||
-              msg "Warning: no expected-commit"
+              fail "expected-commit should be specified"
 
           local flags="" depthflag="" dest_fullpath="" workdir=""
           local remote="origin" rcfile="" rc="" quiet="--quiet"


### PR DESCRIPTION
https://chainguard-dev.slack.com/archives/C063AT3FVFA/p1774299066207669?thread_ts=1774278967.405719&cid=C063AT3FVFA