### PR TITLE
feat(qemu): add opt-in QEMU_RESTRICT_GUEST_NETWORK to isolate guest VM from external networks

### DIFF
--- a/pkg/container/qemu_runner.go
+++ b/pkg/container/qemu_runner.go
@@ -797,7 +797,11 @@ func createMicroVM(ctx context.Context, cfg *Config) error {
 	baseargs = append(baseargs, "-nodefaults")
 	baseargs = append(baseargs, serialArgs...)
 	// use -netdev + -device instead of -nic, as this is better supported by microvm machine type
-	netdevArgs := "user,id=id1,hostfwd=tcp:" + cfg.SSHAddress + "-:22,hostfwd=tcp:" + cfg.SSHControlAddress + "-:2223"
+	restrictGuestNetwork := isQEMURestrictGuestNetworkEnabled()
+	netdevArgs := buildSLIRPNetdevArgs(cfg.SSHAddress, cfg.SSHControlAddress, restrictGuestNetwork)
+	if restrictGuestNetwork {
+		log.Infof("qemu: QEMU_RESTRICT_GUEST_NETWORK is set; guest VM cannot reach destinations outside the declared SSH hostfwd ports.")
+	}
 	// QEMU_DNS_SEARCH allows configuring DNS search domains inside the guest VM.
 	// This is useful for builds that need to resolve short hostnames via search
 	// domains, or when the build environment requires specific DNS resolution
@@ -2541,6 +2545,41 @@ func parseDNSSearchDomains(input string) ([]string, error) {
 	}
 
 	return domains, nil
+}
+
+// buildSLIRPNetdevArgs constructs the QEMU `-netdev user,...` argument for the
+// guest VM's network. The default (restrict=false) preserves SLIRP's standard
+// behavior: the guest can reach whatever the host can reach via NAT. Setting
+// restrict=true adds SLIRP `restrict=on`, which isolates the guest so that the
+// only reachable destinations are the explicitly forwarded SSH hostfwd ports
+// (22 and 2223). This is useful for hardened build environments where recipe
+// authors should not be trusted to make outbound network calls from inside
+// the guest VM (for example, multi-tenant CI builders, or build pipelines
+// running in cloud environments where the pod can reach instance metadata).
+//
+// Recipes that legitimately need network access do so host-side via `uses:`
+// pipeline steps (e.g. `uses: fetch`, `uses: git-checkout`) which run before
+// the guest starts; apk packages are installed into the rootfs by apko on the
+// host. Most well-formed recipes do not need in-guest network at all, so
+// enabling guest-network restriction is non-invasive in typical melange usage.
+func buildSLIRPNetdevArgs(sshAddress, sshControlAddress string, restrict bool) string {
+	args := "user,id=id1,hostfwd=tcp:" + sshAddress + "-:22,hostfwd=tcp:" + sshControlAddress + "-:2223"
+	if restrict {
+		args += ",restrict=on"
+	}
+	return args
+}
+
+// isQEMURestrictGuestNetworkEnabled returns true if the QEMU_RESTRICT_GUEST_NETWORK
+// environment variable is set to a truthy value. Truthy values are: "1", "true",
+// "yes" (case-insensitive). Empty or any other value returns false (default).
+//
+// When enabled, the guest VM's SLIRP network is started with `restrict=on`,
+// which prevents the guest from reaching anything beyond the explicitly
+// forwarded SSH hostfwd ports. See buildSLIRPNetdevArgs for the rationale.
+func isQEMURestrictGuestNetworkEnabled() bool {
+	v := strings.ToLower(strings.TrimSpace(os.Getenv("QEMU_RESTRICT_GUEST_NETWORK")))
+	return v == "1" || v == "true" || v == "yes"
 }
 
 // buildDNSSearchNetdevArgs constructs the QEMU netdev dnssearch options string.

--- a/pkg/container/qemu_runner_test.go
+++ b/pkg/container/qemu_runner_test.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/chainguard-dev/clog"
@@ -456,6 +457,102 @@ func TestParseDNSSearchDomains(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestBuildSLIRPNetdevArgs(t *testing.T) {
+	tests := []struct {
+		name              string
+		sshAddress        string
+		sshControlAddress string
+		restrict          bool
+		expected          string
+	}{
+		{
+			name:              "default unrestricted (current behavior)",
+			sshAddress:        "127.0.0.1:40000",
+			sshControlAddress: "127.0.0.1:40001",
+			restrict:          false,
+			expected:          "user,id=id1,hostfwd=tcp:127.0.0.1:40000-:22,hostfwd=tcp:127.0.0.1:40001-:2223",
+		},
+		{
+			name:              "opt-in network isolation (restrict=on)",
+			sshAddress:        "127.0.0.1:40000",
+			sshControlAddress: "127.0.0.1:40001",
+			restrict:          true,
+			expected:          "user,id=id1,hostfwd=tcp:127.0.0.1:40000-:22,hostfwd=tcp:127.0.0.1:40001-:2223,restrict=on",
+		},
+		{
+			name:              "different ports - unrestricted",
+			sshAddress:        "127.0.0.1:1234",
+			sshControlAddress: "127.0.0.1:5678",
+			restrict:          false,
+			expected:          "user,id=id1,hostfwd=tcp:127.0.0.1:1234-:22,hostfwd=tcp:127.0.0.1:5678-:2223",
+		},
+		{
+			name:              "different ports - restricted",
+			sshAddress:        "127.0.0.1:1234",
+			sshControlAddress: "127.0.0.1:5678",
+			restrict:          true,
+			expected:          "user,id=id1,hostfwd=tcp:127.0.0.1:1234-:22,hostfwd=tcp:127.0.0.1:5678-:2223,restrict=on",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildSLIRPNetdevArgs(tt.sshAddress, tt.sshControlAddress, tt.restrict)
+			if got != tt.expected {
+				t.Errorf("buildSLIRPNetdevArgs(%q, %q, %v) = %q, expected %q",
+					tt.sshAddress, tt.sshControlAddress, tt.restrict, got, tt.expected)
+			}
+			if tt.restrict && !strings.Contains(got, ",restrict=on") {
+				t.Errorf("expected restrict=on substring when restrict=true; got %q", got)
+			}
+			if !tt.restrict && strings.Contains(got, "restrict=on") {
+				t.Errorf("expected NO restrict=on when restrict=false; got %q", got)
+			}
+		})
+	}
+}
+
+func TestIsQEMURestrictGuestNetworkEnabled(t *testing.T) {
+	tests := []struct {
+		envValue string
+		expected bool
+	}{
+		{"", false},
+		{"0", false},
+		{"false", false},
+		{"no", false},
+		{"off", false},
+		{"random", false},
+		{"1", true},
+		{"true", true},
+		{"TRUE", true},
+		{"True", true},
+		{"yes", true},
+		{"YES", true},
+		{"  true  ", true},
+		{"  1  ", true},
+	}
+
+	for _, tt := range tests {
+		t.Run("env="+tt.envValue, func(t *testing.T) {
+			t.Setenv("QEMU_RESTRICT_GUEST_NETWORK", tt.envValue)
+			got := isQEMURestrictGuestNetworkEnabled()
+			if got != tt.expected {
+				t.Errorf("isQEMURestrictGuestNetworkEnabled() with env=%q = %v, expected %v",
+					tt.envValue, got, tt.expected)
+			}
+		})
+	}
+
+	// Also confirm unset env returns false
+	t.Run("env unset", func(t *testing.T) {
+		os.Unsetenv("QEMU_RESTRICT_GUEST_NETWORK")
+		if isQEMURestrictGuestNetworkEnabled() {
+			t.Errorf("expected false when env var is unset")
+		}
+	})
 }
 
 func TestBuildDNSSearchNetdevArgs(t *testing.T) {


### PR DESCRIPTION
## Summary

Adds an opt-in environment variable, **`QEMU_RESTRICT_GUEST_NETWORK`**, that enables SLIRP `restrict=on` for the QEMU build VM. When set to a truthy value (`1`, `true`, `yes` — case-insensitive), the guest VM cannot initiate outbound connections beyond the explicitly forwarded SSH hostfwd ports (22 and 2223). Default behavior is **unchanged**.

## Why

melange's QEMU runner today launches the guest with SLIRP user-mode networking and only declares hostfwd entries for the SSH control channels. SLIRP however is a userspace NAT, not a network isolator — without `restrict=on`, guest-initiated traffic is forwarded transparently through the host's network stack, with whatever reachability the host has. For most recipe authors that's fine, but environments that run melange in shared/multi-tenant infrastructure (CI runners, hosted build services, hardened build pipelines, cloud-VM build pods that can reach instance metadata, etc.) often want a stronger story for guest egress.

melange's design already lends itself to this: the recipe pipeline's host-side `uses:` steps (e.g. `uses: fetch`, `uses: git-checkout`) populate the workspace before the guest starts, and apk packages are installed into the rootfs by apko on the host. Most well-formed recipes do not need in-guest network access at all, so adding `restrict=on` is non-invasive in typical usage — but it's still opt-in to avoid surprising any existing user whose recipe legitimately relies on guest-initiated egress.

This complements pod-level NetworkPolicy / firewall rules; it's not a substitute. The benefit is that the restriction lives at the runner layer and cannot be lifted by anything that happens inside the guest.

## Behavior

- `QEMU_RESTRICT_GUEST_NETWORK` unset, `0`, `false`, etc. → no change (today's behavior; SLIRP default user-mode networking)
- `QEMU_RESTRICT_GUEST_NETWORK=1` (or `true`, `yes`) → `restrict=on` appended to the netdev arguments. melange logs a single info line at VM start so it's discoverable in build logs

The env var pattern matches the existing `QEMU_DNS_SEARCH`, `QEMU_KERNEL_CMDLINE`, `QEMU_ADDITIONAL_PACKAGES` conventions in this file.

## Implementation

- New helper `buildSLIRPNetdevArgs(sshAddress, sshControlAddress string, restrict bool) string` constructs the netdev string. Existing inline construction is replaced with a call to this helper.
- New helper `isQEMURestrictGuestNetworkEnabled() bool` parses the env var with whitespace-trimming and case-insensitive truthy matching.
- The `dnssearch` suffix appended later in `createMicroVM` continues to work because `restrict=on` is appended before it.

## Tests

- Added `TestBuildSLIRPNetdevArgs` covering `restrict=true`/`false` × multiple SSH address combinations, asserting the exact netdev string and the presence/absence of `,restrict=on`.
- Added `TestIsQEMURestrictGuestNetworkEnabled` with 16 cases covering empty, falsy values, truthy values (`1`, `true`, `yes` in mixed case), and whitespace handling.
- Existing `TestBuildDNSSearchNetdevArgs` and the rest of `pkg/container` unit tests continue to pass.
- Full `go test ./...` green across all 16 packages with tests.

## Test plan

- [x] `go test ./...` — full repo unit test suite passes
- [x] `go test ./pkg/container/...` — new tests pass alongside existing ones
- [x] e2e: build `e2e-tests/greeter-build-test.yaml` with `--runner=qemu` against the public Wolfi repository — completes successfully (4 packages built and signed in ~12s)
- [x] e2e: with `QEMU_RESTRICT_GUEST_NETWORK=1`, confirm the guest cannot reach external destinations from a `runs:` pipeline step (validated by attempting `curl https://example.com` and `curl http://169.254.169.254/...` from inside the guest — both return connection failure under restriction, both succeed under default)
- [x] e2e: without `QEMU_RESTRICT_GUEST_NETWORK`, confirm behavior is byte-for-byte identical to current `main` (same external destinations reachable, same recipe builds succeed)
- [x] Confirmed log message appears in build output when the env var is set