### PR TITLE
feat(config): add annotations field to subpackages

### DIFF
--- a/pkg/build/package.go
+++ b/pkg/build/package.go
@@ -82,6 +82,7 @@ func pkgFromSub(sub *config.Subpackage) *config.Package {
 		Options:      sub.Options,
 		Scriptlets:   sub.Scriptlets,
 		Description:  sub.Description,
+		Annotations:  sub.Annotations,
 		URL:          sub.URL,
 		Commit:       sub.Commit,
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -848,6 +848,8 @@ type Subpackage struct {
 	Scriptlets *Scriptlets    `json:"scriptlets,omitempty" yaml:"scriptlets,omitempty"`
 	// Optional: The human readable description of the subpackage
 	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+	// Optional: Annotations for this subpackage
+	Annotations map[string]string `json:"annotations,omitempty" yaml:"annotations,omitempty"`
 	// Optional: The URL to the package's homepage
 	URL string `json:"url,omitempty" yaml:"url,omitempty"`
 	// Optional: The git commit of the subpackage build configuration
@@ -1566,6 +1568,7 @@ func replaceSubpackage(r *strings.Replacer, detectedCommit string, in Subpackage
 		Options:      in.Options,
 		Scriptlets:   replaceScriptlets(r, in.Scriptlets),
 		Description:  r.Replace(in.Description),
+		Annotations:  replaceMap(r, in.Annotations),
 		URL:          r.Replace(in.URL),
 		Commit:       replaceCommit(detectedCommit, in.Commit),
 		Checks:       in.Checks,

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -496,6 +496,35 @@ package:
 	require.Equal(t, "python", cfg.Package.Annotations["cgr.dev/ecosystem"])
 }
 
+func Test_subpackageAnnotations(t *testing.T) {
+	ctx := slogtest.Context(t)
+	fp := filepath.Join(os.TempDir(), "melange-test-subpackageAnnotations")
+	if err := os.WriteFile(fp, []byte(`
+package:
+  name: parent
+  version: 0.0.1
+  epoch: 1
+
+subpackages:
+  - name: parent-docs
+    annotations:
+      cgr.dev/ecosystem: docs
+      cgr.dev/component: manual
+
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := ParseConfiguration(ctx, fp)
+	if err != nil {
+		t.Fatalf("failed to parse configuration: %s", err)
+	}
+
+	require.Len(t, cfg.Subpackages, 1)
+	require.Equal(t, "docs", cfg.Subpackages[0].Annotations["cgr.dev/ecosystem"])
+	require.Equal(t, "manual", cfg.Subpackages[0].Annotations["cgr.dev/component"])
+	require.Nil(t, cfg.Package.Annotations, "subpackage annotations must not leak into parent")
+}
+
 func TestDuplicateSubpackage(t *testing.T) {
 	ctx := slogtest.Context(t)
 

--- a/pkg/config/schema.cue
+++ b/pkg/config/schema.cue
@@ -561,6 +561,9 @@
 	// Optional: The human readable description of the subpackage
 	description?: string
 
+	// Optional: Annotations for this subpackage
+	annotations?: [string]: string
+
 	// Optional: The URL to the package's homepage
 	url?: string
 

--- a/pkg/config/schema.json
+++ b/pkg/config/schema.json
@@ -1025,6 +1025,13 @@
           "type": "string",
           "description": "Optional: The human readable description of the subpackage"
         },
+        "annotations": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "Optional: Annotations for this subpackage"
+        },
         "url": {
           "type": "string",
           "description": "Optional: The URL to the package's homepage"


### PR DESCRIPTION
Mirrors the existing top-level `Package.Annotations`, letting each subpackage carry its own independent annotations map.

🤖 Generated with [Claude Code](https://claude.com/claude-code)