### PR TITLE
feat: Add variable substitution for licenses

### DIFF
--- a/docs/BUILD-FILE.md
+++ b/docs/BUILD-FILE.md
@@ -101,16 +101,35 @@ and which license applies to it) and may include the following fields:
 The license for either the package or part of the package (if there are multiple entries). It is important to note that only packages with OSI-approved licenses can be included in Wolfi. You can check the relevant package info in the licenses page at [opensource.org](https://opensource.org/licenses/).
 
 #### paths [optional]
-The license paths that this license applies to
+File globs (relative to the package root) that this license applies to.
+Defaults to `*` (the whole package). Use this when different parts of the
+package ship under different licenses:
+```yaml
+copyright:
+  - license: Apache-2.0
+    paths:
+      - "*"
+  - license: BSD-3-Clause
+    paths:
+      - "vendor/foo/**"
+```
 
 #### attestation [optional]
-Attestations for this license.
+Free-form attribution text appended to the package's copyright notice (for
+example, the upstream `NOTICE` contents):
+```yaml
+copyright:
+  - license: Apache-2.0
+    attestation: |
+      Copyright 2024 Example Corp.
+      Licensed under the Apache License, Version 2.0.
+```
 
-#### license-path
+#### license-path [optional]
 Path (relative to the build workspace) to a file containing the license
 text to embed in the SBOM. Required for non-SPDX `license` values. Supports
-`${{package.*}}` and `${{vars.*}}` substitution. Must stay within the
-workspace.
+`${{package.*}}` and `${{vars.*}}` substitution. License must stay within
+the workspace.
 
 #### detection-override [optional]
 Overrides the result of automatic license detection for the file referenced
@@ -123,15 +142,12 @@ copyright:
   - license: PSF-2.0
 ```
 
-A more complete example using `license-path` with a versioned directory:
+Another example using `license-path` with a versioned directory:
 ```yaml
 copyright:
   - license: CustomLicense
-    license-path: usr/share/doc/${{package.name}}-${{package.version}}/LICENSE
+    license-path: path/to/${{package.version}}/LICENSE
 ```
-
-  TODO(vaikas): Add attestation example (only found TODO)
-  TODO(vaikas): Add paths example (only found *)
 
 ### dependencies
 List of packages that this package depends on at runtime, but not during build

--- a/docs/BUILD-FILE.md
+++ b/docs/BUILD-FILE.md
@@ -94,8 +94,8 @@ Leaving this out defaults to `all`.
   TODO(vaikas): Saw something about riscv64. Does all include that?
 
 ### copyright
-List of copyrights for this package. Each entry in the list consists of 3
-fields that define the scope (paths, and which license applies to it):
+List of copyrights for this package. Each entry defines the scope (paths,
+and which license applies to it) and may include the following fields:
 
 #### license
 The license for either the package or part of the package (if there are multiple entries). It is important to note that only packages with OSI-approved licenses can be included in Wolfi. You can check the relevant package info in the licenses page at [opensource.org](https://opensource.org/licenses/).
@@ -103,13 +103,31 @@ The license for either the package or part of the package (if there are multiple
 #### paths [optional]
 The license paths that this license applies to
 
-#### attestation
+#### attestation [optional]
 Attestations for this license.
+
+#### license-path
+Path (relative to the build workspace) to a file containing the license
+text to embed in the SBOM. Required for non-SPDX `license` values. Supports
+`${{package.*}}` and `${{vars.*}}` substitution. Must stay within the
+workspace.
+
+#### detection-override [optional]
+Overrides the result of automatic license detection for the file referenced
+by `license-path`. Use this when the on-disk text is misidentified by the
+classifier but the declared `license` is known to be correct.
 
 For example, saying that this entire package has license `PSF-2.0`
 ```yaml
 copyright:
   - license: PSF-2.0
+```
+
+A more complete example using `license-path` with a versioned directory:
+```yaml
+copyright:
+  - license: CustomLicense
+    license-path: usr/share/doc/${{package.name}}-${{package.version}}/LICENSE
 ```
 
   TODO(vaikas): Add attestation example (only found TODO)

--- a/docs/BUILD-FILE.md
+++ b/docs/BUILD-FILE.md
@@ -100,6 +100,8 @@ and which license applies to it) and may include the following fields:
 #### license
 The license for either the package or part of the package (if there are multiple entries). It is important to note that only packages with OSI-approved licenses can be included in Wolfi. You can check the relevant package info in the licenses page at [opensource.org](https://opensource.org/licenses/).
 
+Supports variable substitution, which is useful for producing unique license references across version streamed packages.
+
 #### paths [optional]
 File globs (relative to the package root) that this license applies to.
 Defaults to `*` (the whole package). Use this when different parts of the
@@ -147,6 +149,18 @@ Another example using `license-path` with a versioned directory:
 copyright:
   - license: CustomLicense
     license-path: path/to/${{package.version}}/LICENSE
+```
+
+Variables in `license` are also substituted, which is helpful when the
+SPDX identifier itself is derived from a `var-transforms` rule (e.g.
+selecting `GPL-2.0-only` vs `GPL-3.0-only` based on the upstream version):
+```yaml
+vars:
+  license-version: "2.4"
+
+copyright:
+  - license: LicenseRef-SOME-LICENSE-${{vars.some-version}}
+    license-path: path/to/LICENSE
 ```
 
 ### dependencies

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1526,7 +1526,7 @@ func replaceCopyright(r *strings.Replacer, in []Copyright) []Copyright {
 		out[i] = Copyright{
 			Paths:             replaceAll(r, cp.Paths),
 			Attestation:       cp.Attestation,
-			License:           cp.License,
+			License:           r.Replace(cp.License),
 			LicensePath:       r.Replace(cp.LicensePath),
 			DetectionOverride: cp.DetectionOverride,
 		}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1517,6 +1517,23 @@ func replaceDependencies(r *strings.Replacer, in Dependencies) Dependencies {
 	}
 }
 
+func replaceCopyright(r *strings.Replacer, in []Copyright) []Copyright {
+	if in == nil {
+		return nil
+	}
+	out := make([]Copyright, len(in))
+	for i, cp := range in {
+		out[i] = Copyright{
+			Paths:             replaceAll(r, cp.Paths),
+			Attestation:       cp.Attestation,
+			License:           cp.License,
+			LicensePath:       r.Replace(cp.LicensePath),
+			DetectionOverride: cp.DetectionOverride,
+		}
+	}
+	return out
+}
+
 func replacePackage(r *strings.Replacer, commit string, in Package) Package {
 	return Package{
 		Name:               r.Replace(in.Name),
@@ -1527,7 +1544,7 @@ func replacePackage(r *strings.Replacer, commit string, in Package) Package {
 		URL:                r.Replace(in.URL),
 		Commit:             replaceCommit(commit, in.Commit),
 		TargetArchitecture: replaceAll(r, in.TargetArchitecture),
-		Copyright:          in.Copyright,
+		Copyright:          replaceCopyright(r, in.Copyright),
 		Dependencies:       replaceDependencies(r, in.Dependencies),
 		Options:            in.Options,
 		Scriptlets:         replaceScriptlets(r, in.Scriptlets),

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -2372,33 +2372,35 @@ func TestLicensingInfosMultipleLicenses(t *testing.T) {
 	})
 }
 
-// TestLicensePathVarSubstitution ensures that variable references in
-// copyright[].license-path are resolved during configuration parsing.
-func TestLicensePathVarSubstitution(t *testing.T) {
+// TestCopyrightVarSubstitution ensures that variable references in
+// copyright[].license and copyright[].license-path are resolved during
+// configuration parsing.
+func TestCopyrightVarSubstitution(t *testing.T) {
 	ctx := slogtest.Context(t)
 
-	fp := filepath.Join(os.TempDir(), "melange-test-license-path-vars")
+	fp := filepath.Join(os.TempDir(), "melange-test-copyright-vars")
 	if err := os.WriteFile(fp, []byte(`
 package:
-  name: license-path-vars
+  name: copyright-vars
   version: 1.2.3
   epoch: 0
-  description: test variable substitution in license-path
+  description: test variable substitution in copyright fields
   copyright:
-    - license: CustomLicense
+    - license: ${{vars.spdx-license}}
       license-path: licenses/${{package.name}}-${{package.version}}/LICENSE
-    - license: AnotherLicense
+    - license: LicenseRef-${{package.name}}
       license-path: ${{vars.license-dir}}/NOTICE
-    - license: ThirdLicense
+    - license: GPL-${{vars.short-version}}-only
       license-path: licenses/${{vars.short-version}}/COPYING
 
 vars:
+  spdx-license: Apache-2.0
   license-dir: share/doc
 
 var-transforms:
   - from: ${{package.version}}
-    match: ^(\d+\.\d+)\.\d+$
-    replace: "$1"
+    match: ^(\d+)\.\d+\.\d+$
+    replace: "$1.0"
     to: short-version
 `), 0o644); err != nil {
 		t.Fatal(err)
@@ -2409,9 +2411,12 @@ var-transforms:
 	}
 
 	require.Len(t, cfg.Package.Copyright, 3)
-	require.Equal(t, "licenses/license-path-vars-1.2.3/LICENSE", cfg.Package.Copyright[0].LicensePath)
+	require.Equal(t, "Apache-2.0", cfg.Package.Copyright[0].License)
+	require.Equal(t, "licenses/copyright-vars-1.2.3/LICENSE", cfg.Package.Copyright[0].LicensePath)
+	require.Equal(t, "LicenseRef-copyright-vars", cfg.Package.Copyright[1].License)
 	require.Equal(t, "share/doc/NOTICE", cfg.Package.Copyright[1].LicensePath)
-	require.Equal(t, "licenses/1.2/COPYING", cfg.Package.Copyright[2].LicensePath)
+	require.Equal(t, "GPL-1.0-only", cfg.Package.Copyright[2].License)
+	require.Equal(t, "licenses/1.0/COPYING", cfg.Package.Copyright[2].LicensePath)
 }
 
 func TestLineNumbersInError(t *testing.T) {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -2372,6 +2372,48 @@ func TestLicensingInfosMultipleLicenses(t *testing.T) {
 	})
 }
 
+// TestLicensePathVarSubstitution ensures that variable references in
+// copyright[].license-path are resolved during configuration parsing.
+func TestLicensePathVarSubstitution(t *testing.T) {
+	ctx := slogtest.Context(t)
+
+	fp := filepath.Join(os.TempDir(), "melange-test-license-path-vars")
+	if err := os.WriteFile(fp, []byte(`
+package:
+  name: license-path-vars
+  version: 1.2.3
+  epoch: 0
+  description: test variable substitution in license-path
+  copyright:
+    - license: CustomLicense
+      license-path: licenses/${{package.name}}-${{package.version}}/LICENSE
+    - license: AnotherLicense
+      license-path: ${{vars.license-dir}}/NOTICE
+    - license: ThirdLicense
+      license-path: licenses/${{vars.short-version}}/COPYING
+
+vars:
+  license-dir: share/doc
+
+var-transforms:
+  - from: ${{package.version}}
+    match: ^(\d+\.\d+)\.\d+$
+    replace: "$1"
+    to: short-version
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := ParseConfiguration(ctx, fp)
+	if err != nil {
+		t.Fatalf("failed to parse configuration: %s", err)
+	}
+
+	require.Len(t, cfg.Package.Copyright, 3)
+	require.Equal(t, "licenses/license-path-vars-1.2.3/LICENSE", cfg.Package.Copyright[0].LicensePath)
+	require.Equal(t, "share/doc/NOTICE", cfg.Package.Copyright[1].LicensePath)
+	require.Equal(t, "licenses/1.2/COPYING", cfg.Package.Copyright[2].LicensePath)
+}
+
 func TestLineNumbersInError(t *testing.T) {
 	ctx := slogtest.Context(t)
 


### PR DESCRIPTION
While working on a certain package, I realized that I couldn't use a variable to reflect the path to the license files in the workspace. This allows that, and adds relevant documentation

In addition to license paths, variables are now supported in licensed paths as well (the path within a package where the license applies). Variables are also supported in license names so that license refs can be truly unique per package stream

Also adds missing examples for attestations and paths