### PR TITLE
chore: Bump go to 1.26.2

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -47,7 +47,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
-          version: v2.6.0
+          version: v2.12.2
           args: --timeout=5m --config="${{github.workspace}}/.golangci.yml"
 
       - run: |

--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ GOLANGCI_LINT_BIN = $(GOLANGCI_LINT_DIR)/golangci-lint
 setup-golangci-lint:
 	rm -f $(GOLANGCI_LINT_BIN) || :
 	set -e ;
-	GOBIN=$(GOLANGCI_LINT_DIR) go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.8.0;
+	GOBIN=$(GOLANGCI_LINT_DIR) go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2;
 
 .PHONY: fmt
 fmt: ## Format all go files

--- a/docs/cmd/pipeline-reference-gen/main.go
+++ b/docs/cmd/pipeline-reference-gen/main.go
@@ -127,7 +127,7 @@ func writeFile(path string, doc []*PipelineDoc) error {
 
 	// File doesn't exist, write as-is.
 	if os.IsNotExist(err) {
-		// #nosec G306 - Documentation file should be world-readable
+		// #nosec G306,G703 - Documentation file should be world-readable; path derived from pipeline-dir flag walked by filepath.Walk
 		return os.WriteFile(path, out.Bytes(), 0o644)
 	}
 
@@ -139,6 +139,6 @@ func writeFile(path string, doc []*PipelineDoc) error {
 	// Append to the end
 	content = append(content, out.Bytes()...)
 	fmt.Println("Wrote", path)
-	// #nosec G306 - Documentation file should be world-readable
+	// #nosec G306,G703 - Documentation file should be world-readable; path derived from pipeline-dir flag walked by filepath.Walk
 	return os.WriteFile(path, content, 0o644)
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module chainguard.dev/melange
 
-go 1.26.3
+go 1.26.2
 
 require (
 	chainguard.dev/apko v1.2.9

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module chainguard.dev/melange
 
-go 1.25.7
+go 1.26.3
 
 require (
 	chainguard.dev/apko v1.2.9

--- a/pkg/build/compiler_config.go
+++ b/pkg/build/compiler_config.go
@@ -62,7 +62,7 @@ func (b *Build) createGccSpecFile() error {
 func createClangConfigFile(outputPath string, includePaths ...string) error {
 	var content strings.Builder
 	for _, includePath := range includePaths {
-		content.WriteString(fmt.Sprintf("@%s\n", includePath))
+		fmt.Fprintf(&content, "@%s\n", includePath)
 	}
 
 	// #nosec G306 -- clang config files should be world-readable

--- a/pkg/container/qemu_runner.go
+++ b/pkg/container/qemu_runner.go
@@ -1671,7 +1671,7 @@ func sendSSHCommand(ctx context.Context, client *ssh.Client,
 
 func getUserSSHKey(ctx context.Context) ([]byte, error) {
 	socket := os.Getenv("SSH_AUTH_SOCK")
-	conn, err := net.Dial("unix", socket)
+	conn, err := net.Dial("unix", socket) // #nosec G704 - connecting to user's SSH agent socket from SSH_AUTH_SOCK is intentional
 	if err != nil {
 		clog.FromContext(ctx).Warnf("Failed to open SSH_AUTH_SOCK: %v, falling back to key search", err)
 		currentUser, err := user.Current()
@@ -2275,7 +2275,7 @@ func generateCpio(ctx context.Context, cfg *Config) (string, error) {
 	// Check for prebuilt initramfs via environment variable
 	if prebuiltPath := os.Getenv("QEMU_BASE_INITRAMFS"); prebuiltPath != "" {
 		// Validate file exists and is readable
-		if _, err := os.Stat(prebuiltPath); err != nil {
+		if _, err := os.Stat(prebuiltPath); err != nil { // #nosec G304,G703 - prebuilt initramfs path is intentionally user-configurable via env var
 			return "", fmt.Errorf("QEMU_BASE_INITRAMFS file not accessible: %w", err)
 		}
 		clog.FromContext(ctx).Infof("qemu: using prebuilt base initramfs from QEMU_BASE_INITRAMFS: %s", prebuiltPath)
@@ -2412,7 +2412,7 @@ func GenerateBaseInitramfs(ctx context.Context, arch apko_types.Architecture, cf
 // cpioContainsPath reports whether target exists as a record name in the CPIO
 // archive at cpioFile. CPIO record names are stored without a leading slash.
 func cpioContainsPath(cpioFile, target string) (bool, error) {
-	f, err := os.Open(cpioFile)
+	f, err := os.Open(cpioFile) // #nosec G304,G703 - cpio path is internally computed/cached, not user-supplied
 	if err != nil {
 		return false, err
 	}
@@ -2444,10 +2444,10 @@ func observabilityHookPresent(ctx context.Context, cpioFile string) bool {
 	sidecar := cpioFile + ".observability"
 
 	// Use the cached result when the sidecar is at least as new as the CPIO.
-	cpioInfo, cpioErr := os.Stat(cpioFile)
-	sidecarInfo, sidecarErr := os.Stat(sidecar)
+	cpioInfo, cpioErr := os.Stat(cpioFile)      // #nosec G304,G703 - cpio path is internally computed/cached
+	sidecarInfo, sidecarErr := os.Stat(sidecar) // #nosec G304,G703 - sidecar path is derived from cpioFile
 	if cpioErr == nil && sidecarErr == nil && !sidecarInfo.ModTime().Before(cpioInfo.ModTime()) {
-		data, err := os.ReadFile(sidecar)
+		data, err := os.ReadFile(sidecar) // #nosec G304,G703 - sidecar path is derived from cpioFile
 		if err == nil {
 			return strings.TrimSpace(string(data)) == "true"
 		}
@@ -2465,7 +2465,7 @@ func observabilityHookPresent(ctx context.Context, cpioFile string) bool {
 	if present {
 		val = "true"
 	}
-	if err := os.WriteFile(sidecar, []byte(val+"\n"), 0o600); err != nil {
+	if err := os.WriteFile(sidecar, []byte(val+"\n"), 0o600); err != nil { // #nosec G304,G703 - sidecar path is derived from cpioFile
 		clog.FromContext(ctx).Debugf("qemu: could not write observability sidecar: %v", err)
 	}
 	return present
@@ -2602,7 +2602,7 @@ func injectRuntimeData(ctx context.Context, cfg *Config, modulesDir, baseInitram
 		}
 	}()
 
-	baseFile, err := os.Open(baseInitramfs) // #nosec G304 - Reading base initramfs from cache
+	baseFile, err := os.Open(baseInitramfs) // #nosec G304,G703 - Reading base initramfs from cache or env-configured path
 	if err != nil {
 		return "", fmt.Errorf("failed to open base initramfs: %w", err)
 	}

--- a/pkg/http/http.go
+++ b/pkg/http/http.go
@@ -26,7 +26,7 @@ func (c *RLHTTPClient) Do(req *http.Request) (*http.Response, error) {
 			return nil, err
 		}
 	}
-	resp, err := c.Client.Do(req)
+	resp, err := c.Client.Do(req) // #nosec G107,G704 - URLs come from build configuration, not untrusted runtime input
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Also bump golangci lint and address new lint findings, as we retrieve the binary for performing lint and it must be built against the same or later minor version of go (also syncs the version used in CI with the version specified for local lints in our Makefile)