### PR TITLE
feat: pipelines: split/dev: Add prefix input

### DIFF
--- a/pkg/build/pipelines/split/README.md
+++ b/pkg/build/pipelines/split/README.md
@@ -51,6 +51,7 @@ Split development files
 | Name | Required | Description | Default |
 | ---- | -------- | ----------- | ------- |
 | package | false | The package to split development files from  |  |
+| prefix | false | The package's installation prefix  | /usr |
 
 ## split/infodir
 

--- a/pkg/build/pipelines/split/dev.yaml
+++ b/pkg/build/pipelines/split/dev.yaml
@@ -9,6 +9,10 @@ inputs:
     description: |
       The package to split development files from
     required: false
+  prefix:
+    description: |
+      The package's installation prefix
+    default: "/usr"
 
 pipeline:
   - runs: |
@@ -24,15 +28,23 @@ pipeline:
       i= j=
       cd "$PACKAGE_DIR" || exit 0
 
-      libdirs=usr/
-      [ -d lib/ ] && libdirs="lib/ $libdirs"
-      for i in usr/include usr/lib/pkgconfig usr/share/pkgconfig \
-        usr/share/aclocal usr/share/gettext \
-        usr/bin/*-config usr/bin/*_config usr/share/vala/vapi \
-        usr/share/gir-[0-9]* usr/share/qt*/mkspecs \
-        usr/lib/qt*/mkspecs \
-        usr/lib/cmake usr/share/cmake \
-        usr/lib/glade/modules usr/share/glade/catalogs \
+      prefix="${{inputs.prefix}}"
+      # trim leading /
+      while [ "${prefix#/}" != "$prefix" ]; do
+        prefix="${prefix#/}"
+      done
+      libdirs="${prefix}/"
+      if [ "${prefix%%/*}" = "usr" ] && [ -d lib/ ]; then
+        # usr-merge case
+        libdirs="lib/ $libdirs"
+      fi
+      for i in "${prefix}"/include "${prefix}"/lib/pkgconfig "${prefix}"/share/pkgconfig \
+        "${prefix}"/share/aclocal "${prefix}"/share/gettext \
+        "${prefix}"/bin/*-config "${prefix}"/bin/*_config "${prefix}"/share/vala/vapi \
+        "${prefix}"/share/gir-[0-9]* "${prefix}"/share/qt*/mkspecs \
+        "${prefix}"/lib/qt*/mkspecs \
+        "${prefix}"/lib/cmake "${prefix}"/share/cmake \
+        "${prefix}"/lib/glade/modules "${prefix}"/share/glade/catalogs \
         $(find . -name include -type d) \
         $(find $libdirs -name '*.a' 2>/dev/null) \
         $(find $libdirs -name '*.[cho]' \
@@ -46,9 +58,22 @@ pipeline:
         done
 
         # move *.so links needed when linking the apps to -dev packages
-        for i in lib/*.so usr/lib/*.so; do
-          if [ -L "$i" ]; then
-            mkdir -p "${{targets.contextdir}}"/"${i%/*}"
-            mv "$i" "${{targets.contextdir}}/$i" || return 1
-          fi
+        sodirs="$prefix/lib"
+        # Special case: if the prefix dir is */usr, then search
+        # for .so files in */lib in addition to */usr/lib
+        case "$prefix" in
+          usr)
+            sodirs="lib $sodirs"
+            ;;
+          */usr)
+            sodirs="${prefix%/*}/lib $sodirs"
+            ;;
+        esac
+        for sodir in $sodirs; do
+          for i in "$sodir"/*.so; do
+            if [ -L "$i" ]; then
+              mkdir -p "${{targets.contextdir}}"/"${i%/*}"
+              mv "$i" "${{targets.contextdir}}/$i" || return 1
+            fi
+          done
         done


### PR DESCRIPTION
# What
Support splitting dev files from package installations under prefixes other than `/usr`.

# Why
We frequently need to package custom builds of libraries to be consumed by builds of python libraries. To avoid conflicts with existing Wolfi packages, we use a prefix other than `/usr`.

# Validation
The melange e2e tests include packages that use `split/dev`, so we have some coverage there already. In addition, I selected 32 random packages from `stereo` that use `split/dev` and I did before/after local builds, then compared the APK contents using the following script:

```bash
#!/usr/bin/bash
find stereo stereo.tmp -name '*.apk' | while read apk; do
  tar tfz $apk 2>/dev/null | sort -u > $apk.lst
done
find stereo -name '*.apk.lst' | while read f; do
  diff -u $f "$(echo $f | sed 's/^stereo/stereo.tmp/')"
done
```
1 package (xdpyinfo) ftbfs for both tests. The output of the above script for the other 31 showed no differences.

I confirmed that one of the packages (py3-torch-tensorrt-cuda-13.2) uses the `split/dev` "package" input, just to make sure that case was covered.
