### PR TITLE
feat(qemu): add DNS search domains

### DIFF
--- a/pkg/container/qemu_runner.go
+++ b/pkg/container/qemu_runner.go
@@ -755,7 +755,18 @@ func createMicroVM(ctx context.Context, cfg *Config) error {
 	baseargs = append(baseargs, "-nodefaults")
 	baseargs = append(baseargs, serialArgs...)
 	// use -netdev + -device instead of -nic, as this is better supported by microvm machine type
-	baseargs = append(baseargs, "-netdev", "user,id=id1,hostfwd=tcp:"+cfg.SSHAddress+"-:22,hostfwd=tcp:"+cfg.SSHControlAddress+"-:2223")
+	netdevArgs := "user,id=id1,hostfwd=tcp:" + cfg.SSHAddress + "-:22,hostfwd=tcp:" + cfg.SSHControlAddress + "-:2223"
+	// QEMU_DNS_SEARCH allows configuring DNS search domains inside the guest VM.
+	// This is useful for builds that need to resolve short hostnames via search
+	// domains, or when the build environment requires specific DNS resolution
+	// behavior. The search domain is passed to SLIRP which includes it in DHCP
+	// responses, so the guest receives it naturally via DHCP.
+	// Example: QEMU_DNS_SEARCH=example.com
+	if dnsSearch, ok := os.LookupEnv("QEMU_DNS_SEARCH"); ok {
+		log.Infof("qemu: QEMU_DNS_SEARCH set to %s, adding to SLIRP network config", dnsSearch)
+		netdevArgs += ",dnssearch=" + dnsSearch
+	}
+	baseargs = append(baseargs, "-netdev", netdevArgs)
 	// Set host_mtu to avoid silent packet drops in nested environments (e.g.,
 	// QEMU inside GKE pods). SLIRP defaults to 1500 MTU but the host path MTU
 	// may be lower due to encapsulation (GCP VPC uses 1460, pod networks can be
@@ -787,12 +798,6 @@ func createMicroVM(ctx context.Context, cfg *Config) error {
 		} else {
 			log.Warnf("qemu: TESTING env must be a number, ignoring invalid value: %s", testingValue)
 		}
-	}
-
-	// Support configurable DNS search domains inside the QEMU VM.
-	if dnsSearch, ok := os.LookupEnv("QEMU_DNS_SEARCH"); ok {
-		log.Infof("qemu: QEMU_DNS_SEARCH set to %s, passing to guest via kernel cmdline", dnsSearch)
-		kernelArgs += " dns_search=" + dnsSearch
 	}
 
 	baseargs = append(baseargs, "-append", kernelArgs)

--- a/pkg/container/qemu_runner.go
+++ b/pkg/container/qemu_runner.go
@@ -2330,7 +2330,7 @@ func parseDNSSearchDomains(input string) []string {
 	// Split on comma or whitespace
 	parts := dnsSearchDelimiterRegex.Split(input, -1)
 
-	var domains []string
+	domains := make([]string, 0, len(parts))
 	for _, part := range parts {
 		part = strings.TrimSpace(part)
 		if part == "" {

--- a/pkg/container/qemu_runner.go
+++ b/pkg/container/qemu_runner.go
@@ -759,12 +759,19 @@ func createMicroVM(ctx context.Context, cfg *Config) error {
 	// QEMU_DNS_SEARCH allows configuring DNS search domains inside the guest VM.
 	// This is useful for builds that need to resolve short hostnames via search
 	// domains, or when the build environment requires specific DNS resolution
-	// behavior. The search domain is passed to SLIRP which includes it in DHCP
-	// responses, so the guest receives it naturally via DHCP.
-	// Example: QEMU_DNS_SEARCH=example.com
+	// behavior. The search domains are passed to SLIRP which includes them in DHCP
+	// responses, so the guest receives them naturally via DHCP.
+	// Supports multiple domains: comma or space separated.
+	// Example: QEMU_DNS_SEARCH="example.com my.domain.org"
+	// Example: QEMU_DNS_SEARCH="example.com,my.domain.org"
 	if dnsSearch, ok := os.LookupEnv("QEMU_DNS_SEARCH"); ok {
-		log.Infof("qemu: QEMU_DNS_SEARCH set to %s, adding to SLIRP network config", dnsSearch)
-		netdevArgs += ",dnssearch=" + dnsSearch
+		domains := parseDNSSearchDomains(dnsSearch)
+		if len(domains) > 0 {
+			log.Infof("qemu: QEMU_DNS_SEARCH set to %v, adding %d domains to SLIRP network config", domains, len(domains))
+			netdevArgs += buildDNSSearchNetdevArgs(domains)
+		} else {
+			log.Warnf("qemu: QEMU_DNS_SEARCH contains invalid characters or is empty, ignoring: %s", dnsSearch)
+		}
 	}
 	baseargs = append(baseargs, "-netdev", netdevArgs)
 	// Set host_mtu to avoid silent packet drops in nested environments (e.g.,
@@ -2297,6 +2304,69 @@ func getAdditionalPackages(ctx context.Context) []string {
 	}
 
 	return packages
+}
+
+// dnsSearchDomainRegex matches valid DNS search domain characters.
+// Only allows alphanumeric characters, dots, and hyphens.
+// This prevents injection of QEMU netdev options via malicious domain names.
+var (
+	// dnsSearchDomainRegex matches valid DNS search domain characters.
+	// Only allows alphanumeric characters, dots, and hyphens.
+	// This prevents injection of QEMU netdev options via malicious domain names.
+	dnsSearchDomainRegex = regexp.MustCompile(`^[a-zA-Z0-9.-]+$`)
+	// dnsSearchDelimiterRegex splits on comma or whitespace (space, tab, newline).
+	dnsSearchDelimiterRegex = regexp.MustCompile(`[,\s]+`)
+)
+
+// parseDNSSearchDomains parses and validates DNS search domains from a string.
+// Input can be comma or space delimited (or both).
+// Returns nil if any domain is invalid (fail-safe).
+func parseDNSSearchDomains(input string) []string {
+	input = strings.TrimSpace(input)
+	if input == "" {
+		return nil
+	}
+
+	// Split on comma or whitespace
+	parts := dnsSearchDelimiterRegex.Split(input, -1)
+
+	var domains []string
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+
+		// Validate domain: only allow [a-zA-Z0-9.-]
+		if !dnsSearchDomainRegex.MatchString(part) {
+			// Invalid character found - reject entire input for security
+			return nil
+		}
+
+		domains = append(domains, part)
+	}
+
+	if len(domains) == 0 {
+		return nil
+	}
+
+	return domains
+}
+
+// buildDNSSearchNetdevArgs constructs the QEMU netdev dnssearch options string.
+// Returns empty string if no domains provided.
+// Each domain produces a separate ",dnssearch=<domain>" option.
+func buildDNSSearchNetdevArgs(domains []string) string {
+	if len(domains) == 0 {
+		return ""
+	}
+
+	var builder strings.Builder
+	for _, domain := range domains {
+		builder.WriteString(",dnssearch=")
+		builder.WriteString(domain)
+	}
+	return builder.String()
 }
 
 // getPackageCacheSuffix generates a deterministic cache suffix based on the package list.

--- a/pkg/container/qemu_runner.go
+++ b/pkg/container/qemu_runner.go
@@ -761,17 +761,15 @@ func createMicroVM(ctx context.Context, cfg *Config) error {
 	// domains, or when the build environment requires specific DNS resolution
 	// behavior. The search domains are passed to SLIRP which includes them in DHCP
 	// responses, so the guest receives them naturally via DHCP.
-	// Supports multiple domains: comma or space separated.
-	// Example: QEMU_DNS_SEARCH="example.com my.domain.org"
+	// Multiple domains should be comma-separated.
 	// Example: QEMU_DNS_SEARCH="example.com,my.domain.org"
 	if dnsSearch, ok := os.LookupEnv("QEMU_DNS_SEARCH"); ok {
-		domains := parseDNSSearchDomains(dnsSearch)
-		if len(domains) > 0 {
-			log.Infof("qemu: QEMU_DNS_SEARCH set to %v, adding %d domains to SLIRP network config", domains, len(domains))
-			netdevArgs += buildDNSSearchNetdevArgs(domains)
-		} else {
-			log.Warnf("qemu: QEMU_DNS_SEARCH contains invalid characters or is empty, ignoring: %s", dnsSearch)
+		domains, err := parseDNSSearchDomains(dnsSearch)
+		if err != nil {
+			return fmt.Errorf("invalid QEMU_DNS_SEARCH value %q: %w", dnsSearch, err)
 		}
+		log.Infof("qemu: QEMU_DNS_SEARCH set to %v, adding %d domain(s) to SLIRP network config", domains, len(domains))
+		netdevArgs += buildDNSSearchNetdevArgs(domains)
 	}
 	baseargs = append(baseargs, "-netdev", netdevArgs)
 	// Set host_mtu to avoid silent packet drops in nested environments (e.g.,
@@ -2314,21 +2312,18 @@ var (
 	// Only allows alphanumeric characters, dots, and hyphens.
 	// This prevents injection of QEMU netdev options via malicious domain names.
 	dnsSearchDomainRegex = regexp.MustCompile(`^[a-zA-Z0-9.-]+$`)
-	// dnsSearchDelimiterRegex splits on comma or whitespace (space, tab, newline).
-	dnsSearchDelimiterRegex = regexp.MustCompile(`[,\s]+`)
 )
 
-// parseDNSSearchDomains parses and validates DNS search domains from a string.
-// Input can be comma or space delimited (or both).
-// Returns nil if any domain is invalid (fail-safe).
-func parseDNSSearchDomains(input string) []string {
+// parseDNSSearchDomains parses and validates DNS search domains from a comma-separated string.
+// Returns an error if the input is empty or contains invalid domain characters.
+func parseDNSSearchDomains(input string) ([]string, error) {
 	input = strings.TrimSpace(input)
 	if input == "" {
-		return nil
+		return nil, fmt.Errorf("empty input")
 	}
 
-	// Split on comma or whitespace
-	parts := dnsSearchDelimiterRegex.Split(input, -1)
+	// Only split on commas
+	parts := strings.Split(input, ",")
 
 	domains := make([]string, 0, len(parts))
 	for _, part := range parts {
@@ -2339,18 +2334,17 @@ func parseDNSSearchDomains(input string) []string {
 
 		// Validate domain: only allow [a-zA-Z0-9.-]
 		if !dnsSearchDomainRegex.MatchString(part) {
-			// Invalid character found - reject entire input for security
-			return nil
+			return nil, fmt.Errorf("invalid characters in domain %q: only alphanumeric, dots, and hyphens are allowed", part)
 		}
 
 		domains = append(domains, part)
 	}
 
 	if len(domains) == 0 {
-		return nil
+		return nil, fmt.Errorf("no valid domains found")
 	}
 
-	return domains
+	return domains, nil
 }
 
 // buildDNSSearchNetdevArgs constructs the QEMU netdev dnssearch options string.

--- a/pkg/container/qemu_runner.go
+++ b/pkg/container/qemu_runner.go
@@ -789,6 +789,12 @@ func createMicroVM(ctx context.Context, cfg *Config) error {
 		}
 	}
 
+	// Support configurable DNS search domains inside the QEMU VM.
+	if dnsSearch, ok := os.LookupEnv("QEMU_DNS_SEARCH"); ok {
+		log.Infof("qemu: QEMU_DNS_SEARCH set to %s, passing to guest via kernel cmdline", dnsSearch)
+		kernelArgs += " dns_search=" + dnsSearch
+	}
+
 	baseargs = append(baseargs, "-append", kernelArgs)
 	// we will *not* mount workspace using qemu, this will use 9pfs which is network-based, and will
 	// kill all performances (lots of small files)

--- a/pkg/container/qemu_runner_test.go
+++ b/pkg/container/qemu_runner_test.go
@@ -231,6 +231,254 @@ func TestGetAdditionalPackages(t *testing.T) {
 	}
 }
 
+func TestParseDNSSearchDomains(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []string
+	}{
+		// Valid single domain
+		{
+			name:     "single valid domain",
+			input:    "example.com",
+			expected: []string{"example.com"},
+		},
+		// Valid multiple domains - comma separated
+		{
+			name:     "comma separated domains",
+			input:    "example.com,test.org",
+			expected: []string{"example.com", "test.org"},
+		},
+		// Valid multiple domains - space separated
+		{
+			name:     "space separated domains",
+			input:    "example.com test.org",
+			expected: []string{"example.com", "test.org"},
+		},
+		// Mixed delimiters
+		{
+			name:     "mixed comma and space delimiters",
+			input:    "a.com,b.org c.net",
+			expected: []string{"a.com", "b.org", "c.net"},
+		},
+		// Multiple spaces/commas collapsed
+		{
+			name:     "multiple delimiters collapsed",
+			input:    "a.com,,b.org  c.net",
+			expected: []string{"a.com", "b.org", "c.net"},
+		},
+		// Hyphenated domain
+		{
+			name:     "hyphenated domain",
+			input:    "my-domain.example.com",
+			expected: []string{"my-domain.example.com"},
+		},
+		// Nested subdomains
+		{
+			name:     "nested subdomains",
+			input:    "a.b.c.d.example.com",
+			expected: []string{"a.b.c.d.example.com"},
+		},
+		// Numeric domain parts
+		{
+			name:     "numeric domain parts",
+			input:    "123.example.com",
+			expected: []string{"123.example.com"},
+		},
+		// Empty input
+		{
+			name:     "empty string",
+			input:    "",
+			expected: nil,
+		},
+		// Only whitespace
+		{
+			name:     "only whitespace",
+			input:    "   ",
+			expected: nil,
+		},
+		// Only commas
+		{
+			name:     "only commas",
+			input:    ",,,",
+			expected: nil,
+		},
+		// Injection with equals sign (netdev option injection)
+		{
+			name:     "injection attempt with equals",
+			input:    "evil=value",
+			expected: nil,
+		},
+		// Injection with hostfwd attempt
+		{
+			name:     "hostfwd injection attempt",
+			input:    "foo,hostfwd=tcp::8080-:22",
+			expected: nil,
+		},
+		// Injection with colon
+		{
+			name:     "colon injection (port-like)",
+			input:    "domain:8080",
+			expected: nil,
+		},
+		// Semicolon injection (command separator)
+		{
+			name:     "semicolon injection",
+			input:    "foo;rm -rf /",
+			expected: nil,
+		},
+		// Pipe injection
+		{
+			name:     "pipe injection",
+			input:    "foo|cat /etc/passwd",
+			expected: nil,
+		},
+		// Backtick injection
+		{
+			name:     "backtick injection",
+			input:    "foo`whoami`",
+			expected: nil,
+		},
+		// Dollar sign injection
+		{
+			name:     "dollar sign injection",
+			input:    "foo$HOME",
+			expected: nil,
+		},
+		// Quote injection
+		{
+			name:     "double quote injection",
+			input:    `foo"bar`,
+			expected: nil,
+		},
+		// Single quote injection
+		{
+			name:     "single quote injection",
+			input:    "foo'bar",
+			expected: nil,
+		},
+		// Ampersand injection
+		{
+			name:     "ampersand injection",
+			input:    "foo&bar",
+			expected: nil,
+		},
+		// Parentheses injection
+		{
+			name:     "parentheses injection",
+			input:    "foo(bar)",
+			expected: nil,
+		},
+		// Bracket injection
+		{
+			name:     "bracket injection",
+			input:    "foo[bar]",
+			expected: nil,
+		},
+		// Brace injection
+		{
+			name:     "brace injection",
+			input:    "foo{bar}",
+			expected: nil,
+		},
+		// Angle bracket injection
+		{
+			name:     "angle bracket injection",
+			input:    "foo<bar>",
+			expected: nil,
+		},
+		// Backslash injection
+		{
+			name:     "backslash injection",
+			input:    "foo\\bar",
+			expected: nil,
+		},
+		// Forward slash (path-like)
+		{
+			name:     "forward slash injection",
+			input:    "foo/bar",
+			expected: nil,
+		},
+		// Newline as delimiter (treated like space)
+		{
+			name:     "newline as delimiter",
+			input:    "foo\nbar",
+			expected: []string{"foo", "bar"},
+		},
+		// Tab as delimiter (treated like space)
+		{
+			name:     "tab as delimiter",
+			input:    "foo\tbar",
+			expected: []string{"foo", "bar"},
+		},
+		// One valid, one invalid domain
+		{
+			name:     "mixed valid and invalid domains",
+			input:    "good.com,evil=bad",
+			expected: nil,
+		},
+		// QEMU dnssearch option injection attempt
+		{
+			name:     "dnssearch option injection",
+			input:    "foo,dnssearch=evil.com",
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := parseDNSSearchDomains(tt.input)
+
+			if len(result) != len(tt.expected) {
+				t.Errorf("parseDNSSearchDomains(%q) returned %d domains, expected %d: got %v, want %v",
+					tt.input, len(result), len(tt.expected), result, tt.expected)
+				return
+			}
+
+			for i, domain := range result {
+				if domain != tt.expected[i] {
+					t.Errorf("parseDNSSearchDomains(%q)[%d] = %q, expected %q",
+						tt.input, i, domain, tt.expected[i])
+				}
+			}
+		})
+	}
+}
+
+func TestBuildDNSSearchNetdevArgs(t *testing.T) {
+	tests := []struct {
+		name     string
+		domains  []string
+		expected string
+	}{
+		{
+			name:     "empty domains",
+			domains:  nil,
+			expected: "",
+		},
+		{
+			name:     "single domain",
+			domains:  []string{"example.com"},
+			expected: ",dnssearch=example.com",
+		},
+		{
+			name:     "multiple domains",
+			domains:  []string{"a.com", "b.org", "c.net"},
+			expected: ",dnssearch=a.com,dnssearch=b.org,dnssearch=c.net",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := buildDNSSearchNetdevArgs(tt.domains)
+			if result != tt.expected {
+				t.Errorf("buildDNSSearchNetdevArgs(%v) = %q, expected %q",
+					tt.domains, result, tt.expected)
+			}
+		})
+	}
+}
+
 func TestGetPackageCacheSuffix(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/pkg/container/qemu_runner_test.go
+++ b/pkg/container/qemu_runner_test.go
@@ -236,6 +236,7 @@ func TestParseDNSSearchDomains(t *testing.T) {
 		name     string
 		input    string
 		expected []string
+		wantErr  bool
 	}{
 		// Valid single domain
 		{
@@ -249,22 +250,16 @@ func TestParseDNSSearchDomains(t *testing.T) {
 			input:    "example.com,test.org",
 			expected: []string{"example.com", "test.org"},
 		},
-		// Valid multiple domains - space separated
+		// Multiple commas collapsed
 		{
-			name:     "space separated domains",
-			input:    "example.com test.org",
-			expected: []string{"example.com", "test.org"},
+			name:     "multiple commas collapsed",
+			input:    "a.com,,b.org",
+			expected: []string{"a.com", "b.org"},
 		},
-		// Mixed delimiters
+		// Comma with spaces around domains (trimmed)
 		{
-			name:     "mixed comma and space delimiters",
-			input:    "a.com,b.org c.net",
-			expected: []string{"a.com", "b.org", "c.net"},
-		},
-		// Multiple spaces/commas collapsed
-		{
-			name:     "multiple delimiters collapsed",
-			input:    "a.com,,b.org  c.net",
+			name:     "comma with spaces trimmed",
+			input:    "a.com, b.org , c.net",
 			expected: []string{"a.com", "b.org", "c.net"},
 		},
 		// Hyphenated domain
@@ -287,147 +282,165 @@ func TestParseDNSSearchDomains(t *testing.T) {
 		},
 		// Empty input
 		{
-			name:     "empty string",
-			input:    "",
-			expected: nil,
+			name:    "empty string",
+			input:   "",
+			wantErr: true,
 		},
 		// Only whitespace
 		{
-			name:     "only whitespace",
-			input:    "   ",
-			expected: nil,
+			name:    "only whitespace",
+			input:   "   ",
+			wantErr: true,
 		},
 		// Only commas
 		{
-			name:     "only commas",
-			input:    ",,,",
-			expected: nil,
+			name:    "only commas",
+			input:   ",,,",
+			wantErr: true,
+		},
+		// Space-separated domains (not allowed)
+		{
+			name:    "space separated domains rejected",
+			input:   "example.com test.org",
+			wantErr: true,
+		},
+		// Newline in domain (not allowed)
+		{
+			name:    "newline rejected",
+			input:   "foo\nbar",
+			wantErr: true,
+		},
+		// Tab in domain (not allowed)
+		{
+			name:    "tab rejected",
+			input:   "foo\tbar",
+			wantErr: true,
 		},
 		// Injection with equals sign (netdev option injection)
 		{
-			name:     "injection attempt with equals",
-			input:    "evil=value",
-			expected: nil,
+			name:    "injection attempt with equals",
+			input:   "evil=value",
+			wantErr: true,
 		},
 		// Injection with hostfwd attempt
 		{
-			name:     "hostfwd injection attempt",
-			input:    "foo,hostfwd=tcp::8080-:22",
-			expected: nil,
+			name:    "hostfwd injection attempt",
+			input:   "foo,hostfwd=tcp::8080-:22",
+			wantErr: true,
 		},
 		// Injection with colon
 		{
-			name:     "colon injection (port-like)",
-			input:    "domain:8080",
-			expected: nil,
+			name:    "colon injection (port-like)",
+			input:   "domain:8080",
+			wantErr: true,
 		},
 		// Semicolon injection (command separator)
 		{
-			name:     "semicolon injection",
-			input:    "foo;rm -rf /",
-			expected: nil,
+			name:    "semicolon injection",
+			input:   "foo;rm -rf /",
+			wantErr: true,
 		},
 		// Pipe injection
 		{
-			name:     "pipe injection",
-			input:    "foo|cat /etc/passwd",
-			expected: nil,
+			name:    "pipe injection",
+			input:   "foo|cat /etc/passwd",
+			wantErr: true,
 		},
 		// Backtick injection
 		{
-			name:     "backtick injection",
-			input:    "foo`whoami`",
-			expected: nil,
+			name:    "backtick injection",
+			input:   "foo`whoami`",
+			wantErr: true,
 		},
 		// Dollar sign injection
 		{
-			name:     "dollar sign injection",
-			input:    "foo$HOME",
-			expected: nil,
+			name:    "dollar sign injection",
+			input:   "foo$HOME",
+			wantErr: true,
 		},
 		// Quote injection
 		{
-			name:     "double quote injection",
-			input:    `foo"bar`,
-			expected: nil,
+			name:    "double quote injection",
+			input:   `foo"bar`,
+			wantErr: true,
 		},
 		// Single quote injection
 		{
-			name:     "single quote injection",
-			input:    "foo'bar",
-			expected: nil,
+			name:    "single quote injection",
+			input:   "foo'bar",
+			wantErr: true,
 		},
 		// Ampersand injection
 		{
-			name:     "ampersand injection",
-			input:    "foo&bar",
-			expected: nil,
+			name:    "ampersand injection",
+			input:   "foo&bar",
+			wantErr: true,
 		},
 		// Parentheses injection
 		{
-			name:     "parentheses injection",
-			input:    "foo(bar)",
-			expected: nil,
+			name:    "parentheses injection",
+			input:   "foo(bar)",
+			wantErr: true,
 		},
 		// Bracket injection
 		{
-			name:     "bracket injection",
-			input:    "foo[bar]",
-			expected: nil,
+			name:    "bracket injection",
+			input:   "foo[bar]",
+			wantErr: true,
 		},
 		// Brace injection
 		{
-			name:     "brace injection",
-			input:    "foo{bar}",
-			expected: nil,
+			name:    "brace injection",
+			input:   "foo{bar}",
+			wantErr: true,
 		},
 		// Angle bracket injection
 		{
-			name:     "angle bracket injection",
-			input:    "foo<bar>",
-			expected: nil,
+			name:    "angle bracket injection",
+			input:   "foo<bar>",
+			wantErr: true,
 		},
 		// Backslash injection
 		{
-			name:     "backslash injection",
-			input:    "foo\\bar",
-			expected: nil,
+			name:    "backslash injection",
+			input:   "foo\\bar",
+			wantErr: true,
 		},
 		// Forward slash (path-like)
 		{
-			name:     "forward slash injection",
-			input:    "foo/bar",
-			expected: nil,
-		},
-		// Newline as delimiter (treated like space)
-		{
-			name:     "newline as delimiter",
-			input:    "foo\nbar",
-			expected: []string{"foo", "bar"},
-		},
-		// Tab as delimiter (treated like space)
-		{
-			name:     "tab as delimiter",
-			input:    "foo\tbar",
-			expected: []string{"foo", "bar"},
+			name:    "forward slash injection",
+			input:   "foo/bar",
+			wantErr: true,
 		},
 		// One valid, one invalid domain
 		{
-			name:     "mixed valid and invalid domains",
-			input:    "good.com,evil=bad",
-			expected: nil,
+			name:    "mixed valid and invalid domains",
+			input:   "good.com,evil=bad",
+			wantErr: true,
 		},
 		// QEMU dnssearch option injection attempt
 		{
-			name:     "dnssearch option injection",
-			input:    "foo,dnssearch=evil.com",
-			expected: nil,
+			name:    "dnssearch option injection",
+			input:   "foo,dnssearch=evil.com",
+			wantErr: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := parseDNSSearchDomains(tt.input)
+			result, err := parseDNSSearchDomains(tt.input)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("parseDNSSearchDomains(%q) expected error, got nil with result %v", tt.input, result)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("parseDNSSearchDomains(%q) unexpected %v", tt.input, err)
+				return
+			}
 
 			if len(result) != len(tt.expected) {
 				t.Errorf("parseDNSSearchDomains(%q) returned %d domains, expected %d: got %v, want %v",


### PR DESCRIPTION
There are certain cases where we need to set DNS search domains in a more configurable way.