### PR TITLE
chore(e2e tests): pin 7zip build to gcc-15

### DIFF
--- a/pkg/build/testdata/build_configs/7zip-two-fetches.yaml
+++ b/pkg/build/testdata/build_configs/7zip-two-fetches.yaml
@@ -15,6 +15,7 @@ environment:
       - build-base
       - busybox
       - ca-certificates-bundle
+      - gcc-15-default
       - openssf-compiler-options
 
 pipeline:


### PR DESCRIPTION
Wolfi recently moved to gcc-16 by default, but that causes 7zip to FTBFS. Pin to using gcc-15 as the default compiler.

Ref: https://linear.app/chainguard/issue/PSEC-1015/
