### PR TITLE
Add linter to complain about shipping libtool linker files.

### DIFF
--- a/docs/md/melange_build.md
+++ b/docs/md/melange_build.md
@@ -53,7 +53,7 @@ melange build [flags]
   -i, --interactive                                             when enabled, attaches stdin with a tty to the pod on failure
   -k, --keyring-append strings                                  path to extra keys to include in the build environment keyring
       --license string                                          license to use for the build config file itself (default "NOASSERTION")
-      --lint-require strings                                    linters that must pass (default [dev,infodir,setuidgid,tempdir,usrmerge,varempty,worldwrite])
+      --lint-require strings                                    linters that must pass (default [dev,infodir,libtool/la-files,setuidgid,tempdir,usrmerge,varempty,worldwrite])
       --lint-warn strings                                       linters that will generate warnings (default [binaryarch,cudaruntimelib,dll,duplicate,dylib,lddcheck,maninfo,nonlinux,object,opt,pkgconf,python/docs,python/multiple,python/test,sbom,srv,staticarchive,strip,unsupportedarch,usrlocal])
       --memory string                                           default memory resources to use for builds
       --namespace string                                        namespace to use in package URLs in SBOM (eg wolfi, alpine) (default "unknown")

--- a/docs/md/melange_lint.md
+++ b/docs/md/melange_lint.md
@@ -29,7 +29,7 @@ melange lint [flags]
 
 ```
   -h, --help                   help for lint
-      --lint-require strings   linters that must pass (default [dev,infodir,setuidgid,tempdir,usrmerge,varempty,worldwrite])
+      --lint-require strings   linters that must pass (default [dev,infodir,libtool/la-files,setuidgid,tempdir,usrmerge,varempty,worldwrite])
       --lint-warn strings      linters that will generate warnings (default [binaryarch,cudaruntimelib,dll,duplicate,dylib,lddcheck,maninfo,nonlinux,object,opt,pkgconf,python/docs,python/multiple,python/test,sbom,srv,staticarchive,strip,unsupportedarch,usrlocal])
       --out-dir string         directory where lint results JSON files will be saved (requires --persist-lint-results) (default "packages")
       --persist-lint-results   persist lint results to JSON files in packages/{arch}/ directory

--- a/pkg/linter/linter.go
+++ b/pkg/linter/linter.go
@@ -199,6 +199,11 @@ var linterMap = map[string]linter{
 		Explain:         "This package contains static archives (.a files)",
 		defaultBehavior: Warn,
 	},
+	"libtool/la-files": {
+		LinterFunc:      linters.LaFilesLinter,
+		Explain:         "Remove libtool archive (.la) files from the package, or disable this linter if they are required",
+		defaultBehavior: Require,
+	},
 	"duplicate": {
 		LinterFunc:      linters.DuplicateLinter,
 		Explain:         "This package contains files with the same name and content in different directories (consider symlinking)",

--- a/pkg/linter/linter_test.go
+++ b/pkg/linter/linter_test.go
@@ -571,6 +571,19 @@ func TestLinters(t *testing.T) {
 		linter:  "staticarchive",
 		pkgname: "test-dev",
 		pass:    true, // .a files are expected in -dev packages
+	}, {
+		dirFunc: mkfile(t, "usr/lib/libfoo.la"),
+		linter:  "libtool/la-files",
+		pass:    false,
+	}, {
+		dirFunc: mkfile(t, "usr/lib/libfoo.la"),
+		linter:  "libtool/la-files",
+		pkgname: "foo-dev",
+		pass:    false, // no auto-exemption for -dev; opt-out is via checks.disabled
+	}, {
+		dirFunc: mkfile(t, "usr/lib/libfoo.so"),
+		linter:  "libtool/la-files",
+		pass:    true,
 	}} {
 		ctx := slogtest.Context(t)
 		t.Run(c.linter, func(t *testing.T) {

--- a/pkg/linter/linters/libtool.go
+++ b/pkg/linter/linters/libtool.go
@@ -1,0 +1,37 @@
+// Copyright 2026 Chainguard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package linters
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+	"path/filepath"
+
+	"chainguard.dev/melange/pkg/config"
+)
+
+func LaFilesLinter(ctx context.Context, _ *config.Configuration, pkgname string, fsys fs.FS) error {
+	return AllPaths(ctx, pkgname, fsys,
+		func(path string, d fs.DirEntry) bool { return !d.IsDir() && filepath.Ext(path) == ".la" },
+		func(pkgname string, paths []string) string {
+			fileWord := "file"
+			if len(paths) > 1 {
+				fileWord = "files"
+			}
+			return fmt.Sprintf("%s contains %d libtool archive (.la) %s. Remove them in the build pipeline; if this package legitimately needs to ship .la files, disable this linter via checks.disabled", pkgname, len(paths), fileWord)
+		},
+	)
+}


### PR DESCRIPTION
`.la` files are generated by GNU libtool and are generally considered harmful to ship:
 * They encode hardcoded build-time paths that can break in different environments
 * They can cause double-linking of libraries
 * Modern linkers and `pkg-config` make them unnecessary for shared libraries
 * Debian, Fedora, and Arch all strip them during packaging

This linter will reject packages that ship those files.
As of 2026-05-07 , there are only 4 packages in chainguard that will need overrides for this.