### PR TITLE
ci: allow production.cloudfront.docker.com in harden-runner egress

### DIFF
--- a/.github/workflows/melange-test-pipelines.yaml
+++ b/.github/workflows/melange-test-pipelines.yaml
@@ -93,6 +93,7 @@ jobs:
             packages.wolfi.dev:443
             ppa.launchpadcontent.net:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             proxy.golang.org:443
             pypi.org:443
             raw.githubusercontent.com:443

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,6 +35,7 @@ jobs:
             index.docker.io:443
             objects.githubusercontent.com:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             proxy.golang.org:443
             raw.githubusercontent.com:443
             rekor.sigstore.dev:443


### PR DESCRIPTION
Docker Hub serves image blobs from a CDN, and sometimes uses CloudFront (production.cloudfront.docker.com) in addition to the Cloudflare endpoint already allowlisted. Docker changed this recently (see Docker Hub release notes, ~a week ago: https://docs.docker.com/docker-hub/release-notes/), which is why crane pulls of Docker Hub images (e.g. chainguard/static in the e2e xcover test) started failing harden-runner egress with:

  dial tcp: lookup production.cloudfront.docker.com ... i/o timeout

Same CloudFront usage was observed in mono CI, and fixed here:
https://github.com/chainguard-dev/mono/pull/41186

Add production.cloudfront.docker.com:443 to the egress allowlist in the Test packages (e2e) and release jobs, alongside the existing Cloudflare endpoint.

## Melange Pull Request Template

<!--
*** PULL REQUEST CHECKLIST: PLEASE START HERE ***

The single most important feature of melange is that we can build Wolfi.

Many changes to melange introduce a risk of breaking the build, and sometimes
these are not flushed out until a package is changed (much) later.  This
pertains to basic execution, SCA changes, linter changes, and more.
-->

### Functional Changes

- [ ] This change can build all of Wolfi without errors (describe results in notes)

Notes:

### SCA Changes

- [ ] Examining several representative APKs show no regression / the desired effect (details in notes)

Notes:

### Linter

- [ ] The new check is clean across Wolfi
- [ ] The new check is opt-in or a warning

Notes:
