### PR TITLE
chore(workflows): add tcp.dl.google.com allowed endpoint

### DIFF
--- a/.github/workflows/melange-test-pipelines.yaml
+++ b/.github/workflows/melange-test-pipelines.yaml
@@ -69,6 +69,7 @@ jobs:
             *.githubapp.com:443
             9236a389bd48b984df91adc1bc924620.r2.cloudflarestorage.com:443
             _http._tcp.azure.archive.ubuntu.com:443
+            _https._tcp.dl.google.com:443
             _https._tcp.esm.ubuntu.com:443
             _https._tcp.motd.ubuntu.com:443
             _https._tcp.packages.microsoft.com:443

--- a/.github/workflows/wolfi-presubmit.yaml
+++ b/.github/workflows/wolfi-presubmit.yaml
@@ -104,6 +104,7 @@ jobs:
             *.githubapp.com:443
             9236a389bd48b984df91adc1bc924620.r2.cloudflarestorage.com:443
             _http._tcp.azure.archive.ubuntu.com:443
+            _https._tcp.dl.google.com:443
             _https._tcp.esm.ubuntu.com:443
             _https._tcp.motd.ubuntu.com:443
             _https._tcp.packages.microsoft.com:443


### PR DESCRIPTION
Ref: https://github.com/chainguard-dev/melange/pull/2508/checks?check_run_id=73633559606

