### PR TITLE
fix(qemu): fix CPU/Memory resource precedence

### DIFF
--- a/pkg/build/build_test.go
+++ b/pkg/build/build_test.go
@@ -50,7 +50,7 @@ func TestConfiguration_Load(t *testing.T) {
 				Package: config.Package{
 					Name:      "hello",
 					Version:   "world",
-					Resources: &config.Resources{CPU: "2", Memory: "4Gi"},
+					Resources: &config.Resources{},
 				},
 				Pipeline: []config.Pipeline{
 					{
@@ -127,7 +127,7 @@ func TestConfiguration_Load(t *testing.T) {
 				Package: config.Package{
 					Name:      "cosign",
 					Version:   "2.0.0",
-					Resources: &config.Resources{CPU: "2", Memory: "4Gi"},
+					Resources: &config.Resources{},
 				},
 				Update: config.Update{
 					Enabled: true,
@@ -144,7 +144,7 @@ func TestConfiguration_Load(t *testing.T) {
 			name:       "release-monitor",
 			requireErr: require.NoError,
 			expected: &config.Configuration{
-				Package: config.Package{Name: "bison", Version: "3.8.2", Resources: &config.Resources{CPU: "2", Memory: "4Gi"}},
+				Package: config.Package{Name: "bison", Version: "3.8.2", Resources: &config.Resources{}},
 				Update: config.Update{
 					Enabled: true,
 					Shared:  false,
@@ -199,7 +199,7 @@ func TestConfiguration_Load(t *testing.T) {
 					Name:      "cosign",
 					Version:   "2.0.0",
 					Epoch:     0,
-					Resources: &config.Resources{CPU: "2", Memory: "4Gi"},
+					Resources: &config.Resources{},
 				},
 				Environment: apko_types.ImageConfiguration{
 					Environment: map[string]string{
@@ -282,7 +282,7 @@ package:
 		Package: config.Package{
 			Name:      "nginx",
 			Version:   "100",
-			Resources: &config.Resources{CPU: "2", Memory: "4Gi"},
+			Resources: &config.Resources{},
 		},
 		Subpackages: []config.Subpackage{},
 	}

--- a/pkg/build/test_test.go
+++ b/pkg/build/test_test.go
@@ -179,7 +179,7 @@ func TestConfigurationLoad(t *testing.T) {
 				Package: config.Package{
 					Name:      "hello",
 					Version:   "world",
-					Resources: &config.Resources{CPU: "2", Memory: "4Gi"},
+					Resources: &config.Resources{},
 				},
 				Test: &config.Test{
 					Environment: defaultEnv(),
@@ -291,7 +291,7 @@ func TestConfigurationLoad(t *testing.T) {
 				Package: config.Package{
 					Name:      "py3-pandas",
 					Version:   "2.1.3",
-					Resources: &config.Resources{CPU: "2", Memory: "4Gi"},
+					Resources: &config.Resources{},
 				},
 				Test: &config.Test{
 					Environment: defaultEnv(func(env *apko_types.ImageConfiguration) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1861,16 +1861,11 @@ func ParseConfiguration(ctx context.Context, configurationFilePath string, opts 
 		cfg.Package.Resources.Disk = options.disk
 	}
 
-	// Apply reasonable defaults for CPU and memory if still unset after YAML and CLI
-	// flag processing. Without these, the QEMU runner defaults to all host CPUs
-	// and 85% of host memory, causing resource contention when multiple builds
-	// share a node.
-	if cfg.Package.Resources.CPU == "" {
-		cfg.Package.Resources.CPU = "2"
-	}
-	if cfg.Package.Resources.Memory == "" {
-		cfg.Package.Resources.Memory = "4Gi"
-	}
+	// Host-exhaustion safeguards for CPU and memory live in the QEMU runner
+	// (see effectiveCPU / effectiveMemoryKB in pkg/container/qemu_runner.go),
+	// not here. Defaulting Package.Resources at parse time would clobber
+	// empty-value signals that downstream consumers rely on to decide when
+	// to apply their own, often larger, build-specific defaults.
 
 	// Finally, validate the configuration we ended up with before returning it for use downstream.
 	if err = cfg.validate(ctx); err != nil {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1504,8 +1504,8 @@ package:
     memory: 8Gi
 `,
 			expectResources: &Resources{
-				CPU:    "2",
-				Memory: "4Gi",
+				CPU:    "",
+				Memory: "",
 			},
 			expectTestResources: &Resources{
 				CPU:    "4",
@@ -1540,8 +1540,8 @@ package:
   epoch: 0
 `,
 			expectResources: &Resources{
-				CPU:    "2",
-				Memory: "4Gi",
+				CPU:    "",
+				Memory: "",
 			},
 			expectTestResources: nil,
 			expectParseError:    false,
@@ -1585,8 +1585,8 @@ package:
     memory: 8Gi
 `,
 			expectResources: &Resources{
-				CPU:    "2",
-				Memory: "4Gi",
+				CPU:    "",
+				Memory: "",
 			},
 			expectTestResources: &Resources{
 				CPU:      "4",

--- a/pkg/container/qemu_runner.go
+++ b/pkg/container/qemu_runner.go
@@ -712,18 +712,22 @@ func createMicroVM(ctx context.Context, cfg *Config) error {
 		return fmt.Errorf("unknown architecture: %s", cfg.Arch.ToAPK())
 	}
 
-	// default to use 85% of available memory, if a mem limit is set, respect it.
-	mem := int64(float64(getAvailableMemoryKB()) * 0.85)
+	// Memory: start from 85% of available memory (cgroup-aware via
+	// getAvailableMemoryKB), then apply precedence cfg.Memory > cgroup > fallback
+	// through effectiveMemoryKB. The fallback caps shared-runner VMs at 4 GiB
+	// when neither a user-supplied value nor a cgroup limit is present.
+	hostScaledKB := int64(float64(getAvailableMemoryKB()) * 0.85)
+	cgroupMemKB := int64(getCgroupMemoryLimitKB())
+	var cfgMemKB int64
 	if cfg.Memory != "" {
-		memKb, err := convertHumanToKB(cfg.Memory)
+		var err error
+		cfgMemKB, err = convertHumanToKB(cfg.Memory)
 		if err != nil {
 			return err
 		}
-
-		if mem > memKb {
-			mem = memKb
-		}
 	}
+	mem := effectiveMemoryKB(cfgMemKB, hostScaledKB, cgroupMemKB)
+
 	// Memory configuration - virtiofs requires shared memory backend
 	if cfg.VirtiofsEnabled {
 		// Round up memory to MiB boundary for memory-backend-memfd alignment
@@ -734,19 +738,20 @@ func createMicroVM(ctx context.Context, cfg *Config) error {
 		baseargs = append(baseargs, "-m", fmt.Sprintf("%dk", mem))
 	}
 
-	// default to use all CPUs, if a cgroup or config limit is set, respect it.
+	// CPU: apply precedence cfg.CPU > cgroup > fallback through effectiveCPU.
 	// In a container (e.g. Kubernetes pod), runtime.NumCPU() returns the host's
-	// total CPUs, not the pod's allocation. Check cgroup limits first.
-	nproc := runtime.NumCPU()
-	if cgroupCPU := getCgroupCPULimitCores(); cgroupCPU > 0 && cgroupCPU < nproc {
-		nproc = cgroupCPU
-	}
+	// total CPUs, not the pod's allocation; the cgroup check below covers that.
+	// The fallback caps shared-runner VMs at 2 vCPUs when neither a user-
+	// supplied value nor a cgroup limit is present.
+	hostCPU := runtime.NumCPU()
+	cgroupCPU := getCgroupCPULimitCores()
+	var cfgCPU int
 	if cfg.CPU != "" {
-		cpu, err := strconv.Atoi(cfg.CPU)
-		if err == nil && nproc > cpu {
-			nproc = cpu
+		if parsed, err := strconv.Atoi(cfg.CPU); err == nil && parsed > 0 {
+			cfgCPU = parsed
 		}
 	}
+	nproc := effectiveCPU(cfgCPU, cgroupCPU, hostCPU)
 	baseargs = append(baseargs, "-smp", fmt.Sprintf("%d,dies=1,sockets=1,cores=%d,threads=1", nproc, nproc))
 
 	// use kvm on linux, Hypervisor.framework on macOS, and software for cross-arch
@@ -1821,6 +1826,88 @@ func convertHumanToKB(memory string) (int64, error) {
 
 	// Return the value in kilobytes
 	return num * multiplier / 1024, nil
+}
+
+// cpuFallbackCap is the host-exhaustion safeguard cap (in vCPUs) applied
+// only when neither cfg.CPU nor a cgroup CPU limit is present.
+const cpuFallbackCap = 2
+
+// memFallbackCapKB is the host-exhaustion safeguard cap (in KB) applied
+// only when neither cfg.Memory nor a cgroup memory limit is present.
+// 4 GiB in KB.
+const memFallbackCapKB int64 = 4 * 1024 * 1024
+
+// effectiveCPU returns the vCPU count the VM should be pinned to, enforcing
+// the precedence:
+//
+//	cfgCPU (user flag / YAML)  >  cgroupCPU (container runtime)  >  fallback cap
+//
+// Arguments:
+//   - cfgCPU: value parsed from cfg.CPU, or 0 if empty/invalid.
+//   - cgroupCPU: value from getCgroupCPULimitCores(), or 0 if no limit.
+//   - hostCPU: runtime.NumCPU() on the invoking host.
+//
+// Precedence and capping:
+//   - hostCPU is first narrowed by the cgroup limit (when present and < host).
+//   - A user-supplied cfgCPU is then capped at that cgroup-narrowed host so
+//     the user request is honoured only when it fits on the effective host.
+//   - When cfgCPU is zero AND no cgroup limit is driving the budget, the
+//     min(cap, host) fallback fires. This safeguard prevents shared GKE /
+//     CI runners with empty YAML from claiming every host core.
+func effectiveCPU(cfgCPU, cgroupCPU, hostCPU int) int {
+	effHost := hostCPU
+	cgroupNarrows := cgroupCPU > 0 && cgroupCPU < hostCPU
+	if cgroupNarrows {
+		effHost = cgroupCPU
+	}
+	if cfgCPU > 0 {
+		if effHost > 0 && effHost < cfgCPU {
+			return effHost
+		}
+		return cfgCPU
+	}
+	if cgroupNarrows {
+		return cgroupCPU
+	}
+	if hostCPU < cpuFallbackCap {
+		return hostCPU
+	}
+	return cpuFallbackCap
+}
+
+// effectiveMemoryKB returns the memory (in KB) the VM should be allocated,
+// enforcing the precedence:
+//
+//	cfgMemoryKB (user flag / YAML)  >  cgroup (reflected in hostScaledKB)  >  fallback cap
+//
+// Arguments:
+//   - cfgMemoryKB: value parsed from cfg.Memory, or 0 if empty.
+//   - hostScaledKB: the runner's 85%-of-available-memory budget. This value
+//     is already cgroup-aware because getAvailableMemoryKB() consults the
+//     cgroup limit before falling back to /proc/meminfo.
+//   - cgroupMemoryKB: value from getCgroupMemoryLimitKB(), or 0 if no limit.
+//     Used only to distinguish "cgroup is driving the budget" (no extra cap)
+//     from "no cgroup present" (apply host-exhaustion cap).
+//
+// When cfgMemoryKB is set it takes precedence but is capped at hostScaledKB,
+// so a user request larger than host availability does not oversubscribe.
+// When cfgMemoryKB is unset and cgroupMemoryKB is present, hostScaledKB is
+// used as-is (cgroup already narrows it). When both are unset, the fallback
+// cap fires so a 128 GiB host does not hand its VM ~108 GiB.
+func effectiveMemoryKB(cfgMemoryKB, hostScaledKB, cgroupMemoryKB int64) int64 {
+	if cfgMemoryKB > 0 {
+		if hostScaledKB > 0 && hostScaledKB < cfgMemoryKB {
+			return hostScaledKB
+		}
+		return cfgMemoryKB
+	}
+	if cgroupMemoryKB > 0 {
+		return hostScaledKB
+	}
+	if hostScaledKB < memFallbackCapKB {
+		return hostScaledKB
+	}
+	return memFallbackCapKB
 }
 
 // getCgroupCPULimitCores reads the cgroup CPU quota for the current process and

--- a/pkg/container/qemu_runner_test.go
+++ b/pkg/container/qemu_runner_test.go
@@ -924,3 +924,90 @@ func findSubstring(s, substr string) bool {
 	}
 	return false
 }
+
+func TestEffectiveCPU(t *testing.T) {
+	tests := []struct {
+		name      string
+		cfgCPU    int
+		cgroupCPU int
+		hostCPU   int
+		want      int
+	}{
+		// Flag / YAML precedence (Invariants 1 & 2):
+		// cfg wins over the fallback (never returns 2 when cfgCPU is set)
+		// but is still capped at the cgroup-narrowed host.
+		{name: "flag wins under host", cfgCPU: 4, cgroupCPU: 0, hostCPU: 8, want: 4},
+		{name: "flag wins over cgroup when smaller", cfgCPU: 4, cgroupCPU: 8, hostCPU: 16, want: 4},
+		{name: "flag wins at host boundary", cfgCPU: 8, cgroupCPU: 0, hostCPU: 8, want: 8},
+		{name: "flag capped at host when larger", cfgCPU: 16, cgroupCPU: 0, hostCPU: 8, want: 8},
+		{name: "flag capped at cgroup when cgroup narrower", cfgCPU: 16, cgroupCPU: 4, hostCPU: 8, want: 4},
+		{name: "flag capped at cgroup on big host", cfgCPU: 16, cgroupCPU: 4, hostCPU: 32, want: 4},
+
+		// Cgroup precedence (Invariant 3)
+		{name: "cgroup wins when cfg empty", cfgCPU: 0, cgroupCPU: 3, hostCPU: 8, want: 3},
+		{name: "cgroup at host boundary falls to fallback", cfgCPU: 0, cgroupCPU: 8, hostCPU: 8, want: 2},
+		// cgroupCPU >= hostCPU means cgroup didn't actually narrow — fallback applies.
+
+		// Fallback (Invariant 4)
+		{name: "regression: no cfg no cgroup big host", cfgCPU: 0, cgroupCPU: 0, hostCPU: 16, want: 2},
+		{name: "fallback caps at 2 on 32-core host", cfgCPU: 0, cgroupCPU: 0, hostCPU: 32, want: 2},
+		{name: "fallback small host", cfgCPU: 0, cgroupCPU: 0, hostCPU: 1, want: 1},
+		{name: "fallback exact 2 host", cfgCPU: 0, cgroupCPU: 0, hostCPU: 2, want: 2},
+
+		// Edge: zero / degenerate inputs
+		{name: "all zero (degenerate)", cfgCPU: 0, cgroupCPU: 0, hostCPU: 0, want: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := effectiveCPU(tt.cfgCPU, tt.cgroupCPU, tt.hostCPU)
+			if got != tt.want {
+				t.Errorf("effectiveCPU(cfg=%d, cgroup=%d, host=%d) = %d, want %d",
+					tt.cfgCPU, tt.cgroupCPU, tt.hostCPU, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEffectiveMemoryKB(t *testing.T) {
+	const (
+		gib       = int64(1024 * 1024) // 1 GiB in KB
+		fallback  = int64(4 * 1024 * 1024)
+		bigHost   = int64(108 * 1024 * 1024) // 108 GiB in KB (85% of 128 GiB)
+		smallHost = int64(2 * 1024 * 1024)
+	)
+
+	tests := []struct {
+		name     string
+		cfgKB    int64
+		hostKB   int64 // the already-scaled (85%) host-available value
+		cgroupKB int64
+		want     int64
+	}{
+		// Flag / YAML precedence
+		{name: "cfg wins under host", cfgKB: 8 * gib, hostKB: bigHost, cgroupKB: 0, want: 8 * gib},
+		{name: "cfg wins over cgroup", cfgKB: 8 * gib, hostKB: 16 * gib, cgroupKB: 32 * gib, want: 8 * gib},
+		{name: "cfg capped at host", cfgKB: 32 * gib, hostKB: smallHost, cgroupKB: 0, want: smallHost},
+
+		// Cgroup precedence: host is already cgroup-aware, so pass through.
+		{name: "cgroup wins when cfg empty", cfgKB: 0, hostKB: 8 * gib, cgroupKB: 16 * gib, want: 8 * gib},
+
+		// Fallback cap at 4Gi when no cfg and no cgroup
+		{name: "regression: 128GiB host capped at 4GiB", cfgKB: 0, hostKB: bigHost, cgroupKB: 0, want: fallback},
+		{name: "fallback exact 4GiB host", cfgKB: 0, hostKB: fallback, cgroupKB: 0, want: fallback},
+		{name: "fallback small host below cap", cfgKB: 0, hostKB: 2 * gib, cgroupKB: 0, want: 2 * gib},
+
+		// Edge
+		{name: "cfg zero host zero", cfgKB: 0, hostKB: 0, cgroupKB: 0, want: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := effectiveMemoryKB(tt.cfgKB, tt.hostKB, tt.cgroupKB)
+			if got != tt.want {
+				t.Errorf("effectiveMemoryKB(cfg=%d, host=%d, cgroup=%d) = %d, want %d",
+					tt.cfgKB, tt.hostKB, tt.cgroupKB, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Currently, passing in `--cpu`/`--memory` externally will not apply due to the resource defaults we introduced here. Given the order in which we're calling things, these defaults overwrite what we pass in elsewhere, so we end up with `2 CPU` or `4Gi` no matter what.

This PR will fix the order for which resource configuration takes precedence.