### PR TITLE
feat(pipelines): add reason fields to fetch and git-checkout

### DIFF
--- a/e2e-tests/git-checkout-build.yaml
+++ b/e2e-tests/git-checkout-build.yaml
@@ -126,6 +126,7 @@ pipeline:
     with:
       repository: ${{vars.giturl}}
       branch: 1.x
+      reason: testing mutable git-checkout reference
 
   - name: "check branch without expected"
     working-directory: branch-no-expected

--- a/pkg/build/pipelines/README.md
+++ b/pkg/build/pipelines/README.md
@@ -30,6 +30,7 @@ Fetch and extract external object into workspace
 | extract | false | Whether to extract the downloaded artifact as a source tarball.  | true |
 | purl-name | false | package-URL (PURL) name for use in SPDX SBOM External References  | ${{package.name}} |
 | purl-version | false | package-URL (PURL) version for use in SPDX SBOM External References  | ${{package.version}} |
+| reason | false | Provide reason why fetch is used, instead of git-checkout  |  |
 | retry-limit | false | The number of times to retry fetching before failing.  | 5 |
 | strip-components | false | The number of path components to strip while extracting.  | 1 |
 | timeout | false | The timeout (in seconds) to use for connecting and reading. The fetch will fail if the timeout is hit.  | 5 |
@@ -61,6 +62,7 @@ Check out sources from git
 | initial-backoff | false | Initial backoff duration in seconds before first retry.  | 2 |
 | max-backoff | false | Maximum backoff duration in seconds between retries.  | 60 |
 | max-retries | false | Maximum number of retry attempts for git clone operation on failure.  | 3 |
+| reason | false | Provide reason for a mutable reference.  |  |
 | recurse-submodules | false | Indicates whether --recurse-submodules should be passed to git clone.  | false |
 | repository | true | The repository to check out sources from.  |  |
 | shallow-submodules | false | Whether to use --shallow-submodules when recurse-submodules is true. Ignored if recurse-submodules is false.  | false |

--- a/pkg/build/pipelines/fetch.yaml
+++ b/pkg/build/pipelines/fetch.yaml
@@ -69,6 +69,10 @@ inputs:
       Whether to delete the fetched artifact after unpacking.
     default: false
 
+  reason:
+    description: |
+      Provide reason why fetch is used, instead of git-checkout
+
 pipeline:
   - runs: |
       if [ "${{inputs.expected-sha256}}" == "" ] && [ "${{inputs.expected-sha512}}" == "" ] && [ "${{inputs.expected-none}}" == "" ]; then

--- a/pkg/build/pipelines/git-checkout.yaml
+++ b/pkg/build/pipelines/git-checkout.yaml
@@ -89,6 +89,9 @@ inputs:
     description: |
       Maximum backoff duration in seconds between retries.
     default: "60"
+  reason:
+    description: |
+      Provide reason for a mutable reference.
 
 pipeline:
   - runs: |

--- a/pkg/source/testdata/fetch.yaml
+++ b/pkg/source/testdata/fetch.yaml
@@ -21,5 +21,6 @@ pipeline:
   - uses: fetch
     with:
       uri: https://unofficial-builds.nodejs.org/download/release/v22.9.0/node-v22.9.0-linux-x64-glibc-217.tar.gz
+      reason: this is a test of the fetch pipeline
 
   - runs: echo "steps after"


### PR DESCRIPTION
When fetch is used, or when git-checkout is used with a mutable
reference, it can be helpful to have a field to document why it is
used. For example to document that there is no git repository for a
given package, or that immutable reference is established externally.

After this lands linting can be added to flag up undocumented usage of
fetch or mutable usage of git-checkout.
