### PR TITLE
feat(git-checkout): log resolved clone URL after successful clone

### DIFF
--- a/pkg/build/pipelines/git-checkout.yaml
+++ b/pkg/build/pipelines/git-checkout.yaml
@@ -330,6 +330,8 @@ pipeline:
               ${depthflag:+"${depthflag}"} "$repo" "$workdir" ||
               fail "git clone failed after $max_retries retries"
 
+          msg "cloned from $(cd "$workdir" && git remote get-url origin)"
+
           vr cd "$workdir"
 
           # Configure sparse-checkout if paths were provided


### PR DESCRIPTION
## What/Why

Log the resolved remote URL after git clone completes in the git-checkout pipeline. When git `insteadOf` rules rewrite the URL (e.g. to a local mirror), the clone log only shows the original configured URL. This one-line addition shows the actual URL git resolved to, making mirror usage visible in build logs without enabling `GIT_TRACE`.

Example output when a rewrite is active:
```
[git checkout] cloned from https://mirror.example.com/org/repo.git
```

When no rewrite is active, it shows the original URL:
```
[git checkout] cloned from https://github.com/org/repo.git
```

## Proof it works

Verified in elastic build staging: the log line shows the mirror URL when `insteadOf` rewrites are configured, and the original URL when they are not.

## Risk + AI role

Low -- single log line addition. AI-assisted.

## Review focus

- Placement: the line runs after clone success but before `cd` into the workdir, using a subshell to avoid changing the working directory.