### PR TITLE
ci: remove stale wolfi-presubmit package matrix entries

### DIFF
--- a/.github/workflows/wolfi-presubmit.yaml
+++ b/.github/workflows/wolfi-presubmit.yaml
@@ -78,15 +78,12 @@ jobs:
           #- glibc # takes ~35-40 minutes to build; not an all-encompassing signal of Melange functionality; TODO: replace with a smaller, related package
           #- xmlto # TODO: https://github.com/wolfi-dev/os/issues/26442
           - bubblewrap
-          - cadvisor # uses cgroups
           - dpkg
           - fixuid # uses a diff test user
           - fping # uses get/setcaps
           - gitsign
-          - grafana-image-renderer
           - guac
           - lzo
-          - mdbook
           - ncurses
           - perl-yaml-syck
           - postfix


### PR DESCRIPTION
## Melange Pull Request Template

<!--
*** PULL REQUEST CHECKLIST: PLEASE START HERE ***

The single most important feature of melange is that we can build Wolfi.

Many changes to melange introduce a risk of breaking the build, and sometimes
these are not flushed out until a package is changed (much) later.  This
pertains to basic execution, SCA changes, linter changes, and more.
-->

### Functional Changes

- [x] This change can build all of Wolfi without errors (describe results in notes)

Notes:

CI-only change. No melange code paths affected. The matrix still exercises 19 packages across bubblewrap and qemu runners.

### SCA Changes

- [x] Examining several representative APKs show no regression / the desired effect (details in notes)

Notes:

N/A. No SCA-related code changed.

### Linter

- [x] The new check is clean across Wolfi
- [x] The new check is opt-in or a warning

Notes:

N/A. No linter changes.

---

## What

Drop `cadvisor`, `grafana-image-renderer`, and `mdbook` from the `wolfi-presubmit.yaml` matrix. Their YAMLs no longer exist in `wolfi-dev/os` (root-level lookups and full-repo code search both return no matches), so `wolfictl bump <pkg>` followed by `make package/<pkg>` against the `wolfi-dev/os` Makefile fails with `No rule to make target`.

## Why

These three matrix entries fail on every PR (including `main`) and create persistent red CI noise that masks legitimate failures. Removing them restores a green baseline without reducing coverage in any meaningful way - the matrix still exercises 19 packages across bubblewrap and qemu runners, covering cgroups, get/setcaps, diff users, license-path, Perl/Python/Ruby builds, and more.

## Notes

- If anyone wants comparable coverage for cgroups (`cadvisor` was tagged "uses cgroups"), a replacement package from the still-existing matrix already exercises similar paths; if not, a follow-up could add a new entry from a currently-existing `wolfi-dev/os` YAML.

## Testing

- Verified all three YAMLs are absent from `wolfi-dev/os` via `gh api repos/wolfi-dev/os/contents/<pkg>.yaml` (404 for each) and `gh api search/code?q=filename:<pkg>.yaml+repo:wolfi-dev/os` (zero hits).
- Recent main-branch runs of `wolfi-presubmit.yaml` confirm these three entries have been failing on every run; the rest of the matrix is green.
- Watch the next `wolfi-presubmit` run on this PR to confirm the matrix is green with these three removed.