### PR TITLE
fix(build): make MutateWith deterministic for forwarded inputs

### DIFF
--- a/pkg/build/pipeline.go
+++ b/pkg/build/pipeline.go
@@ -40,14 +40,25 @@ const WorkDir = "/home/build"
 func (sm *SubstitutionMap) MutateWith(with map[string]string) (map[string]string, error) {
 	nw := maps.Clone(sm.Substitutions)
 
+	// Seed the parent's inherited "${{...}}" entries first, then this pipeline's
+	// own plain inputs, resolving each against the parent so a forwarded self-ref
+	// (`foo: ${{inputs.foo}}`) takes the parent value and the input then wins.
 	for k, v := range with {
-		// already mutated?
 		if strings.HasPrefix(k, "${{") {
 			nw[k] = v
-		} else {
-			nk := fmt.Sprintf("${{inputs.%s}}", k)
-			nw[nk] = v
 		}
+	}
+	for k, v := range with {
+		if strings.HasPrefix(k, "${{") {
+			continue
+		}
+		nk := fmt.Sprintf("${{inputs.%s}}", k)
+		// Resolve against the parent scope; keep raw if not yet in scope (a
+		// sibling input) — the mutation loop below resolves it.
+		if rv, err := util.MutateStringFromMap(nw, v); err == nil {
+			v = rv
+		}
+		nw[nk] = v
 	}
 
 	// do the actual mutations

--- a/pkg/build/pipeline_test.go
+++ b/pkg/build/pipeline_test.go
@@ -15,6 +15,7 @@
 package build
 
 import (
+	"maps"
 	"os"
 	"path/filepath"
 	"testing"
@@ -104,6 +105,170 @@ func Test_MutateWith(t *testing.T) {
 		if gotFullVer != tc.want {
 			t.Errorf("got %s, want %s", gotFullVer, tc.want)
 		}
+	}
+}
+
+// Regression: a nested `uses:` that forwards a same-named input (compile.go
+// merges the parent's resolved "${{inputs.X}}" with the child's own "X") must
+// resolve deterministically regardless of Go's random map order.
+func Test_MutateWith_ForwardedSameNamedInput(t *testing.T) {
+	sm := &SubstitutionMap{Substitutions: map[string]string{}}
+
+	for _, tc := range []struct {
+		name  string
+		with  map[string]string
+		wants map[string]string // key -> expected resolved value
+	}{{
+		name: "forwarded self-reference resolves to parent value",
+		with: map[string]string{
+			"${{inputs.admin-password}}": "adminpw",                    // inherited from parent
+			"admin-password":             "${{inputs.admin-password}}", // forwarded down
+		},
+		wants: map[string]string{"${{inputs.admin-password}}": "adminpw"},
+	}, {
+		name: "literal override wins over inherited value",
+		with: map[string]string{
+			"${{inputs.admin-password}}": "adminpw",
+			"admin-password":             "literalsecret",
+		},
+		wants: map[string]string{"${{inputs.admin-password}}": "literalsecret"},
+	}, {
+		name: "child default wins over inherited parent value",
+		with: map[string]string{
+			"${{inputs.tls-cert-dir}}": "/tmp/tls", // parent's value
+			"tls-cert-dir":             "",         // child's default (validateWith filled it)
+		},
+		wants: map[string]string{"${{inputs.tls-cert-dir}}": ""},
+	}, {
+		name:  "plain input with no collision resolves normally",
+		with:  map[string]string{"foo": "bar"},
+		wants: map[string]string{"${{inputs.foo}}": "bar"},
+	}, {
+		// Order-independence here comes from the final mutation loop
+		// re-resolving every entry, not from the input-loop order.
+		name: "sibling reference resolves regardless of order",
+		with: map[string]string{
+			"a": "${{inputs.b}}",
+			"b": "bee",
+		},
+		wants: map[string]string{
+			"${{inputs.a}}": "bee",
+			"${{inputs.b}}": "bee",
+		},
+	}, {
+		name: "multiple forwarded inputs all resolve to parent values",
+		with: map[string]string{
+			"${{inputs.password}}": "pw",
+			"password":             "${{inputs.password}}",
+			"${{inputs.cert-dir}}": "/d",
+			"cert-dir":             "${{inputs.cert-dir}}",
+		},
+		wants: map[string]string{
+			"${{inputs.password}}": "pw",
+			"${{inputs.cert-dir}}": "/d",
+		},
+	}} {
+		t.Run(tc.name, func(t *testing.T) {
+			// Run many times to defeat randomized map iteration order.
+			for i := range 1000 {
+				got, err := sm.MutateWith(tc.with)
+				if err != nil {
+					t.Fatalf("MutateWith: %v", err)
+				}
+				for k, want := range tc.wants {
+					if v := got[k]; v != want {
+						t.Fatalf("iter %d: %s: got %q, want %q", i, k, v, want)
+					}
+				}
+			}
+		})
+	}
+}
+
+// Forwarding the same-named input down many levels must keep resolving to the
+// top value at any depth (each level passes a fully-resolved map to the next).
+func Test_MutateWith_DeepForwarding(t *testing.T) {
+	sm := &SubstitutionMap{Substitutions: map[string]string{}}
+	for i := range 1000 {
+		// Top level: the input takes its real value.
+		m, err := sm.MutateWith(map[string]string{"admin-password": "adminpw"})
+		if err != nil {
+			t.Fatalf("iter %d top: %v", i, err)
+		}
+		// Each deeper level inherits the parent's resolved map and forwards the
+		// same-named input (the self-referential `X: ${{inputs.X}}`).
+		for lvl := 1; lvl <= 5; lvl++ {
+			child := maps.Clone(m)
+			child["admin-password"] = "${{inputs.admin-password}}"
+			m, err = sm.MutateWith(child)
+			if err != nil {
+				t.Fatalf("iter %d level %d: %v", i, lvl, err)
+			}
+		}
+		if v := m["${{inputs.admin-password}}"]; v != "adminpw" {
+			t.Fatalf("iter %d: 6-level forwarded value = %q, want %q", i, v, "adminpw")
+		}
+	}
+}
+
+// Functional: compile a 3-level nested `uses:` (parent->child->grandchild) that
+// forwards a same-named input down to a `runs:` block. Pre-fix this
+// intermittently failed stripComments with "invalid parameter name".
+func Test_CompilePipelines_NestedForwardedInput(t *testing.T) {
+	ctx := slogtest.Context(t)
+	dir := t.TempDir()
+	write := func(name, body string) {
+		t.Helper()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte(body), 0o644))
+	}
+	write("parent.yaml", `
+inputs:
+  password:
+    default: defaultpw
+pipeline:
+  - uses: child
+    with:
+      password: ${{inputs.password}}
+`)
+	write("child.yaml", `
+inputs:
+  password:
+    default: childdefault
+pipeline:
+  - uses: grandchild
+    with:
+      password: ${{inputs.password}}
+`)
+	write("grandchild.yaml", `
+inputs:
+  password:
+    default: grandchilddefault
+pipeline:
+  - runs: |
+      echo "pw=${{inputs.password}}"
+`)
+
+	// repeats is an iteration count (NOT nesting depth); the pre-fix bug was
+	// intermittent (random map order), so repeat to fail reliably.
+	const repeats = 200
+	for i := range repeats {
+		cfg := config.Configuration{
+			Package: config.Package{Name: "foo", Version: "1.2.3"},
+			Pipeline: []config.Pipeline{{
+				Uses: "parent",
+				With: map[string]string{"password": "topsecret"},
+			}},
+		}
+		c := &Compiled{PipelineDirs: []string{dir}}
+		sm, err := NewSubstitutionMap(&cfg, "", "", nil)
+		require.NoError(t, err)
+
+		require.NoError(t, c.CompilePipelines(ctx, sm, cfg.Pipeline), "iter %d", i)
+
+		// parent -> child -> grandchild -> runs step
+		runs := cfg.Pipeline[0].Pipeline[0].Pipeline[0].Pipeline[0].Runs
+		require.Contains(t, runs, "pw=topsecret", "iter %d: runs=%q", i, runs)
+		require.NotContains(t, runs, "${{", "iter %d: unresolved template in runs=%q", i, runs)
 	}
 }
 


### PR DESCRIPTION
## Problem

Nesting `uses:` and forwarding a same-named input down — `A` uses `B`, `B` uses `C` with `{ foo: ${{inputs.foo}} }`, where `C` also declares input `foo` — substitutes **nondeterministically** (depends on Go's randomized map iteration). Two intermittent symptoms:

1. **Compile crash:** `${{inputs.foo}}` is sometimes left unresolved; in a `runs:` block `stripComments` then fails with `invalid parameter name`.
2. **Silent wrong value:** a literal override (`{ foo: secret }`) sometimes resolves to the inherited parent value instead of `secret`, with no error.

(Hit in practice by 2-level test bring-up pipelines forwarding `admin-password` / `tls-cert-dir`.)

## Root cause

`compilePipeline` merges the parent's resolved substitution map into the child's `with`, so the merged map holds two entries that collide on one key in `MutateWith`:

```
"${{inputs.foo}}" -> "<parent value>"   (inherited)
"foo"             -> "${{inputs.foo}}"  (child's forward)
```

The single insert loop writes both to `nw["${{inputs.foo}}"]`; `for range` over a map is randomized, so the winner is nondeterministic. When the self-reference wins it resolves to itself and stays unresolved.

## Fix

Make the merge deterministic and ordered: seed the inherited `${{...}}` entries, then apply this pipeline's own inputs (names sorted) resolved against the parent scope — so a forwarded self-reference takes the parent value and a literal override always wins.

## Tests

Each repeats to defeat random map order; all fail on `main`, pass here:
- `Test_MutateWith_ForwardedSameNamedInput` — self-ref, override, default-wins, no-collision, sibling-ref, multi-key.
- `Test_MutateWith_DeepForwarding` — 6-level forwarding chain.
- `Test_CompilePipelines_NestedForwardedInput` — end-to-end 3-level nested `uses:` reproducing the `stripComments` failure.

## Fix site (for reviewers)

The collision originates where `compilePipeline` merges the parent map into the child `with`; I fixed it in `MutateWith`. Alternatives: resolve forwarded `with` values against the parent before merging, or don't let an inherited `${{inputs.X}}` shadow a declared child input. Happy to move it.
