### PR TITLE
git-checkout: guard branch+expected-commit against stale/diverged commits

### DIFF
--- a/e2e-tests/git-checkout-build.yaml
+++ b/e2e-tests/git-checkout-build.yaml
@@ -173,6 +173,27 @@ pipeline:
       cd ..
       rm -R branch-tip-expected
 
+  # a specific commit with no branch and no tag (the shape used by packages
+  # that pin an upstream commit directly, e.g. eco-python-llvm-triton pinning
+  # an llvm-project commit). With depth: -1 the full history is present, so the
+  # ancestry-guarded reset to the (older, on-default-branch) commit succeeds.
+  # 0007b4c is an older commit on the fixture's default branch.
+  - name: "expected commit, no branch"
+    working-directory: commit-no-branch
+    uses: git-checkout
+    with:
+      repository: ${{vars.giturl}}
+      expected-commit: 0007b4cdf2358e7d9b0d774baf5cba9f862c023b
+      depth: -1
+
+  - name: "check expected commit, no branch"
+    working-directory: commit-no-branch
+    runs: |
+      hash=$(git rev-parse --verify HEAD)
+      [ "$hash" = 0007b4cdf2358e7d9b0d774baf5cba9f862c023b ]
+      cd ..
+      rm -R commit-no-branch
+
   # for an annotated tag you can point to either the commit
   # or the tag object hash object
   - name: "annotated hash"

--- a/e2e-tests/git-checkout-build.yaml
+++ b/e2e-tests/git-checkout-build.yaml
@@ -153,6 +153,26 @@ pipeline:
       cd ..
       rm -R branch-old-expected
 
+  # expected-commit-is-branch-tip: when the expected-commit IS the current tip
+  # of the branch, the checkout succeeds (the branch is treated as an immutable
+  # release pointer).  4b1593d is the current tip of the 1.x branch.
+  - name: "branch tip with expected-commit-is-branch-tip"
+    working-directory: branch-tip-expected
+    uses: git-checkout
+    with:
+      repository: ${{vars.giturl}}
+      branch: 1.x
+      expected-commit: 4b1593d8d8038f8c0ce1e2c608c9dd89066a2a0f
+      expected-commit-is-branch-tip: true
+
+  - name: "check branch tip with expected-commit-is-branch-tip"
+    working-directory: branch-tip-expected
+    runs: |
+      hash=$(git rev-parse --verify HEAD)
+      [ "$hash" = 4b1593d8d8038f8c0ce1e2c608c9dd89066a2a0f ]
+      cd ..
+      rm -R branch-tip-expected
+
   # for an annotated tag you can point to either the commit
   # or the tag object hash object
   - name: "annotated hash"

--- a/e2e-tests/git-checkout-build.yaml
+++ b/e2e-tests/git-checkout-build.yaml
@@ -156,6 +156,11 @@ pipeline:
   # expected-commit-is-branch-tip: when the expected-commit IS the current tip
   # of the branch, the checkout succeeds (the branch is treated as an immutable
   # release pointer).  4b1593d is the current tip of the 1.x branch.
+  #
+  # The flag is verification-only and must not change the clone depth.  With no
+  # explicit depth, branch + expected-commit-is-branch-tip defaults to a shallow
+  # (depth 1) clone -- we only compare against the tip -- so 'git show HEAD^'
+  # must fail here.
   - name: "branch tip with expected-commit-is-branch-tip"
     working-directory: branch-tip-expected
     uses: git-checkout
@@ -170,8 +175,69 @@ pipeline:
     runs: |
       hash=$(git rev-parse --verify HEAD)
       [ "$hash" = 4b1593d8d8038f8c0ce1e2c608c9dd89066a2a0f ]
+      if out=$(git show HEAD^ 2>&1); then
+          echo "FAIL: expected a shallow clone (depth 1) but 'git show HEAD^' succeeded"
+          echo "git show HEAD^ output: $out"
+          exit 1
+      fi
       cd ..
       rm -R branch-tip-expected
+
+  # ...with an explicit depth: -1 it must still produce a full clone (some
+  # builds need history), so 'git show HEAD^' must succeed.
+  - name: "branch tip with expected-commit-is-branch-tip, depth -1"
+    working-directory: branch-tip-full
+    uses: git-checkout
+    with:
+      repository: ${{vars.giturl}}
+      branch: 1.x
+      expected-commit: 4b1593d8d8038f8c0ce1e2c608c9dd89066a2a0f
+      expected-commit-is-branch-tip: true
+      depth: -1
+
+  - name: "check branch tip with expected-commit-is-branch-tip, depth -1"
+    working-directory: branch-tip-full
+    runs: |
+      hash=$(git rev-parse --verify HEAD)
+      [ "$hash" = 4b1593d8d8038f8c0ce1e2c608c9dd89066a2a0f ]
+      out=$(git show HEAD^ 2>&1) || {
+          echo "FAIL: expected a full clone (depth -1) but 'git show HEAD^' failed"
+          echo "git show HEAD^ output: $out"
+          exit 1
+      }
+      cd ..
+      rm -R branch-tip-full
+
+  # ...with an explicit finite depth it honors that depth: a depth-2 clone of
+  # 1.x has the tip and its parent but nothing beyond, so 'git show HEAD^'
+  # succeeds while 'git show HEAD~2' fails.
+  - name: "branch tip with expected-commit-is-branch-tip, partial depth"
+    working-directory: branch-tip-partial
+    uses: git-checkout
+    with:
+      repository: ${{vars.giturl}}
+      branch: 1.x
+      expected-commit: 4b1593d8d8038f8c0ce1e2c608c9dd89066a2a0f
+      expected-commit-is-branch-tip: true
+      depth: 2
+
+  - name: "check branch tip with expected-commit-is-branch-tip, partial depth"
+    working-directory: branch-tip-partial
+    runs: |
+      hash=$(git rev-parse --verify HEAD)
+      [ "$hash" = 4b1593d8d8038f8c0ce1e2c608c9dd89066a2a0f ]
+      out=$(git show HEAD^ 2>&1) || {
+          echo "FAIL: depth 2 should include HEAD^ but 'git show HEAD^' failed"
+          echo "git show HEAD^ output: $out"
+          exit 1
+      }
+      if out=$(git show HEAD~2 2>&1); then
+          echo "FAIL: depth 2 should not include HEAD~2 but 'git show HEAD~2' succeeded"
+          echo "git show HEAD~2 output: $out"
+          exit 1
+      fi
+      cd ..
+      rm -R branch-tip-partial
 
   # a specific commit with no branch and no tag (the shape used by packages
   # that pin an upstream commit directly, e.g. eco-python-llvm-triton pinning

--- a/pkg/build/pipelines/README.md
+++ b/pkg/build/pipelines/README.md
@@ -59,6 +59,7 @@ Check out sources from git
 | depth | false | The depth to use when cloning. Use -1 to get full branch history. If 'branch' and 'expected-commit' are provided the default is -1. Otherwise, default is to use '1' (shallow clone).  | unset |
 | destination | false | The path to check out the sources to.  | . |
 | expected-commit | false | The expected commit hash  |  |
+| expected-commit-is-branch-tip | false | When "true", require that expected-commit exactly matches the tip of the checked-out branch instead of allowing any older commit on the branch.  Use this when a branch is used as an immutable release pointer (e.g. version-named release branches) so that a stale expected-commit -- for example after bumping the version but forgetting to update the commit -- fails loudly instead of silently checking out old code. Only valid together with 'branch'; mutually exclusive with 'tag'.  | false |
 | initial-backoff | false | Initial backoff duration in seconds before first retry.  | 2 |
 | max-backoff | false | Maximum backoff duration in seconds between retries.  | 60 |
 | max-retries | false | Maximum number of retry attempts for git clone operation on failure.  | 3 |

--- a/pkg/build/pipelines/git-checkout.yaml
+++ b/pkg/build/pipelines/git-checkout.yaml
@@ -300,7 +300,7 @@ pipeline:
           if [ "$depth" = "unset" ]; then
             depth=1
             if [ -n "$branch" ] && [ -n "$expcommit" ] &&
-                [ "$expected_commit_is_branch_tip" != "true" ]; then
+                [ "$expected_commit_is_branch_tip" = "false" ]; then
               # if we're just checking out a specific commit on a branch
               # then we need to get history, otherwise it will break
               # if the expected commit is not tip of the branch.

--- a/pkg/build/pipelines/git-checkout.yaml
+++ b/pkg/build/pipelines/git-checkout.yaml
@@ -30,6 +30,16 @@ inputs:
   expected-commit:
     description: |
       The expected commit hash
+  expected-commit-is-branch-tip:
+    description: |
+      When "true", require that expected-commit exactly matches the tip of
+      the checked-out branch instead of allowing any older commit on the
+      branch.  Use this when a branch is used as an immutable release pointer
+      (e.g. version-named release branches) so that a stale expected-commit --
+      for example after bumping the version but forgetting to update the
+      commit -- fails loudly instead of silently checking out old code.
+      Only valid together with 'branch'; mutually exclusive with 'tag'.
+    default: "false"
   recurse-submodules:
     description: |
       Indicates whether --recurse-submodules should be passed to git clone.
@@ -232,11 +242,13 @@ pipeline:
           local cherry_pick="$8" sparse_paths="$9"
           local max_retries="${10:-3}" initial_backoff="${11:-2}" max_backoff="${12:-60}"
           local shallow_submodules="${13:-false}" submodule_jobs="${14:-1}"
+          local expected_commit_is_branch_tip="${15:-false}"
           msg "repo='$repo' dest='$dest' depth='$depth' branch='$branch'" \
               "tag='$tag' expcommit='$expcommit' recurse='$recurse'" \
               "sparse_paths='$sparse_paths' max_retries='$max_retries'" \
               "initial_backoff='$initial_backoff' max_backoff='$max_backoff'" \
-              "shallow_submodules='$shallow_submodules' submodule_jobs='$submodule_jobs'"
+              "shallow_submodules='$shallow_submodules' submodule_jobs='$submodule_jobs'" \
+              "expected_commit_is_branch_tip='$expected_commit_is_branch_tip'"
 
           case "$recurse" in
               true|false) :;;
@@ -246,6 +258,11 @@ pipeline:
               true|false) :;;
               *) fail "shallow_submodules must be true or false, not '$shallow_submodules'"
           esac
+          case "$expected_commit_is_branch_tip" in
+              true|false) :;;
+              *) fail "expected-commit-is-branch-tip must be true or false," \
+                      "not '$expected_commit_is_branch_tip'"
+          esac
 
           [ -n "$repo" ] || fail "repository not provided"
 
@@ -253,6 +270,17 @@ pipeline:
               msg "Warning: you have not specified a branch or tag."
           elif [ -n "$branch" ] && [ -n "$tag" ]; then
               fail "both branch ($branch) and tag ($tag) are specified."
+          fi
+
+          if [ "$expected_commit_is_branch_tip" = "true" ]; then
+              [ -z "$tag" ] ||
+                  fail "expected-commit-is-branch-tip is only valid with" \
+                       "'branch', not 'tag'."
+              [ -n "$branch" ] ||
+                  fail "expected-commit-is-branch-tip requires 'branch' to be set."
+              [ -n "$expcommit" ] ||
+                  fail "expected-commit-is-branch-tip requires 'expected-commit'" \
+                       "to be set."
           fi
 
           [ -n "$expcommit" ] ||
@@ -271,10 +299,13 @@ pipeline:
 
           if [ "$depth" = "unset" ]; then
             depth=1
-            if [ -n "$branch" ] && [ -n "$expcommit" ]; then
+            if [ -n "$branch" ] && [ -n "$expcommit" ] &&
+                [ "$expected_commit_is_branch_tip" != "true" ]; then
               # if we're just checking out a specific commit on a branch
               # then we need to get history, otherwise it will break
               # if the expected commit is not tip of the branch.
+              # (when expected-commit-is-branch-tip is set we only compare
+              # against the tip, so a shallow clone is sufficient.)
               depth=-1
             fi
           fi
@@ -323,10 +354,30 @@ pipeline:
           if [ -z "$tag" ]; then
               foundcommit=$(git rev-parse --verify HEAD)
               if [ -n "$expcommit" ] && [ "$expcommit" != "$foundcommit" ]; then
-                  if [ "$depth" = "-1" ]; then
-                      msg "expected commit $expcommit on ${branch:-HEAD}," \
-                          "got $foundcommit, performing reset"
-                      vr git reset --hard "$expcommit"
+                  if [ "$expected_commit_is_branch_tip" = "true" ]; then
+                      # the branch is being used as an immutable release
+                      # pointer, so expected-commit must be its tip exactly.
+                      fail "expected-commit $expcommit is not the tip of branch" \
+                           "${branch:-HEAD} ($foundcommit); the branch advanced" \
+                           "or the version was bumped without updating" \
+                           "expected-commit"
+                  elif [ "$depth" = "-1" ]; then
+                      # depth=-1 is a full clone, so $foundcommit (the branch
+                      # tip) has its complete history present.  Only reset to
+                      # $expcommit if it is reachable from the tip; otherwise it
+                      # belongs to a different/diverged branch and resetting
+                      # would silently build stale code (e.g. the branch was
+                      # bumped but expected-commit was not).
+                      if git merge-base --is-ancestor "$expcommit" "$foundcommit"; then
+                          msg "expected commit $expcommit on ${branch:-HEAD}," \
+                              "got $foundcommit, performing reset"
+                          vr git reset --hard "$expcommit"
+                      else
+                          fail "expected commit $expcommit is not reachable from" \
+                               "${branch:-HEAD} (tip $foundcommit); the branch may" \
+                               "have diverged from the pinned commit -- update" \
+                               "expected-commit"
+                      fi
                   else
                       fail "expected commit $expcommit on ${branch:-HEAD}," \
                            "got $foundcommit, set depth to -1 to attempt a reset"
@@ -390,6 +441,7 @@ pipeline:
           "${{inputs.sparse-paths}}" \
           "${{inputs.max-retries}}" "${{inputs.initial-backoff}}" \
           "${{inputs.max-backoff}}" \
-          "${{inputs.shallow-submodules}}" "${{inputs.submodule-jobs}}"
+          "${{inputs.shallow-submodules}}" "${{inputs.submodule-jobs}}" \
+          "${{inputs.expected-commit-is-branch-tip}}"
 
       rm -f "$cpickf"


### PR DESCRIPTION
## Problem

Some upstreams publish releases by advancing a **version-named branch** rather
than cutting tags — the branch *is* the release marker (e.g. `stable/cinc-vX.Y`,
`rNN.NN`, `MAJOR.MINOR.x`). Packages tracking those upstreams use `git-checkout`
with `branch:` + `expected-commit:` instead of `tag:`.

In that mode the pipeline's no-tag (branch) path is a silent-correctness
footgun. When both `branch` and `expected-commit` are set, `depth` defaults to
`-1` (a full clone of all branches/objects), and the pipeline does
`git reset --hard $expected-commit` to whatever object the clone contains —
with no check that the commit is actually on the named branch. So a stale or
foreign `expected-commit` (e.g. the version was bumped, moving a templated
branch, but the commit wasn't updated) silently builds the wrong source
instead of failing.

## Fix

Two complementary safeguards in the no-tag path:

1. **Default-on ancestry guard** — before the reset, require `expected-commit`
   to be reachable from the branch tip (`git merge-base --is-ancestor`). A
   commit that isn't on the branch now fails loudly. Pinning an *older* commit
   that is genuinely on the branch still works.
2. **Opt-in `expected-commit-is-branch-tip: true`** — require `expected-commit`
   to equal the branch tip exactly, for branches used as immutable release
   pointers (the branch-as-release-marker case above). Mutually exclusive with
   `tag`; keeps the clone shallow since no reset is needed.

## Tests

Added e2e positive cases for both behaviors in `git-checkout-build.yaml`; the
existing "branch with old expected" case already covers the older-on-branch
path of the ancestry guard.

## Notes

A scan of downstream package configs found several packages silently building
the wrong source under this footgun (branch bumped, commit left stale); this
guard surfaces them as loud failures.

v2: fix missing documentation for added git-checkout pipeline option.

Refs: [PSEC-1093]

🤖 Generated with [Claude Code](https://claude.com/claude-code)
