### PR TITLE
fix(ci): harden against template injection and credential exposure

### DIFF
--- a/.actionlint.yaml
+++ b/.actionlint.yaml
@@ -1,0 +1,3 @@
+self-hosted-runner:
+  labels:
+    - ubuntu-latest-8-core

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: daily
+    cooldown:
+      default-days: 3
     open-pull-requests-limit: 10
     groups:
       gomod:
@@ -15,6 +17,8 @@ updates:
     directory: "/"
     schedule:
       interval: daily
+    cooldown:
+      default-days: 3
     open-pull-requests-limit: 10
     groups:
       actions:

--- a/.github/workflows/actionlint.yaml
+++ b/.github/workflows/actionlint.yaml
@@ -24,7 +24,7 @@ jobs:
     name: Action lint
     runs-on: ubuntu-latest
     steps:
-      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+      - uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
         with:
           egress-policy: block
           allowed-endpoints: >

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,7 +17,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+      - uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
         with:
           egress-policy: block
           allowed-endpoints: >

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -35,6 +35,8 @@ jobs:
             sum.golang.org:443
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -58,9 +58,11 @@ jobs:
           ./melange keygen
 
       - name: Build package
+        env:
+          MATRIX_CFG: ${{ matrix.cfg }}
         run: |
-          path=examples/${{matrix.cfg}}
-          if [ "${{matrix.cfg}}" == "melange.yaml" ]; then
+          path=examples/$MATRIX_CFG
+          if [ "$MATRIX_CFG" == "melange.yaml" ]; then
             path="melange.yaml"
           fi
           ./melange build $path --arch=x86_64 --namespace=wolfi

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -38,7 +38,7 @@ jobs:
         --cap-add NET_ADMIN --cap-add SYS_ADMIN --security-opt seccomp=unconfined --security-opt apparmor:unconfined
 
     steps:
-      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+      - uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
         with:
           egress-policy: audit
 

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -43,6 +43,8 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: "go.mod"

--- a/.github/workflows/go-tests.yaml
+++ b/.github/workflows/go-tests.yaml
@@ -16,7 +16,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+      - uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
         with:
           egress-policy: block
           allowed-endpoints: >

--- a/.github/workflows/go-tests.yaml
+++ b/.github/workflows/go-tests.yaml
@@ -47,6 +47,8 @@ jobs:
             translationproject.org:443
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:

--- a/.github/workflows/melange-test-pipelines.yaml
+++ b/.github/workflows/melange-test-pipelines.yaml
@@ -113,8 +113,10 @@ jobs:
           path: ${{ github.workspace }}/.melange-dir
           run-id: ${{ github.run_id }}
 
-      - run: |
-          sudo mv ${{ github.workspace }}/.melange-dir/melange /usr/bin/melange
+      - env:
+          GITHUB_WORKSPACE: ${{ github.workspace }}
+        run: |
+          sudo mv "$GITHUB_WORKSPACE"/.melange-dir/melange /usr/bin/melange
           sudo chmod a+x /usr/bin/melange
           melange version
 

--- a/.github/workflows/melange-test-pipelines.yaml
+++ b/.github/workflows/melange-test-pipelines.yaml
@@ -17,7 +17,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+      - uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
         with:
           egress-policy: block
           allowed-endpoints: >
@@ -63,7 +63,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+      - uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
         with:
           egress-policy: block
           allowed-endpoints: >
@@ -135,7 +135,7 @@ jobs:
           go-version-file: "./go.mod"
           check-latest: true
 
-      - uses: cue-lang/setup-cue@a93fa358375740cd8b0078f76355512b9208acb1
+      - uses: cue-lang/setup-cue@a93fa358375740cd8b0078f76355512b9208acb1 # v1.0.1
 
       - name: Install QEMU/KVM
         run: |

--- a/.github/workflows/melange-test-pipelines.yaml
+++ b/.github/workflows/melange-test-pipelines.yaml
@@ -35,6 +35,8 @@ jobs:
             sum.golang.org:443
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
@@ -105,6 +107,8 @@ jobs:
             us.download.nvidia.com:443
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       # Grab the melange we uploaded above, and install it.
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -124,6 +128,8 @@ jobs:
           sudo apt-get -y install bubblewrap
       - uses: ./.github/actions/setup-bubblewrap
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: "./go.mod"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,7 @@ jobs:
       contents: write
 
     steps:
-      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+      - uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
         with:
           egress-policy: block
           allowed-endpoints: >

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -45,13 +45,15 @@ jobs:
             uploads.github.com:443
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Check if any changes since last release
         id: check
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          git fetch --tags
+          git fetch --tags  # no creds needed: repo is public; if this ever goes private, pass token explicitly here
           TAG=$(git tag --points-at HEAD)
           if [ -z "$TAG" ]; then
             echo "No tag points at HEAD, so we need a new tag and then a new release."
@@ -79,6 +81,7 @@ jobs:
         if: steps.check.outputs.need_release == 'yes'
         with:
           ref: ${{ steps.check.outputs.existing_tag || steps.create_tag.outputs.new_tag }}
+          persist-credentials: false
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         if: steps.check.outputs.need_release == 'yes'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -57,16 +57,16 @@ jobs:
           TAG=$(git tag --points-at HEAD)
           if [ -z "$TAG" ]; then
             echo "No tag points at HEAD, so we need a new tag and then a new release."
-            echo "need_release=yes" >> $GITHUB_OUTPUT
+            echo "need_release=yes" >> "$GITHUB_OUTPUT"
           else
             RELEASE=$(gh release view "$TAG" --json tagName --jq '.tagName' || echo "none")
             if [ "$RELEASE" == "$TAG" ]; then
               echo "A release exists for tag $TAG, which has the latest changes, so no need for a new tag or release."
-              echo "need_release=no" >> $GITHUB_OUTPUT
+              echo "need_release=no" >> "$GITHUB_OUTPUT"
             else
               echo "Tag $TAG exists, but no release is associated. Need a new release."
-              echo "need_release=yes" >> $GITHUB_OUTPUT
-              echo "existing_tag=$TAG" >> $GITHUB_OUTPUT
+              echo "need_release=yes" >> "$GITHUB_OUTPUT"
+              echo "existing_tag=$TAG" >> "$GITHUB_OUTPUT"
             fi
           fi
 

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -17,7 +17,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+      - uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
         with:
           egress-policy: block
           allowed-endpoints: >

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -36,6 +36,8 @@ jobs:
             sum.golang.org:443
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:

--- a/.github/workflows/wolfi-presubmit.yaml
+++ b/.github/workflows/wolfi-presubmit.yaml
@@ -34,6 +34,8 @@ jobs:
             sum.golang.org:443
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
@@ -166,6 +168,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: wolfi-dev/os
+          persist-credentials: false
 
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -198,6 +201,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           path: melange-src
+          persist-credentials: false
       - if: matrix.runner == 'bubblewrap'
         uses: ./melange-src/.github/actions/setup-bubblewrap
       - if: matrix.runner == 'bubblewrap'

--- a/.github/workflows/wolfi-presubmit.yaml
+++ b/.github/workflows/wolfi-presubmit.yaml
@@ -17,7 +17,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+      - uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
         with:
           egress-policy: block
           allowed-endpoints: >
@@ -98,7 +98,7 @@ jobs:
           - tini
 
     steps:
-      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+      - uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
         with:
           egress-policy: block
           allowed-endpoints: >

--- a/.github/workflows/wolfi-presubmit.yaml
+++ b/.github/workflows/wolfi-presubmit.yaml
@@ -173,8 +173,10 @@ jobs:
           path: ${{ github.workspace }}/.melange-dir
           run-id: ${{ github.run_id }}
 
-      - run: |
-          sudo mv ${{ github.workspace }}/.melange-dir/melange /usr/bin/melange
+      - env:
+          GITHUB_WORKSPACE: ${{ github.workspace }}
+        run: |
+          sudo mv "$GITHUB_WORKSPACE"/.melange-dir/melange /usr/bin/melange
           sudo chmod a+x /usr/bin/melange
           melange version
 
@@ -184,8 +186,10 @@ jobs:
       # this need to point to main to always get the latest action
       - uses: wolfi-dev/actions/install-wolfictl@d8faf0b2bf2a7c6eefc571567ef370faae5baed2 # last commit that had the scan command
 
-      - run: |
-          wolfictl bump ${{ matrix.package }}
+      - env:
+          MATRIX_PACKAGE: ${{ matrix.package }}
+        run: |
+          wolfictl bump "$MATRIX_PACKAGE"
 
       - if: matrix.runner == 'bubblewrap'
         run: |
@@ -197,11 +201,15 @@ jobs:
       - if: matrix.runner == 'bubblewrap'
         uses: ./melange-src/.github/actions/setup-bubblewrap
       - if: matrix.runner == 'bubblewrap'
+        env:
+          MATRIX_PACKAGE: ${{ matrix.package }}
         run: |
-          make SHELL="/bin/bash" MELANGE="sudo melange" MELANGE_RUNNER="bubblewrap" MELANGE_EXTRA_OPTS="--generate-provenance" package/${{ matrix.package }}
+          make SHELL="/bin/bash" MELANGE="sudo melange" MELANGE_RUNNER="bubblewrap" MELANGE_EXTRA_OPTS="--generate-provenance" package/"$MATRIX_PACKAGE"
       - if: matrix.runner == 'bubblewrap'
+        env:
+          MATRIX_PACKAGE: ${{ matrix.package }}
         run: |
-          make SHELL="/bin/bash" MELANGE="sudo melange" MELANGE_RUNNER="docker" test/${{ matrix.package }}
+          make SHELL="/bin/bash" MELANGE="sudo melange" MELANGE_RUNNER="docker" test/"$MATRIX_PACKAGE"
 
       - name: Download kernel for VMs
         if: matrix.runner == 'qemu'
@@ -224,8 +232,10 @@ jobs:
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
 
-      - name: Make package ${{matrix.package}} with QEMU Runner
+      - name: Make package ${{ matrix.package }} with QEMU Runner
         if: matrix.runner == 'qemu'
+        env:
+          MATRIX_PACKAGE: ${{ matrix.package }}
         run: |
           make \
             SHELL="/bin/bash" \
@@ -233,7 +243,7 @@ jobs:
             QEMU_KERNEL_MODULES=/tmp/kernel/lib/modules/ \
             MELANGE="/usr/bin/melange" \
             MELANGE_EXTRA_OPTS="--runner qemu --generate-provenance" \
-            package/${{ matrix.package }}
+            package/"$MATRIX_PACKAGE"
 
       - name: Output SLSA provenance
         run: |
@@ -246,11 +256,15 @@ jobs:
 
       - name: Run tests to verify xattrs with bubblewrap runner
         if: matrix.runner == 'bubblewrap' && matrix.package == 'fping'
+        env:
+          MATRIX_PACKAGE: ${{ matrix.package }}
         run: |
-          make SHELL="/bin/bash" MELANGE="sudo melange" MELANGE_RUNNER="bubblewrap" test/${{ matrix.package }}
+          make SHELL="/bin/bash" MELANGE="sudo melange" MELANGE_RUNNER="bubblewrap" test/"$MATRIX_PACKAGE"
 
       - name: Run tests with QEMU runner
         if: matrix.runner == 'qemu'
+        env:
+          MATRIX_PACKAGE: ${{ matrix.package }}
         run: |
           make \
             SHELL="/bin/bash" \
@@ -258,7 +272,7 @@ jobs:
             QEMU_KERNEL_MODULES=/tmp/kernel/lib/modules/ \
             MELANGE="/usr/bin/melange" \
             MELANGE_EXTRA_OPTS="--runner qemu" \
-            test/${{ matrix.package }}
+            test/"$MATRIX_PACKAGE"
 
       - name: Check package ${{ matrix.package }} xattrs for QEMU-built package
         if: matrix.runner == 'qemu' && matrix.package == 'fping'
@@ -277,18 +291,20 @@ jobs:
           ls -hal packages/x86_64/usr/bin/sudo
 
       - name: Test installable and Scan for CVEs
+        env:
+          MATRIX_PACKAGE: ${{ matrix.package }}
         run: |
-          if [[ "${{ matrix.package }}" == "fping" ]]; then
-            docker run --rm -v $(pwd):/work --workdir /work cgr.dev/chainguard/wolfi-base /bin/sh -c "sed 's|=.*||' -i /etc/apk/world; apk add --allow-untrusted -X ./packages/ packages/x86_64/${{ matrix.package }}-*.apk; apk add libcap-utils; getcap /usr/sbin/fping"
-          elif [[ "${{ matrix.package }}" == "sudo" ]]; then
-            docker run --rm -v $(pwd):/work --workdir /work cgr.dev/chainguard/wolfi-base /bin/sh -c "sed 's|=.*||' -i /etc/apk/world; apk add --allow-untrusted -X ./packages/ packages/x86_64/${{ matrix.package }}-*.apk; ls -hal /usr/bin/sudo"
-          elif [[ "${{ matrix.package }}" == "postfix" ]]; then
-            docker run --rm -v $(pwd):/work --workdir /work cgr.dev/chainguard/wolfi-base /bin/sh -c "sed 's|=.*||' -i /etc/apk/world; apk add --allow-untrusted -X ./packages/ packages/x86_64/${{ matrix.package }}-*.apk; ls -hal /var/spool/postfix; ls -hal /var/lib/postfix"
+          if [[ "$MATRIX_PACKAGE" == "fping" ]]; then
+            docker run --rm -v $(pwd):/work --workdir /work cgr.dev/chainguard/wolfi-base /bin/sh -c "sed 's|=.*||' -i /etc/apk/world; apk add --allow-untrusted -X ./packages/ packages/x86_64/$MATRIX_PACKAGE-*.apk; apk add libcap-utils; getcap /usr/sbin/fping"
+          elif [[ "$MATRIX_PACKAGE" == "sudo" ]]; then
+            docker run --rm -v $(pwd):/work --workdir /work cgr.dev/chainguard/wolfi-base /bin/sh -c "sed 's|=.*||' -i /etc/apk/world; apk add --allow-untrusted -X ./packages/ packages/x86_64/$MATRIX_PACKAGE-*.apk; ls -hal /usr/bin/sudo"
+          elif [[ "$MATRIX_PACKAGE" == "postfix" ]]; then
+            docker run --rm -v $(pwd):/work --workdir /work cgr.dev/chainguard/wolfi-base /bin/sh -c "sed 's|=.*||' -i /etc/apk/world; apk add --allow-untrusted -X ./packages/ packages/x86_64/$MATRIX_PACKAGE-*.apk; ls -hal /var/spool/postfix; ls -hal /var/lib/postfix"
           else
-            docker run --rm -v $(pwd):/work --workdir /work cgr.dev/chainguard/wolfi-base /bin/sh -c "sed 's|=.*||' -i /etc/apk/world; apk add --allow-untrusted -X ./packages/ packages/x86_64/${{ matrix.package }}-*.apk"
+            docker run --rm -v $(pwd):/work --workdir /work cgr.dev/chainguard/wolfi-base /bin/sh -c "sed 's|=.*||' -i /etc/apk/world; apk add --allow-untrusted -X ./packages/ packages/x86_64/$MATRIX_PACKAGE-*.apk"
           fi
           # There is a huge fixed cost for every wolfictl scan invocation for grype DB init.
           # Do this outside of the loop in one invocation with every package.
           wolfictl scan \
-          packages/x86_64/${{ matrix.package }}-*.apk \
+          packages/x86_64/"$MATRIX_PACKAGE"-*.apk \
           2> /dev/null # The error message renders strangely on GitHub Actions, and the important information is already being sent to stdout.

--- a/.github/workflows/wolfi-presubmit.yaml
+++ b/.github/workflows/wolfi-presubmit.yaml
@@ -299,13 +299,13 @@ jobs:
           MATRIX_PACKAGE: ${{ matrix.package }}
         run: |
           if [[ "$MATRIX_PACKAGE" == "fping" ]]; then
-            docker run --rm -v $(pwd):/work --workdir /work cgr.dev/chainguard/wolfi-base /bin/sh -c "sed 's|=.*||' -i /etc/apk/world; apk add --allow-untrusted -X ./packages/ packages/x86_64/$MATRIX_PACKAGE-*.apk; apk add libcap-utils; getcap /usr/sbin/fping"
+            docker run --rm -v "$(pwd)":/work --workdir /work cgr.dev/chainguard/wolfi-base /bin/sh -c "sed 's|=.*||' -i /etc/apk/world; apk add --allow-untrusted -X ./packages/ packages/x86_64/$MATRIX_PACKAGE-*.apk; apk add libcap-utils; getcap /usr/sbin/fping"
           elif [[ "$MATRIX_PACKAGE" == "sudo" ]]; then
-            docker run --rm -v $(pwd):/work --workdir /work cgr.dev/chainguard/wolfi-base /bin/sh -c "sed 's|=.*||' -i /etc/apk/world; apk add --allow-untrusted -X ./packages/ packages/x86_64/$MATRIX_PACKAGE-*.apk; ls -hal /usr/bin/sudo"
+            docker run --rm -v "$(pwd)":/work --workdir /work cgr.dev/chainguard/wolfi-base /bin/sh -c "sed 's|=.*||' -i /etc/apk/world; apk add --allow-untrusted -X ./packages/ packages/x86_64/$MATRIX_PACKAGE-*.apk; ls -hal /usr/bin/sudo"
           elif [[ "$MATRIX_PACKAGE" == "postfix" ]]; then
-            docker run --rm -v $(pwd):/work --workdir /work cgr.dev/chainguard/wolfi-base /bin/sh -c "sed 's|=.*||' -i /etc/apk/world; apk add --allow-untrusted -X ./packages/ packages/x86_64/$MATRIX_PACKAGE-*.apk; ls -hal /var/spool/postfix; ls -hal /var/lib/postfix"
+            docker run --rm -v "$(pwd)":/work --workdir /work cgr.dev/chainguard/wolfi-base /bin/sh -c "sed 's|=.*||' -i /etc/apk/world; apk add --allow-untrusted -X ./packages/ packages/x86_64/$MATRIX_PACKAGE-*.apk; ls -hal /var/spool/postfix; ls -hal /var/lib/postfix"
           else
-            docker run --rm -v $(pwd):/work --workdir /work cgr.dev/chainguard/wolfi-base /bin/sh -c "sed 's|=.*||' -i /etc/apk/world; apk add --allow-untrusted -X ./packages/ packages/x86_64/$MATRIX_PACKAGE-*.apk"
+            docker run --rm -v "$(pwd)":/work --workdir /work cgr.dev/chainguard/wolfi-base /bin/sh -c "sed 's|=.*||' -i /etc/apk/world; apk add --allow-untrusted -X ./packages/ packages/x86_64/$MATRIX_PACKAGE-*.apk"
           fi
           # There is a huge fixed cost for every wolfictl scan invocation for grype DB init.
           # Do this outside of the loop in one invocation with every package.

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -9,11 +9,15 @@ on:
     paths:
       - '.github/workflows/**'
       - '.github/actions/**'
+      - '.github/dependabot.yml'
+      - '.github/zizmor.yml'
   push:
     branches: ['main']
     paths:
       - '.github/workflows/**'
       - '.github/actions/**'
+      - '.github/dependabot.yml'
+      - '.github/zizmor.yml'
 
 permissions: {}
 
@@ -42,3 +46,5 @@ jobs:
 
       - name: Run zizmor
         uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
+        with:
+          persona: pedantic

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -30,7 +30,7 @@ jobs:
       contents: read # Clone the repository
       security-events: write # Upload SARIF results to Code Scanning
     steps:
-      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+      - uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
         with:
           egress-policy: block
           allowed-endpoints: >

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,10 @@
+rules:
+  dependabot-cooldown:
+    config:
+      days: 3
+  anonymous-definition:
+    disable: true
+  undocumented-permissions:
+    disable: true
+  concurrency-limits:
+    disable: true


### PR DESCRIPTION

## Summary

This patch series addresses GitHub Actions security findings from the PSEC-923 sweep
of `chainguard-dev/melange`. Five commits are included.

Sweep date: 2026-05-02. zizmor version: 1.24.1 (auditor persona for sweep;
patches configure pedantic persona for ongoing CI).

## Patches

### 0001 — fix(ci): resolve template injection findings

Fixes 18 `template-injection` zizmor findings across three workflow files by moving
`${{ context }}` expressions into `env:` variables and referencing them via `$VAR_NAME`
in `run:` blocks. All injected values are workflow-controlled (`matrix.cfg`,
`matrix.package`, `github.workspace`) rather than attacker-controlled, but the pedantic
persona correctly flags them as a code hygiene concern.

**Files changed:**
- `e2e.yaml` — `${{matrix.cfg}}` in the "Build package" step (1 step, 2 occurrences)
- `melange-test-pipelines.yaml` — `${{ github.workspace }}` in the install-melange step
- `wolfi-presubmit.yaml` — `${{ github.workspace }}` in install-melange step;
  `${{ matrix.package }}` in 8 additional steps: wolfictl bump, bubblewrap build/test,
  QEMU build/test, xattr verification, and the "Test installable and Scan for CVEs" step

All `env:` blocks are placed before `run:`, and all generated shell references use
double-quoted `"$VAR_NAME"` form where appropriate. Step `name:` fields containing
`${{ matrix.package }}` (e.g., `Make package ${{ matrix.package }} with QEMU Runner`)
are intentionally preserved — zizmor does not flag them and they keep matrix rows
distinguishable in the Actions UI.

### 0002 — fix(ci): add persist-credentials: false to checkout steps

Fixes 12 `artipacked` zizmor findings across 7 workflow files by adding
`persist-credentials: false` to all checkout steps that did not already have it.

**Artipacked checkouts fixed:**
- `build.yaml`: build job (1 checkout)
- `e2e.yaml`: rebuild job (1 checkout)
- `go-tests.yaml`: test job (1 checkout)
- `melange-test-pipelines.yaml`: build-melange job (1 checkout) and test-packages job
  (2 checkouts — initial + mid-job re-checkout)
- `release.yaml`: release job (2 checkouts — initial + tag-specific)
- `verify.yaml`: golangci job (1 checkout)
- `wolfi-presubmit.yaml`: build-melange job (1 checkout), build-packages job —
  wolfi-dev/os checkout and conditional melange-src checkout (2 checkouts)

**Release workflow rationale**: Both checkout steps in `release.yaml` receive
`persist-credentials: false` because all downstream write operations pass their token
explicitly: `mathieudutour/github-tag-action` receives `github_token:` as a step input,
and `make release` (which runs goreleaser) receives `GITHUB_TOKEN` as an env var.
The `git fetch --tags` step is read-only on a public repository; a comment was added
to document this assumption. See `manual-review.md` for full reasoning.

### 0003 — fix(ci): add pedantic persona, zizmor config, and dependabot cooldown

Configures ongoing zizmor CI to use the pedantic persona (catching all template
expansions, not just attacker-controlled sources), suppresses noisy pedantic-only rules
with no security impact, adds a 3-day dependabot cooldown, and extends CI path triggers
to cover config file changes.

**Changes:**
- `.github/zizmor.yml` (new file): suppress `concurrency-limits` (9 findings),
  `anonymous-definition` (1 finding), and `undocumented-permissions` (1 finding) —
  all pedantic-only with no exploitable security impact. Sets `dependabot-cooldown`
  threshold to 3 days to match the `dependabot.yml` cooldown.
- `.github/workflows/zizmor.yaml`: add `persona: pedantic` to the `zizmor-action`
  step. Extend `paths:` triggers to include `.github/dependabot.yml` and
  `.github/zizmor.yml` so changes to those files trigger the zizmor check.
- `.github/workflows/actionlint.yaml`: extend `paths:` triggers to include
  `.github/dependabot.yml` and `.github/zizmor.yml`.
- `.github/dependabot.yml`: add `cooldown: default-days: 3` to both the `gomod` and
  `github-actions` package ecosystems, satisfying the `dependabot-cooldown` zizmor rule.

### 0004 — fix(ci): address actionlint and shellcheck findings

Fixes mechanical actionlint/shellcheck findings.

**Changes:**
- `.actionlint.yaml` (new file): registers `ubuntu-latest-8-core` as a known custom
  runner label, suppressing the false-positive `runner-label` warning that appeared for
  `melange-test-pipelines.yaml` and `wolfi-presubmit.yaml`.
- `release.yaml`: quote `$GITHUB_OUTPUT` in redirect operators (SC2086). Four
  occurrences of `>> $GITHUB_OUTPUT` corrected to `>> "$GITHUB_OUTPUT"` in the
  "Check if any changes since last release" step.
- `wolfi-presubmit.yaml`: quote `$(pwd)` in docker run `-v` arguments (SC2046). All
  four docker run invocations in "Test installable and Scan for CVEs" updated to use
  `"$(pwd)":/work`.

### 0005 — fix(ci): add missing version comments to SHA-pinned action refs

Resolves `ref-version-mismatch` zizmor findings by annotating SHA-pinned action refs
with their corresponding version tag or branch name (looked up via the GitHub API).

---

## Findings Not Patched

| Finding | Count | Disposition |
|---------|-------|-------------|
| `cache-poisoning` | 2 | Manual review — see manual-review.md |
| `unpinned-images` | 1 | Manual review — `alpine:latest` requires SHA lookup |
| `ref-version-mismatch` | 1 | Fixed in patch 0005 |
| `stale-action-refs` | 1 | Manual review — requires online check |
| `concurrency-limits` | 9 | Suppressed in zizmor.yml (low security value) |
| `anonymous-definition` | 1 | Suppressed in zizmor.yml (cosmetic, no security impact) |
| `undocumented-permissions` | 1 | Suppressed in zizmor.yml (style only) |

## References

- Campaign: PSEC-923 <https://linear.app/chainguard/issue/PSEC-923/>
- zizmor version: 1.24.1
- Sweep date: 2026-05-02

Refs: PSEC-923