### PR TITLE
fix maven configure

### DIFF
--- a/pkg/build/pipelines/maven/configure-mirror.yaml
+++ b/pkg/build/pipelines/maven/configure-mirror.yaml
@@ -30,7 +30,7 @@ pipeline:
               <id>google-maven-central</id>
               <name>GCS Maven Central mirror</name>
               <url>https://maven-central.storage-download.googleapis.com/maven2/</url>
-              <mirrorOf>*</mirrorOf>
+              <mirrorOf>central</mirrorOf>
             </mirror>
           </mirrors>
         </settings>

--- a/pkg/sca/sca.go
+++ b/pkg/sca/sca.go
@@ -718,6 +718,10 @@ func generateSharedObjectNameDeps(ctx context.Context, hdl SCAHandle, generated 
 			if setting.Key == "microsoft_systemcrypto" && setting.Value == "1" {
 				fipscrypto = true
 			}
+			// Geomys module
+			if setting.Key == "GOFIPS140" && setting.Value == "v1.0.0-c2097c7c" {
+				generated.Runtime = append(generated.Runtime, "NIST-CMVP-9999")
+			}
 		}
 		// strong indication of go-fips openssl compiled binary, will dlopen the below at runtime
 		if cgo && fipscrypto {


### PR DESCRIPTION
- **geomys**
  

- **fix(maven): mirror only Maven Central, not all repositories**
  The GCS-hosted mirror at maven-central.storage-download.googleapis.com
  only contains Maven Central artifacts. Using mirrorOf=* redirected
  every repository declared in a project's POM (Spring, JBoss,
  Confluent, Jitpack, Sonatype staging, etc.) to that bucket, causing
  404s for any artifact not on Maven Central. Restrict the mirror to
  mirrorOf=central so non-central repositories are reached at their
  real URLs.
  
  Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
  