### PR TITLE
chore(pipelines/xcover): add scope parameter

### DIFF
--- a/e2e-tests/xcover-nopkg-test.yaml
+++ b/e2e-tests/xcover-nopkg-test.yaml
@@ -7,7 +7,6 @@ package:
 capabilities:
   add:
     - CAP_SYS_ADMIN
-    - CAP_SYS_RESOURCE
 
 test:
   environment:

--- a/e2e-tests/xcover-project-scope-nopkg-test.yaml
+++ b/e2e-tests/xcover-project-scope-nopkg-test.yaml
@@ -1,0 +1,52 @@
+package:
+  name: crane
+  version: "0.20.3"
+  epoch: 3
+  description: Tests the xcover project function scope on a Go binary
+
+capabilities:
+  add:
+    - CAP_SYS_ADMIN
+
+test:
+  environment:
+    contents:
+      packages:
+        - jq
+        - crane
+  pipeline:
+    - uses: xcover/profile
+      with:
+        executable-path: /usr/bin/crane
+        scope: project
+    - runs: |
+        crane version || exit 1
+        crane --help
+    - runs: |
+        crane manifest chainguard/static | jq '.schemaVersion' | grep '2' || exit 1
+    - runs: |
+        crane ls chainguard/static | grep -E 'latest|v[0-9]+.[0-9]+.[0-9]+' || exit 1
+    - runs: |
+        crane digest chainguard/static:latest && echo "Image exists" || exit 1
+    - runs: |
+        crane pull chainguard/static:latest static_latest.tar || exit 1
+        [ -f static_latest.tar ] || exit 1
+    - uses: xcover/stop
+    - runs: |
+        # Project scope must keep only crane's own Go module functions
+        # (github.com/google/go-containerregistry/...) plus root main.* funcs.
+        # Any Go stdlib or third-party dependency symbol means scope leaked,
+        # i.e. the pipeline did not actually apply scope=project.
+        mod="github.com/google/go-containerregistry"
+        jq -r '.funcs_traced[]' xcover-report.json > traced.txt
+        [ -s traced.txt ] || { echo "no functions traced"; exit 1; }
+        leaked=$(grep -vE "^(main\\.|${mod}[/.])" traced.txt || true)
+        if [ -n "$leaked" ]; then
+          echo "project scope leaked non-project functions:"
+          echo "$leaked" | head -20
+          exit 1
+        fi
+        echo "all $(wc -l < traced.txt) traced functions are project-scoped"
+    - uses: xcover/ensure
+      with:
+        min-coverage: 10

--- a/examples/test-xcover.yaml
+++ b/examples/test-xcover.yaml
@@ -40,7 +40,6 @@ update:
 capabilities:
   add:
     - CAP_SYS_ADMIN
-    - CAP_SYS_RESOURCE
 
 test:
   environment:

--- a/pkg/build/pipelines/xcover/README.md
+++ b/pkg/build/pipelines/xcover/README.md
@@ -32,6 +32,7 @@ Start the coverage profile with the xcover tool
 | include-functions | false | The function symbols to include in profiling as a regular expression. When set, only matching symbols are profiled. |  |
 | log-level | false | The log level of the xcover profile command. | info |
 | package | false | The xcover package | xcover |
+| scope | false | The function scope to profile: "binary" (all functions) or "project" (project module only). The "project" scope is only supported by Go binaries and is a no-op for others. | project |
 | verbose | false | Enable verbosity of the xcover profile command. It prints out all the functions being traced real-time. | false |
 | wait-timeout | false | The maximum amount of time to wait for the xcover profiler to be ready for profiling, in seconds. | 60 |
 

--- a/pkg/build/pipelines/xcover/profile.yaml
+++ b/pkg/build/pipelines/xcover/profile.yaml
@@ -19,6 +19,10 @@ inputs:
   include-functions:
     description: The function symbols to include in profiling as a regular expression. When set, only matching symbols are profiled.
     required: false
+  scope:
+    description: 'The function scope to profile: "binary" (all functions) or "project" (project module only). The "project" scope is only supported by Go binaries and is a no-op for others.'
+    required: false
+    default: project
   log-level:
     description: The log level of the xcover profile command.
     required: false
@@ -40,6 +44,7 @@ pipeline:
         --path ${{inputs.executable-path}} \
         --exclude=${{inputs.exclude-functions}} \
         --include=${{inputs.include-functions}} \
+        --scope=${{inputs.scope}} \
         --log-level=${{inputs.log-level}} \
         --verbose=${{inputs.verbose}} \
         --status \


### PR DESCRIPTION
### Functional Changes

This PR updates the xcover/profile pipeline by adding the new scope parameter.

The scope profile parameter allows to scope the tracing to just the project functions.

#### Support

It is now supported for Go binaries, scoping to the Go module by default using the .go.buildinfo ELF section as source of truth for filtering based on symbol prefix.

### SCA Changes

- [ ] Examining several representative APKs show no regression / the desired effect (details in notes)

Notes:

### Linter

- [ ] The new check is clean across Wolfi
- [ ] The new check is opt-in or a warning

Notes:
