### PR TITLE
go/build/v2: updated go/build pipeline

### DIFF
--- a/e2e-tests/git-dirty-detection-build.yaml
+++ b/e2e-tests/git-dirty-detection-build.yaml
@@ -9,7 +9,7 @@ package:
 environment:
   contents:
     packages:
-      - go
+      - go-1.26
       - git
   environment:
     CGO_ENABLED: "0"
@@ -44,10 +44,9 @@ pipeline:
       git commit -m "Initial commit"
 
   # Test 1: Clean repository should not have +dirty
-  - uses: go/build
+  - uses: go/build/v2
     with:
       modroot: hello-app
-      packages: .
       output: git-clean-binary
       ignore-untracked-files: false
 
@@ -68,10 +67,9 @@ pipeline:
       cd hello-app
       echo "// Modified tracked file" >> main.go
 
-  - uses: go/build
+  - uses: go/build/v2
     with:
       modroot: hello-app
-      packages: .
       output: git-modified-tracked-binary
       ignore-untracked-files: true
 
@@ -93,10 +91,9 @@ pipeline:
       git checkout -- main.go  # Reset to clean
       echo "untracked content" > untracked.txt
 
-  - uses: go/build
+  - uses: go/build/v2
     with:
       modroot: hello-app
-      packages: .
       output: git-untracked-not-ignored-binary
       ignore-untracked-files: false
 
@@ -113,10 +110,9 @@ pipeline:
       fi
 
   # Test 4: Same untracked file, ignore-untracked-files: true should NOT be +dirty
-  - uses: go/build
+  - uses: go/build/v2
     with:
       modroot: hello-app
-      packages: .
       output: git-untracked-ignored-binary
       ignore-untracked-files: true
 

--- a/e2e-tests/go-build-v2-build-test.yaml
+++ b/e2e-tests/go-build-v2-build-test.yaml
@@ -1,0 +1,40 @@
+package:
+  name: go-build-v2-build-test
+  version: "1.3.1"
+  epoch: 0
+  description: A simple, modern and secure encryption tool (and Go library) with small explicit keys, no config options, and UNIX-style composability.
+  copyright:
+    - license: BSD-3-Clause
+
+environment:
+  contents:
+    packages:
+      - go-1.26
+
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: https://github.com/FiloSottile/age.git
+      tag: v${{package.version}}
+      expected-commit: b8564adb6d58329b8a3e267360ca2b0abc4efe1d
+
+  - uses: go/build/v2
+    with:
+      packages: ./...
+      ldflags: -X main.Version=${{package.version}}
+
+test:
+  environment:
+    contents:
+      packages:
+        - busybox
+        - wolfi-baselayout
+  pipeline:
+    - runs: age --help
+    - runs: age-inspect --help
+    - runs: age-keygen --help
+    - runs: age-plugin-batchpass --help
+    - runs: age-plugin-pq --help
+    - runs: age-plugin-tag --help
+    - runs: age-plugin-tagpq --help
+    - runs: age-plugin-tagtest --help

--- a/pkg/build/pipelines/go/build/v2.yaml
+++ b/pkg/build/pipelines/go/build/v2.yaml
@@ -1,0 +1,129 @@
+name: Run a build using the go compiler
+
+needs:
+  packages:
+    - busybox
+    - ca-certificates-bundle
+
+inputs:
+  packages:
+    description: |
+      List of space-separated packages to compile. Files can also be specified.
+      This value is passed as an argument to go build. All paths are relative
+      to inputs.modroot. Can be multiple packages. Defaults to "." build current package. To build all packages use "./...".
+    default: "."
+
+  tags:
+    description: |
+      A comma-separated list of build tags to append to the go compiler
+
+  toolchaintags:
+    description: |
+      A comma-separated list of default toolchain go build tags
+    default: "netgo,osusergo"
+
+  output:
+    description: |
+      Filename to use when writing the binary. The final install location inside
+      the apk will be in prefix / install-dir / output. This is optional, by default the name of the package is used.
+    default: ""
+
+  vendor:
+    description: |
+      If true, the go mod command will also update the vendor directory
+    default: "false"
+
+  modroot:
+    default: "."
+    required: false
+    description: |
+      Top directory of the go module, this is where go.mod lives. Before buiding
+      the go pipeline wil cd into this directory.
+
+  prefix:
+    description: |
+      Prefix to relocate binaries
+    default: usr
+
+  ldflags:
+    description: |
+      List of [pattern=]arg to append to the go compiler with -ldflags
+
+  strip:
+    description: |
+      Set of strip ldflags passed to the go compiler
+    # Note symbols tables are useful for cryptography audits and govulncheck
+    default: "-w"
+
+  install-dir:
+    description: |
+      Directory where binaries will be installed
+    default: bin
+
+  experiments:
+    description: |
+      A comma-separated list of Golang experiment names (ex: loopvar) to use
+      when building the binary.
+    default: ""
+
+  extra-args:
+    description: |
+      A space-separated list of extra arguments to pass to the go build command.
+    default: ""
+
+  amd64:
+    description: |
+      GOAMD64 microarchitecture level to use
+    default: "v2"
+
+  arm64:
+    description: |
+      GOARM64 microarchitecture level to use
+    default: "v8.0"
+
+  buildmode:
+    description: |
+      The -buildmode flag value. See "go help buildmode" for more information.
+    default: "default"
+
+  ignore-untracked-files:
+    description: |
+      If true, we will provide a gitignore that ignore all untracked files.
+    default: "true"
+
+pipeline:
+  - runs: |
+
+      # We sometimes have stray files in our build environment
+      # That we don't neccesarily want surfaced in the build version
+      if [ "${{inputs.ignore-untracked-files}}" = "true" ]; then
+        mkdir -p ~/.config/git/
+        touch ~/.config/git/ignore
+        cp ~/.config/git/ignore ~/.config/git/ignore.bak
+        echo '**' > ~/.config/git/ignore
+      fi
+
+      cd "${{inputs.modroot}}"
+
+      # check if modroot is set correctly by checking go.mod file exist
+      if [ ! -e go.mod ]; then
+        echo "go.mod not found in ${{inputs.modroot}}"
+        exit 1
+      fi
+
+      LDFLAGS="${{inputs.strip}} ${{inputs.ldflags}}"
+
+      BASE_PATH="${{inputs.prefix}}/${{inputs.install-dir}}/${{inputs.output}}"
+
+      # Take advantage of melange's buid cache for downloaded modules
+      export GOMODCACHE=/var/cache/melange/gomodcache
+
+      GOAMD64="${{inputs.amd64}}" GOARM64="${{inputs.arm64}}" GOEXPERIMENT="${{inputs.experiments}}" go build -o "${{targets.contextdir}}"/${BASE_PATH} -tags "${{inputs.toolchaintags}},${{inputs.tags}}" -ldflags "${LDFLAGS}" -trimpath -buildmode ${{inputs.buildmode}} ${{inputs.extra-args}} ${{inputs.packages}}
+
+      # Clean up the gitignore file we created to avoid interfering with subsequent builds
+      if [ "${{inputs.ignore-untracked-files}}" = "true" ]; then
+        mv ~/.config/git/ignore.bak ~/.config/git/ignore
+      fi
+
+  # Strip go binaries by default
+  - uses: strip


### PR DESCRIPTION
Do all the things I dreamed to do:
- do not require to specify packages, defaulting to "."
- allow building multiple packages or even all of them with "./..."
- make output optional, now that by default the same name of the binary as the package is used and multiple packages can be built
- drop the deps updates, instead use go/bump or omnibump pipelines
- drop the tidy key, now that deps are not updated tidy is not needed either
- drop go-package, instead set preffered go toolchain in environment
- drop build-base dependency, purego builds are now faster
- drop support for go.mod.local/go.sum.local overlays
- always strip resulting binaries

Welcome to go/build/v2!
