### PR TITLE
fix(pipelines/autoconf/configure): add libtool

### DIFF
--- a/pkg/build/pipelines/autoconf/configure.yaml
+++ b/pkg/build/pipelines/autoconf/configure.yaml
@@ -4,6 +4,7 @@ needs:
   packages:
     - autoconf
     - automake
+    - libtool
 
 inputs:
   dir:


### PR DESCRIPTION
libtool is a very common autogen requirement, thus add it as default
dependency.
