### PR TITLE
chore(source): allow GitHub verified signatures

### DIFF
--- a/.chainguard/source.yaml
+++ b/.chainguard/source.yaml
@@ -11,3 +11,6 @@ spec:
     - key:
         # allow commits signed by GitHub, e.g. the UI
         kms: https://github.com/web-flow.gpg
+  # Allow Github verified ssh, gpg, and smime signatures
+  github:
+    verified: true


### PR DESCRIPTION
## Melange Pull Request Template

<!--
*** PULL REQUEST CHECKLIST: PLEASE START HERE ***

The single most important feature of melange is that we can build Wolfi.

Many changes to melange introduce a risk of breaking the build, and sometimes
these are not flushed out until a package is changed (much) later.  This
pertains to basic execution, SCA changes, linter changes, and more.
-->

### Functional Changes

- [x] This change can build all of Wolfi without errors (describe results in notes)

Notes:

Config-only change to `.chainguard/source.yaml`. No melange code paths or build behavior are affected.

### SCA Changes

- [x] Examining several representative APKs show no regression / the desired effect (details in notes)

Notes:

N/A. No SCA-related code changed.

### Linter

- [x] The new check is clean across Wolfi
- [x] The new check is opt-in or a warning

Notes:

N/A. No linter changes.

---

## What

Add `github.verified: true` to `.chainguard/source.yaml` so commits that GitHub marks as Verified (via any signing method GitHub recognizes - SSH, GPG, S/MIME) satisfy the source signing policy.

## Why

Broadens the set of accepted commit signing methods, reducing friction for contributors who already sign their commits via GitHub-recognized mechanisms. The existing sigstore keyless and `web-flow.gpg` authorities remain in place; this is purely additive.

## Testing

- Diff is a 3-line YAML addition; no executable code paths changed.
- Behavior change is verifiable on subsequent PRs: commits that GitHub displays as Verified should now satisfy the commit-signing enforcement without requiring sigstore signing.