### PR TITLE
sca: Generate dlopen dependencies

### DIFF
--- a/pkg/sca/e2e_test.go
+++ b/pkg/sca/e2e_test.go
@@ -145,10 +145,13 @@ func TestAnalyze(t *testing.T) {
 				"so:libcrypt.so.1",
 				"so:libcrypto.so.3",
 				"so:libfdisk.so.1",
+				"so:libkmod.so.2",
+				"so:liblzma.so.5",
 				"so:libm.so.6",
 				"so:libmount.so.1",
 				"so:libssl.so.3",
 				"so:libudev.so.1",
+				"so:libzstd.so.1",
 			},
 			Provides: []string{
 				"cmd:bootctl=256.2-r1",
@@ -216,6 +219,24 @@ func TestAnalyze(t *testing.T) {
 				"so:libsystemd-core-256.so=0",
 				"so:libsystemd-shared-256.so=0",
 			},
+		},
+	}, {
+		apk:     "libsystemd-256.2-r1.apk",
+		cfgpath: "systemd.yaml",
+		want: config.Dependencies{
+			Runtime: []string{
+				"so:ld-linux-x86-64.so.2",
+				"so:libc.so.6",
+				"so:libcap.so.2",
+				"so:liblzma.so.5",
+				"so:libsystemd.so.0",
+				"so:libzstd.so.1",
+			},
+			Provides: []string{
+				"so-ver:libsystemd.so.0=256.2-r1",
+				"so:libsystemd.so.0=0",
+			},
+			Vendored: nil,
 		},
 	}} {
 		t.Run(c.apk, func(t *testing.T) {

--- a/pkg/sca/sca.go
+++ b/pkg/sca/sca.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"debug/buildinfo"
 	"debug/elf"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -36,6 +37,7 @@ import (
 	"github.com/chainguard-dev/go-pkgconfig"
 
 	"chainguard.dev/melange/pkg/config"
+	"chainguard.dev/melange/pkg/util"
 )
 
 // LibDirs is the list of library directories to search for shared objects.
@@ -733,6 +735,143 @@ func generateSharedObjectNameDeps(ctx context.Context, hdl SCAHandle, generated 
 	return nil
 }
 
+type DlopenJSON struct {
+	SOname      []string
+	Feature     string
+	Description string
+	Priority    string
+}
+
+// Find the dlopen dependencies specified in the ELF notes and return
+// a string array listing all of them.
+func findDlopenDeps(ctx context.Context, hdl SCAHandle, bin *elf.File, path string) ([]string, error) {
+	log := clog.FromContext(ctx)
+
+	deps := []string{}
+
+	for _, section := range bin.Sections {
+		if section.Type != elf.SHT_NOTE {
+			continue
+		}
+		if section.Name != ".note.dlopen" {
+			continue
+		}
+
+		notes, err := util.ReadElfNotes(section, bin.ByteOrder)
+		if err != nil {
+			return nil, err
+		}
+
+		pkgResolver := hdl.PkgResolver()
+		if pkgResolver == nil {
+			log.Debugf("Package resolver is nil; not checking if dlopen dependency exists")
+		}
+
+		for _, note := range notes {
+			var jsonNotes []util.DlopenDependency
+
+			err := json.Unmarshal([]byte(note.Description), &jsonNotes)
+			if err != nil {
+				log.Warnf("could not parse JSON note for %s; ignoring dlopen dependencies for the file", path)
+				continue
+			}
+
+			for _, dlopenNote := range jsonNotes {
+				// According to the spec, if there are
+				// multiple sonames specified then the
+				// implementation should use the first
+				// one that is available on the system.
+				//
+				// We don't take into account the
+				// priority, but perhaps we should.
+				if pkgResolver == nil {
+					// We can't check if the
+					// dependency exists.  Just
+					// use the first one.
+					if len(dlopenNote.SOname) > 0 {
+						deps = append(deps, dlopenNote.SOname[0])
+					}
+					continue
+				}
+
+				// Check if the dependency exists in stereo.
+				for _, dep := range dlopenNote.SOname {
+					candidates, err := pkgResolver.ResolvePackage("so:"+dep, map[*apk.RepositoryPackage]string{})
+					if err == nil && len(candidates) > 0 {
+						deps = append(deps, dep)
+						break
+					} else {
+						log.Debugf("found dlopen dependency %s for %s but no package provides it", dep, path)
+					}
+				}
+			}
+		}
+	}
+
+	return deps, nil
+}
+
+func generateDlopenDeps(ctx context.Context, hdl SCAHandle, generated *config.Dependencies, extraLibDirs []string) error {
+	log := clog.FromContext(ctx)
+	log.Infof("scanning for dlopen dependencies...")
+
+	fsys, err := hdl.Filesystem()
+	if err != nil {
+		return err
+	}
+
+	if err := fs.WalkDir(fsys, ".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		fi, err := d.Info()
+		if err != nil {
+			return err
+		}
+
+		mode := fi.Mode()
+
+		if !mode.IsRegular() {
+			return nil
+		}
+
+		rawFile, err := fsys.Open(path)
+		if err != nil {
+			return nil
+		}
+		defer rawFile.Close()
+
+		seekableFile, ok := rawFile.(io.ReaderAt)
+		if !ok {
+			return nil
+		}
+
+		elfFile, err := elf.NewFile(seekableFile)
+		if err != nil {
+			return nil
+		}
+		defer elfFile.Close()
+
+		dlopenDeps, err := findDlopenDeps(ctx, hdl, elfFile, path)
+		if err != nil {
+			return err
+		}
+
+		for _, dep := range dlopenDeps {
+			log.Infof("  found dlopen dependency %s for %s", dep, path)
+
+			generated.Runtime = append(generated.Runtime, "so:"+dep)
+		}
+
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // TODO(xnox): Note remove this feature flag, once successful
 // note this can generate depends on pc: files that do not exist in
 // wolfi, however package install tests will catch that in presubmit
@@ -1184,6 +1323,7 @@ func Analyze(ctx context.Context, hdl SCAHandle, generated *config.Dependencies)
 		generateSharedObjectNameDeps,
 		generateCmdProviders,
 		generateDocDeps,
+		generateDlopenDeps,
 		generatePkgConfigDeps,
 		generatePerlDeps,
 		generatePythonDeps,

--- a/pkg/util/elfutils.go
+++ b/pkg/util/elfutils.go
@@ -1,0 +1,163 @@
+// Copyright 2026 Chainguard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Utilities to read and manipulate ELF files.
+
+package util
+
+import (
+	"bytes"
+	"debug/elf"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
+// align4 computes the padding size for a 4-byte aligned field of size
+// N.
+func align4(n uint32) uint32 {
+	return (n + 3) &^ 3
+}
+
+// Representation of the contents of a note inside an ELF note
+// section.
+//
+// A section may contain multiple notes, each one laid out in the
+// following format:
+//
+//	+----------+ <-----+
+//	|  namesz  |       |
+//	+----------+       |
+//	|  descsz  |       |  Header
+//	+----------+       |
+//	|   type   |       |
+//	+----------+ <-----+
+//	|   name   |
+//	+----------+
+//	|   type   |
+//	+----------+
+//
+// We don't store "namesz" nor "descsz" in this struct.
+type ELFNote struct {
+	Name        string
+	Type        uint32
+	Description string
+}
+
+// Read the contents of the note(s) inside an ELF section.
+func ReadElfNotes(section *elf.Section, byteOrder binary.ByteOrder) ([]ELFNote, error) {
+	if section.Type != elf.SHT_NOTE {
+		return nil, fmt.Errorf("invalid ELF section type")
+	}
+
+	data, err := section.Data()
+	if err != nil {
+		return nil, err
+	}
+
+	reader := bytes.NewReader(data)
+
+	notes := []ELFNote{}
+
+	for reader.Len() > 0 {
+		// Read the note header.  It's composed of the name
+		// size, description size and note type.
+		var namesz, descsz, noteType uint32
+
+		if err := binary.Read(reader, byteOrder, &namesz); err != nil {
+			return nil, err
+		}
+		if int(namesz) > reader.Len() || namesz > 256 {
+			return nil, fmt.Errorf("namesz is too big on section %s", section.Name)
+		}
+
+		if err := binary.Read(reader, byteOrder, &descsz); err != nil {
+			return nil, err
+		}
+		if int(descsz) > reader.Len() || descsz > 8192 {
+			return nil, fmt.Errorf("descsz is too big on section %s", section.Name)
+		}
+
+		if err := binary.Read(reader, byteOrder, &noteType); err != nil {
+			return nil, err
+		}
+
+		// Read the note name.
+		name := make([]byte, namesz)
+		_, err := reader.Read(name)
+		if err != nil {
+			return nil, err
+		}
+		// The note name is 4-byte aligned, so we have to
+		// calculate the padding size and skip it.
+		if _, err := reader.Seek(int64(align4(namesz)-namesz), io.SeekCurrent); err != nil {
+			return nil, err
+		}
+
+		// Read the note description.
+		desc := make([]byte, descsz)
+		_, err = reader.Read(desc)
+		if err != nil {
+			return nil, err
+		}
+		// The note description is 4-byte aligned, so we have
+		// to calculate the padding size and skip it.
+		if _, err := reader.Seek(int64(align4(descsz)-descsz), io.SeekCurrent); err != nil {
+			return nil, err
+		}
+
+		notes = append(notes, ELFNote{
+			Name:        string(bytes.TrimRight(name, "\x00")),
+			Type:        noteType,
+			Description: string(bytes.TrimRight(desc, "\x00")),
+		})
+	}
+
+	return notes, nil
+}
+
+// Representation of a dlopen dependency as seen in the JSON contents
+// inside the note description.
+//
+// See https://uapi-group.org/specifications/specs/elf_dlopen_metadata/
+// for the official specification of the format.
+type DlopenDependency struct {
+	SOname      []string `json:"soname"`
+	Feature     string   `json:"feature,omitempty"`
+	Description string   `json:"description,omitempty"`
+	Priority    string   `json:"priority,omitempty"`
+}
+
+// Implementation of the UnmarshallJSON interface for a
+// DlopenDependency.
+func (d *DlopenDependency) UnmarshallJSON(data []byte) error {
+	// Doing some type aliasing trick to avoid infinite recursion.
+	type DlopenAlias DlopenDependency
+	rawData := &struct {
+		*DlopenAlias
+	}{
+		DlopenAlias: (*DlopenAlias)(d),
+	}
+
+	if err := json.Unmarshal(data, &rawData); err != nil {
+		return err
+	}
+
+	if rawData.Priority == "" {
+		d.Priority = "recommended"
+	}
+
+	return nil
+}


### PR DESCRIPTION
The systemd upstream project created a new ELF note format to represent dependencies to shared objects that are dlopen'ed by a binary.  This has always been a source of problems for distros, who often needed manually detect these dlopen calls and explicitly add the runtime dependencies to their packages instead of relying on the contents of DT_NEEDED.

Debian and Fedora have already implemented support for this feature on their build systems.  As of this writing systemd seems to be the only project that generates these notes, but this will hopefully change now that it's become a UAPI spec[1].

[1]: https://uapi-group.org/specifications/specs/elf_dlopen_metadata/