### PR TITLE
fix(renovate): bump git-checkout regardless of tag if there is only one

### DIFF
--- a/pkg/renovate/bump/bump.go
+++ b/pkg/renovate/bump/bump.go
@@ -149,8 +149,23 @@ func New(ctx context.Context, opts ...Option) renovate.Renovator {
 			RecurseNodes().
 			Filter(yit.WithMapValue("git-checkout"))
 
+		var gitCheckoutNodes []*yaml.Node
 		for gitCheckoutNode, ok := it(); ok; gitCheckoutNode, ok = it() {
-			if err := updateGitCheckout(ctx, rc.Configuration, gitCheckoutNode, bcfg.ExpectedCommit); err != nil {
+			gitCheckoutNodes = append(gitCheckoutNodes, gitCheckoutNode)
+		}
+
+		for _, gitCheckoutNode := range gitCheckoutNodes {
+			// When there are multiple git-checkout nodes, only bump the ones
+			// whose tag is derived from package.version. With a single
+			// git-checkout node, always bump it regardless of its tag.
+			if versioned, err := gitCheckoutDependsOnVersion(rc.Configuration, gitCheckoutNode); err != nil {
+				return err
+			} else if len(gitCheckoutNodes) > 1 && !versioned {
+				log.Infof("Skipping git-checkout node as tag is not derived from package.version")
+				continue
+			}
+
+			if err := updateGitCheckout(ctx, gitCheckoutNode, bcfg.ExpectedCommit); err != nil {
 				return err
 			}
 		}
@@ -220,23 +235,32 @@ func updateFetch(ctx context.Context, rc *renovate.RenovationContext, node *yaml
 	return nil
 }
 
+// gitCheckoutDependsOnVersion reports whether a "git-checkout" pipeline node's
+// tag is derived from package.version. If there is no tag (e.g. a branch-only
+// checkout), it returns true since branches are often built from main and
+// should not be skipped.
+func gitCheckoutDependsOnVersion(cfg *config.Configuration, node *yaml.Node) (bool, error) {
+	withNode, err := renovate.NodeFromMapping(node, "with")
+	if err != nil {
+		return false, err
+	}
+
+	// If a tag is present, check whether it contains a version substitution.
+	tag, tagErr := renovate.NodeFromMapping(withNode, "tag")
+	if tagErr == nil {
+		return dependsOnVersion(tag.Value, cfg), nil
+	}
+
+	return true, nil
+}
+
 // updateGitCheckout takes a "git-checkout" pipeline node and updates the parameters of it.
-func updateGitCheckout(ctx context.Context, cfg *config.Configuration, node *yaml.Node, expectedGitSha string) error {
+func updateGitCheckout(ctx context.Context, node *yaml.Node, expectedGitSha string) error {
 	log := clog.FromContext(ctx)
 
 	withNode, err := renovate.NodeFromMapping(node, "with")
 	if err != nil {
 		return err
-	}
-
-	// If a tag is present, check it contains a version substitution.
-	// If it doesn't depend on package.version, skip updating.
-	// If there is no tag (e.g. branch-only checkout), always update since
-	// branches are often built from main and should not be skipped.
-	tag, tagErr := renovate.NodeFromMapping(withNode, "tag")
-	if tagErr == nil && !dependsOnVersion(tag.Value, cfg) {
-		log.Infof("Skipping git-checkout node as tag is not derived from package.version")
-		return nil
 	}
 
 	log.Infof("processing git-checkout node")


### PR DESCRIPTION
Currently, the bump library only bumps a git-checkout if it depends on the version of the package. This works well when there are multiple checkouts, or one checkout where the package depends on version (which is almost every case). But there are cases where there is a single checkout, but it does not depend on the version, and there is an implicit assumption that it will get updated. 

This change bumps the checkout without the dependency check if there is only one checkout.


<!--
*** PULL REQUEST CHECKLIST: PLEASE START HERE ***

The single most important feature of melange is that we can build Wolfi.

Many changes to melange introduce a risk of breaking the build, and sometimes
these are not flushed out until a package is changed (much) later.  This
pertains to basic execution, SCA changes, linter changes, and more.
-->

### Functional Changes

- [x] This change can build all of Wolfi without errors (describe results in notes)

Notes:

### SCA Changes

- [x] Examining several representative APKs show no regression / the desired effect (details in notes)

Notes:

### Linter

- [x] The new check is clean across Wolfi
- [x] The new check is opt-in or a warning