### PR TITLE
linter: validate cfg.Package.Version against path traversal in saveLintResults

### DIFF
--- a/pkg/linter/linter_test.go
+++ b/pkg/linter/linter_test.go
@@ -759,3 +759,20 @@ func Test_lintApkWithOutput(t *testing.T) {
 	assert.NotEmpty(t, manInfoFindings[0].Message)
 	assert.NotEmpty(t, manInfoFindings[0].Explain)
 }
+
+func Test_saveLintResultsVersionTraversal(t *testing.T) {
+	ctx := slogtest.Context(t)
+
+	cfg := &config.Configuration{
+		Package: config.Package{
+			Name:    "testpkg",
+			Version: "1.0-../../etc/cron.d/evil",
+		},
+	}
+	results := map[string]*types.PackageLintResults{
+		"testpkg": {},
+	}
+
+	err := saveLintResults(ctx, cfg, results, t.TempDir(), "x86_64")
+	assert.ErrorContains(t, err, "path traversal")
+}

--- a/pkg/linter/results.go
+++ b/pkg/linter/results.go
@@ -51,6 +51,11 @@ func saveLintResults(ctx context.Context, cfg *config.Configuration, results map
 		return fmt.Errorf("invalid arch %q: contains path traversal sequence", arch)
 	}
 
+	// Validate version to prevent path traversal
+	if containsPathTraversal(cfg.Package.Version) {
+		return fmt.Errorf("invalid package version %q: contains path traversal sequence", cfg.Package.Version)
+	}
+
 	// Ensure the package directory exists
 	packageDir := filepath.Join(outputDir, arch)
 	if err := os.MkdirAll(packageDir, 0o755); err != nil {


### PR DESCRIPTION
## Summary

- `saveLintResults` in `pkg/linter/results.go` validated `arch` and `pkgName` against `containsPathTraversal()` but omitted the same check on `cfg.Package.Version`.
- All three fields are interpolated into the output filename; an APK with a crafted `pkgver` (e.g. `1.0-../../etc/cron.d/evil`) in `.PKGINFO` can write the lint result file outside `packageDir` via `filepath.Join`/`Clean` resolving the `..` segments.
- Trigger: `melange lint <crafted-apk> --persist-lint-results`
- Affected: HEAD (2582b68) and v0.50.4

## Fix

Add `containsPathTraversal(cfg.Package.Version)` check before the per-package loop, where `cfg.Package.Version` is validated once (it is package-level, not per-subpackage).

## Test

New `Test_saveLintResultsVersionTraversal` in `pkg/linter/linter_test.go` calls `saveLintResults` directly with a traversal version string and asserts an error is returned.

## References

- Reported responsibly via security@ — reporter offered a PR and a PoC APK; this commit incorporates their suggested fix.
- Internal tracking: SECINT-293

🤖 Generated with [Claude Code](https://claude.com/claude-code)