### PR TITLE
feat: pipelines: autoconf: Add targets input for make and make-install

### DIFF
--- a/pkg/build/pipelines/autoconf/README.md
+++ b/pkg/build/pipelines/autoconf/README.md
@@ -29,6 +29,7 @@ Run autoconf make install
 | ---- | -------- | ----------- | ------- |
 | dir | false | The directory containing the Makefile.  | . |
 | opts | false | Options to pass to the make command.  |  |
+| targets | false | Makefile install targets, space-separated.  | install |
 
 ## autoconf/make
 
@@ -40,6 +41,7 @@ Run autoconf make
 | ---- | -------- | ----------- | ------- |
 | dir | false | The directory containing the Makefile.  | . |
 | opts | false | Options to pass to the make command.  |  |
+| targets | false | Makefile targets to build, space-separated.  |  |
 
 
 <!-- end:pipeline-reference-gen -->

--- a/pkg/build/pipelines/autoconf/make-install.yaml
+++ b/pkg/build/pipelines/autoconf/make-install.yaml
@@ -11,13 +11,18 @@ inputs:
       Options to pass to the make command.
     default: ''
 
+  targets:
+    description: |
+      Makefile install targets, space-separated.
+    default: "install"
+
 needs:
   packages:
     - make
 
 pipeline:
   - runs: |
-      make -C "${{inputs.dir}}" install DESTDIR="${{targets.contextdir}}" V=1 ${{inputs.opts}}
+      make -C "${{inputs.dir}}" ${{inputs.targets}} DESTDIR="${{targets.contextdir}}" V=1 ${{inputs.opts}}
 
   # Delete all GNU libtool metadata files.  These things are the bane of a
   # packager's existence: they contain useless metadata, cause overlinking and

--- a/pkg/build/pipelines/autoconf/make.yaml
+++ b/pkg/build/pipelines/autoconf/make.yaml
@@ -11,10 +11,15 @@ inputs:
       Options to pass to the make command.
     default: ''
 
+  targets:
+    description: |
+      Makefile targets to build, space-separated.
+    default: ''
+
 needs:
   packages:
     - make
 
 pipeline:
   - runs: |
-      make -C "${{inputs.dir}}" -j$(nproc) V=1 ${{inputs.opts}}
+      make -C "${{inputs.dir}}" -j$(nproc) V=1 ${{inputs.opts}} ${{inputs.targets}}


### PR DESCRIPTION
# What
Allow overriding the `Makefile` target used for build and/or install.

# Why
`install` isn't always the appropriate install target. I'm packaging an `openssl` variant that wants to use the `install_sw` and `install_ssldirs` targets. I added it to both `make` and `make-install` for symmetry.

# How is this validated?
Several existing `melange` tests use these pipelines, so CI has regression tested them. I've locally tested the feature in a new config (https://github.com/chainguard-dev/stereo/pull/121759)

# Note
This supports multiple space-separated options. You can of course just call the pipeline multiple times instead, but giving `make` multiple targets
at once may allow it to do more in parallel.
