### PR TITLE
feat(qemu): apply reasonable CPU/memory defaults

### DIFF
--- a/pkg/build/build_test.go
+++ b/pkg/build/build_test.go
@@ -50,7 +50,7 @@ func TestConfiguration_Load(t *testing.T) {
 				Package: config.Package{
 					Name:      "hello",
 					Version:   "world",
-					Resources: &config.Resources{},
+					Resources: &config.Resources{CPU: "2", Memory: "4Gi"},
 				},
 				Pipeline: []config.Pipeline{
 					{
@@ -127,7 +127,7 @@ func TestConfiguration_Load(t *testing.T) {
 				Package: config.Package{
 					Name:      "cosign",
 					Version:   "2.0.0",
-					Resources: &config.Resources{},
+					Resources: &config.Resources{CPU: "2", Memory: "4Gi"},
 				},
 				Update: config.Update{
 					Enabled: true,
@@ -144,7 +144,7 @@ func TestConfiguration_Load(t *testing.T) {
 			name:       "release-monitor",
 			requireErr: require.NoError,
 			expected: &config.Configuration{
-				Package: config.Package{Name: "bison", Version: "3.8.2", Resources: &config.Resources{}},
+				Package: config.Package{Name: "bison", Version: "3.8.2", Resources: &config.Resources{CPU: "2", Memory: "4Gi"}},
 				Update: config.Update{
 					Enabled: true,
 					Shared:  false,
@@ -199,7 +199,7 @@ func TestConfiguration_Load(t *testing.T) {
 					Name:      "cosign",
 					Version:   "2.0.0",
 					Epoch:     0,
-					Resources: &config.Resources{},
+					Resources: &config.Resources{CPU: "2", Memory: "4Gi"},
 				},
 				Environment: apko_types.ImageConfiguration{
 					Environment: map[string]string{
@@ -282,7 +282,7 @@ package:
 		Package: config.Package{
 			Name:      "nginx",
 			Version:   "100",
-			Resources: &config.Resources{},
+			Resources: &config.Resources{CPU: "2", Memory: "4Gi"},
 		},
 		Subpackages: []config.Subpackage{},
 	}

--- a/pkg/build/test_test.go
+++ b/pkg/build/test_test.go
@@ -179,7 +179,7 @@ func TestConfigurationLoad(t *testing.T) {
 				Package: config.Package{
 					Name:      "hello",
 					Version:   "world",
-					Resources: &config.Resources{},
+					Resources: &config.Resources{CPU: "2", Memory: "4Gi"},
 				},
 				Test: &config.Test{
 					Environment: defaultEnv(),
@@ -291,7 +291,7 @@ func TestConfigurationLoad(t *testing.T) {
 				Package: config.Package{
 					Name:      "py3-pandas",
 					Version:   "2.1.3",
-					Resources: &config.Resources{},
+					Resources: &config.Resources{CPU: "2", Memory: "4Gi"},
 				},
 				Test: &config.Test{
 					Environment: defaultEnv(func(env *apko_types.ImageConfiguration) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1861,6 +1861,17 @@ func ParseConfiguration(ctx context.Context, configurationFilePath string, opts 
 		cfg.Package.Resources.Disk = options.disk
 	}
 
+	// Apply reasonable defaults for CPU and memory if still unset after YAML and CLI
+	// flag processing. Without these, the QEMU runner defaults to all host CPUs
+	// and 85% of host memory, causing resource contention when multiple builds
+	// share a node.
+	if cfg.Package.Resources.CPU == "" {
+		cfg.Package.Resources.CPU = "2"
+	}
+	if cfg.Package.Resources.Memory == "" {
+		cfg.Package.Resources.Memory = "4Gi"
+	}
+
 	// Finally, validate the configuration we ended up with before returning it for use downstream.
 	if err = cfg.validate(ctx); err != nil {
 		return nil, fmt.Errorf("validating configuration %q: %w", cfg.Package.Name, err)

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1504,8 +1504,8 @@ package:
     memory: 8Gi
 `,
 			expectResources: &Resources{
-				CPU:    "",
-				Memory: "",
+				CPU:    "2",
+				Memory: "4Gi",
 			},
 			expectTestResources: &Resources{
 				CPU:    "4",
@@ -1540,8 +1540,8 @@ package:
   epoch: 0
 `,
 			expectResources: &Resources{
-				CPU:    "",
-				Memory: "",
+				CPU:    "2",
+				Memory: "4Gi",
 			},
 			expectTestResources: nil,
 			expectParseError:    false,
@@ -1585,8 +1585,8 @@ package:
     memory: 8Gi
 `,
 			expectResources: &Resources{
-				CPU:    "",
-				Memory: "",
+				CPU:    "2",
+				Memory: "4Gi",
 			},
 			expectTestResources: &Resources{
 				CPU:      "4",

--- a/pkg/container/qemu_runner.go
+++ b/pkg/container/qemu_runner.go
@@ -697,8 +697,13 @@ func createMicroVM(ctx context.Context, cfg *Config) error {
 		baseargs = append(baseargs, "-m", fmt.Sprintf("%dk", mem))
 	}
 
-	// default to use all CPUs, if a cpu limit is set, respect it.
+	// default to use all CPUs, if a cgroup or config limit is set, respect it.
+	// In a container (e.g. Kubernetes pod), runtime.NumCPU() returns the host's
+	// total CPUs, not the pod's allocation. Check cgroup limits first.
 	nproc := runtime.NumCPU()
+	if cgroupCPU := getCgroupCPULimitCores(); cgroupCPU > 0 && cgroupCPU < nproc {
+		nproc = cgroupCPU
+	}
 	if cfg.CPU != "" {
 		cpu, err := strconv.Atoi(cfg.CPU)
 		if err == nil && nproc > cpu {
@@ -1758,6 +1763,39 @@ func convertHumanToKB(memory string) (int64, error) {
 
 	// Return the value in kilobytes
 	return num * multiplier / 1024, nil
+}
+
+// getCgroupCPULimitCores reads the cgroup CPU quota for the current process and
+// returns the number of whole CPU cores available. It checks cgroup v2 first,
+// then falls back to cgroup v1. Returns 0 if no cgroup limit is found.
+func getCgroupCPULimitCores() int {
+	// cgroup v2: /sys/fs/cgroup/cpu.max (format: "quota period" e.g. "1000000 100000")
+	if data, err := os.ReadFile("/sys/fs/cgroup/cpu.max"); err == nil {
+		s := strings.TrimSpace(string(data))
+		if !strings.HasPrefix(s, "max") {
+			parts := strings.Fields(s)
+			if len(parts) == 2 {
+				quota, err1 := strconv.ParseInt(parts[0], 10, 64)
+				period, err2 := strconv.ParseInt(parts[1], 10, 64)
+				if err1 == nil && err2 == nil && period > 0 && quota > 0 {
+					return max(int(quota/period), 1)
+				}
+			}
+		}
+	}
+
+	// cgroup v1: cpu.cfs_quota_us / cpu.cfs_period_us
+	quotaData, err1 := os.ReadFile("/sys/fs/cgroup/cpu/cpu.cfs_quota_us")
+	periodData, err2 := os.ReadFile("/sys/fs/cgroup/cpu/cpu.cfs_period_us")
+	if err1 == nil && err2 == nil {
+		quota, err1 := strconv.ParseInt(strings.TrimSpace(string(quotaData)), 10, 64)
+		period, err2 := strconv.ParseInt(strings.TrimSpace(string(periodData)), 10, 64)
+		if err1 == nil && err2 == nil && period > 0 && quota > 0 {
+			return max(int(quota/period), 1)
+		}
+	}
+
+	return 0
 }
 
 // getCgroupMemoryLimitKB reads the cgroup memory limit for the current process.


### PR DESCRIPTION
We've always defaulted to all of the host's cores and ~85% of the available memory for the QEMU Runner. This works for one-off builds but running multiple on the same host will likely cause one or more (or all) of the builds to fail if all of them attempt to request this.

To that end, this PR sets a 2 CPU/4Gi memory default for the QEMU runner if `resources` are unset in the package's Melange definition.