### PR TITLE
Expose schema to dependents

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -47,7 +47,12 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"chainguard.dev/melange/pkg/util"
+
+	_ "embed"
 )
+
+//go:embed schema.json
+var SchemaJSON []byte
 
 const (
 	buildUser   = "build"


### PR DESCRIPTION
I'm doing some strange things where it would be very useful to have access to this schema as a dependency of melange.