### PR TITLE
chore(harden-runner): add more Go endpoints

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,6 +24,7 @@ jobs:
             *.blob.core.windows.net:443
             *.githubapp.com:443
             api.github.com:443
+            dl.google.com:443
             github.com:443
             go.dev:443
             goreleaser.com:443

--- a/.github/workflows/go-tests.yaml
+++ b/.github/workflows/go-tests.yaml
@@ -25,6 +25,7 @@ jobs:
             7-zip.org:443
             api.github.com:443
             azure.archive.ubuntu.com:80
+            dl.google.com:443
             esm.ubuntu.com:443
             files.pythonhosted.org:443
             git.savannah.gnu.org:443

--- a/.github/workflows/melange-test-pipelines.yaml
+++ b/.github/workflows/melange-test-pipelines.yaml
@@ -24,6 +24,7 @@ jobs:
             *.blob.core.windows.net:443
             *.githubapp.com:443
             api.github.com:443
+            dl.google.com:443
             github.com:443
             go.dev:443
             objects.githubusercontent.com:443
@@ -76,6 +77,7 @@ jobs:
             auth.docker.io:443
             azure.archive.ubuntu.com:80
             dl-cdn.alpinelinux.org:443
+            dl.google.com:443
             esm.ubuntu.com:443
             files.pythonhosted.org:443
             git.netfilter.org:443

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,6 +26,7 @@ jobs:
             *.githubapp.com:443
             api.github.com:443
             auth.docker.io:443
+            dl.google.com:443
             fulcio.sigstore.dev:443
             ghcr.io:443
             github.com:443

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -24,6 +24,7 @@ jobs:
             *.blob.core.windows.net:443
             *.githubapp.com:443
             api.github.com:443
+            dl.google.com:443
             github.com:443
             go.dev:443
             golangci-lint.run:443

--- a/.github/workflows/wolfi-presubmit.yaml
+++ b/.github/workflows/wolfi-presubmit.yaml
@@ -24,6 +24,7 @@ jobs:
             *.blob.core.windows.net:443
             *.githubapp.com:443
             api.github.com:443
+            dl.google.com:443
             github.com:443
             go.dev:443
             objects.githubusercontent.com:443
@@ -117,6 +118,7 @@ jobs:
             cpan.metacpan.org:443
             de.postfix.org:443
             dl-cdn.alpinelinux.org:443
+            dl.google.com:443
             doc-10-as-docs.googleusercontent.com:443
             download.docker.com:443
             drive.google.com:443
@@ -127,10 +129,12 @@ jobs:
             ghcr.io:443
             git.dpkg.org:443
             github.com:443
+            go.dev:443
             grype.anchore.io:443
             index.crates.io:443
             invisible-mirror.net:443
             motd.ubuntu.com:443
+            objects.githubusercontent.com:443
             packages.microsoft.com:443
             packages.wolfi.dev:443
             pkg-containers.githubusercontent.com:443
@@ -140,6 +144,7 @@ jobs:
             raw.githubusercontent.com:443
             registry.npmjs.org:443
             registry.yarnpkg.com:443
+            release-assets.githubusercontent.com:443
             results-receiver.actions.githubusercontent.com:443
             security.ubuntu.com:80
             static.crates.io:443


### PR DESCRIPTION
This PR adds more endpoints in the event we don't use the Golang cache.