### PR TITLE
feat(pipelines/xcover): add include-functions

### DIFF
--- a/.github/workflows/go-tests.yaml
+++ b/.github/workflows/go-tests.yaml
@@ -33,6 +33,7 @@ jobs:
             git.sv.gnu.org:9418
             github.com:443
             go.dev:443
+            https.git.savannah.gnu.org:443
             motd.ubuntu.com:443
             objects.githubusercontent.com:443
             packages.microsoft.com:443

--- a/e2e-tests/xcover-nopkg-test.yaml
+++ b/e2e-tests/xcover-nopkg-test.yaml
@@ -19,6 +19,7 @@ test:
     - uses: xcover/profile
       with:
         executable-path: /usr/bin/crane
+        include-functions: ^github\\.com/google/go-containerregistry
         exclude-functions: ^runtime\\.
     - runs: |
         crane version || exit 1

--- a/pkg/build/pipelines/xcover/README.md
+++ b/pkg/build/pipelines/xcover/README.md
@@ -29,6 +29,7 @@ Start the coverage profile with the xcover tool
 | ---- | -------- | ----------- | ------- |
 | exclude-functions | false | The function symbols to exclude from profiling as a regular expression. |  |
 | executable-path | true | The path to the executable of the application to test. |  |
+| include-functions | false | The function symbols to include in profiling as a regular expression. When set, only matching symbols are profiled. |  |
 | log-level | false | The log level of the xcover profile command. | info |
 | package | false | The xcover package | xcover |
 | verbose | false | Enable verbosity of the xcover profile command. It prints out all the functions being traced real-time. | false |

--- a/pkg/build/pipelines/xcover/profile.yaml
+++ b/pkg/build/pipelines/xcover/profile.yaml
@@ -16,6 +16,9 @@ inputs:
   exclude-functions:
     description: The function symbols to exclude from profiling as a regular expression.
     required: false
+  include-functions:
+    description: The function symbols to include in profiling as a regular expression. When set, only matching symbols are profiled.
+    required: false
   log-level:
     description: The log level of the xcover profile command.
     required: false
@@ -35,7 +38,8 @@ pipeline:
       # Run profile in background.
       xcover run \
         --path ${{inputs.executable-path}} \
-        --exclude ${{inputs.exclude-functions}} \
+        --exclude=${{inputs.exclude-functions}} \
+        --include=${{inputs.include-functions}} \
         --log-level=${{inputs.log-level}} \
         --verbose=${{inputs.verbose}} \
         --status \


### PR DESCRIPTION
### Functional Changes

It is not a functional change per se in Melange, but in a Melange pipeline `xcover/profile`.
`--include-functions` xcover flag allows to filter functions to be traced. This PR adds support to the as new parameter.

### Additional changes

This PR also updates the egress policy for the GitHub runner hardening in order to run the integration tests.
This is not something this PR introduces but apparently the HTTPS RR DNS request was blocked before (https.git.savannah.gnu.org) for the integration tests on the package `sed`.
