### PR TITLE
Fix/improve shell comparison syntax

### DIFF
--- a/pkg/build/pipelines/fetch.yaml
+++ b/pkg/build/pipelines/fetch.yaml
@@ -75,14 +75,14 @@ inputs:
 
 pipeline:
   - runs: |
-      if [ "${{inputs.expected-sha256}}" == "" ] && [ "${{inputs.expected-sha512}}" == "" ] && [ "${{inputs.expected-none}}" == "" ]; then
-        printf "One of expected-sha256 or expected-sha512 is required"
+      if [ -z "${{inputs.expected-sha256}}" ] && [ -z "${{inputs.expected-sha512}}" ] && [ -z "${{inputs.expected-none}}" ]; then
+        printf "One of expected-sha256 or expected-sha512 is required\n"
         exit 1
       fi
 
       bn=$(basename ${{inputs.uri}})
 
-      if [ ! "${{inputs.expected-sha256}}" == "" ]; then
+      if [ -n "${{inputs.expected-sha256}}" ]; then
         fn="/var/cache/melange/sha256:${{inputs.expected-sha256}}"
         if [ -f $fn ]; then
           printf "fetch: found $fn in cache\n"
@@ -100,9 +100,9 @@ pipeline:
         wget '-T${{inputs.timeout}}' '--dns-timeout=${{inputs.dns-timeout}}' '--tries=${{inputs.retry-limit}}' --random-wait --retry-connrefused --continue '${{inputs.uri}}'
       fi
 
-      if [ "${{inputs.expected-none}}" != "" ]; then
+      if [ -n "${{inputs.expected-none}}" ]; then
         printf "fetch: Checksum validation skipped\n"
-      elif [ "${{inputs.expected-sha256}}" != "" ]; then
+      elif [ -n "${{inputs.expected-sha256}}" ]; then
         printf "fetch: Expected sha256: ${{inputs.expected-sha256}}\n"
         sum=$(sha256sum $bn | awk '{print $1}')
         if [ "${{inputs.expected-sha256}}" != "$sum" ]; then

--- a/pkg/build/pipelines/git-checkout.yaml
+++ b/pkg/build/pipelines/git-checkout.yaml
@@ -204,7 +204,7 @@ pipeline:
 
             unshallow_arg=""
             is_shallow=$(git rev-parse --is-shallow-repository)
-            if [ "$is_shallow" == "true" ] ; then
+            if [ "$is_shallow" = "true" ] ; then
                 unshallow_arg="--unshallow"
             fi
 

--- a/pkg/build/pipelines/go/build.yaml
+++ b/pkg/build/pipelines/go/build.yaml
@@ -135,7 +135,7 @@ pipeline:
       export GOMODCACHE=/var/cache/melange/gomodcache
 
       # Install any specified dependencies
-      if [ ! "${{inputs.deps}}" == "" ]; then
+      if [ -n "${{inputs.deps}}" ]; then
         for dep in ${{inputs.deps}}; do
           go get $dep
         done

--- a/pkg/build/pipelines/go/install.yaml
+++ b/pkg/build/pipelines/go/install.yaml
@@ -77,7 +77,7 @@ pipeline:
       # Installed binaries will be stored in a tmp dir
       export GOBIN=$(mktemp -d)
 
-      if [ ! "${{inputs.version}}" == "" ]; then
+      if [ -n "${{inputs.version}}" ]; then
         VERSION="@${{inputs.version}}"
       fi
 

--- a/pkg/build/pipelines/npm/install.yaml
+++ b/pkg/build/pipelines/npm/install.yaml
@@ -35,7 +35,7 @@ inputs:
 pipeline:
   - runs: |
       # Require npm-package to be 'npm' or 'pnpm'
-      if [ ! "${{inputs.npm-package}}" == "npm" ] && [ ! "${{inputs.npm-package}}" == "pnpm" ]; then
+      if [ ! "${{inputs.npm-package}}" = "npm" ] && [ ! "${{inputs.npm-package}}" = "pnpm" ]; then
           echo "Invalid npm-package '${{inputs.npm-package}}'; must be 'npm' or 'pnpm'."
           exit 1
       fi
@@ -43,7 +43,7 @@ pipeline:
       mkdir -p "${{inputs.prefix}}"/bin
       mkdir -p "${{inputs.prefix}}"/lib
       mkdir -p $HOME/.pnpm/store
-      if [ "${{inputs.npm-package}}" == "pnpm" ]; then
+      if [ "${{inputs.npm-package}}" = "pnpm" ]; then
           export PNPM_HOME=~/.pnpm/store
           export SHELL=sh
           export ENV=/etc/profile
@@ -56,7 +56,7 @@ pipeline:
       # Does not support overrides; to be fixed below if needed.
       ${{inputs.npm-package}} install -g "${{inputs.package}}@${{inputs.version}}" -prefix "${{inputs.prefix}}"
 
-      if [ ! "${{inputs.overrides}}" == "" ]; then
+      if [ -n "${{inputs.overrides}}" ]; then
           # Move to /lib, which contains the node_modules folder.
           cd "${{inputs.prefix}}/lib"
 
@@ -92,7 +92,7 @@ pipeline:
 
           # ... to reinstall non-vulnerable node_modules.
           args=""
-          if [ "${{inputs.npm-package}}" == "npm" ]; then
+          if [ "${{inputs.npm-package}}" = "npm" ]; then
               args="${args} --install-strategy=shallow "
           fi
           ${{inputs.npm-package}} i ${args} .

--- a/pkg/build/pipelines/split/debug.yaml
+++ b/pkg/build/pipelines/split/debug.yaml
@@ -19,7 +19,7 @@ pipeline:
         PACKAGE_DIR="${{targets.outdir}}/${{inputs.package}}"
       fi
 
-      if [ "$PACKAGE_DIR" == "${{targets.contextdir}}" ]; then
+      if [ "$PACKAGE_DIR" = "${{targets.contextdir}}" ]; then
         echo "ERROR: Package can not split files from itself!" && exit 1
       fi
 

--- a/pkg/build/pipelines/split/dev.yaml
+++ b/pkg/build/pipelines/split/dev.yaml
@@ -21,11 +21,10 @@ pipeline:
         PACKAGE_DIR="${{targets.outdir}}/${{inputs.package}}"
       fi
 
-      if [ "$PACKAGE_DIR" == "${{targets.contextdir}}" ]; then
+      if [ "$PACKAGE_DIR" = "${{targets.contextdir}}" ]; then
         echo "ERROR: Package can not split files from itself!" && exit 1
       fi
 
-      i= j=
       cd "$PACKAGE_DIR" || exit 0
 
       prefix="${{inputs.prefix}}"

--- a/pkg/build/pipelines/split/infodir.yaml
+++ b/pkg/build/pipelines/split/infodir.yaml
@@ -17,7 +17,7 @@ pipeline:
         PACKAGE_DIR="${{targets.outdir}}/${{inputs.package}}"
       fi
 
-      if [ "$PACKAGE_DIR" == "${{targets.contextdir}}" ]; then
+      if [ "$PACKAGE_DIR" = "${{targets.contextdir}}" ]; then
         echo "ERROR: Package can not split files from itself!" && exit 1
       fi
 

--- a/pkg/build/pipelines/split/lib.yaml
+++ b/pkg/build/pipelines/split/lib.yaml
@@ -36,7 +36,7 @@ pipeline:
         PACKAGE_DIR="${{targets.outdir}}/${{inputs.package}}"
       fi
 
-      if [ "$PACKAGE_DIR" == "${{targets.contextdir}}" ]; then
+      if [ "$PACKAGE_DIR" = "${{targets.contextdir}}" ]; then
         echo "ERROR: Package can not split files from itself!" && exit 1
       fi
 

--- a/pkg/build/pipelines/split/locales.yaml
+++ b/pkg/build/pipelines/split/locales.yaml
@@ -17,7 +17,7 @@ pipeline:
         PACKAGE_DIR="${{targets.outdir}}/${{inputs.package}}"
       fi
 
-      if [ "$PACKAGE_DIR" == "${{targets.contextdir}}" ]; then
+      if [ "$PACKAGE_DIR" = "${{targets.contextdir}}" ]; then
         echo "ERROR: Package can not split files from itself!" && exit 1
       fi
 

--- a/pkg/build/pipelines/split/static.yaml
+++ b/pkg/build/pipelines/split/static.yaml
@@ -17,7 +17,7 @@ pipeline:
         PACKAGE_DIR="${{targets.outdir}}/${{inputs.package}}"
       fi
 
-      if [ "$PACKAGE_DIR" == "${{targets.contextdir}}" ]; then
+      if [ "$PACKAGE_DIR" = "${{targets.contextdir}}" ]; then
         echo "ERROR: Package can not split files from itself!" && exit 1
       fi
 

--- a/pkg/cond/subst_test.go
+++ b/pkg/cond/subst_test.go
@@ -124,7 +124,7 @@ func TestSubstTrailingMarker(t *testing.T) {
 }
 
 func TestSubstVarShellFragment(t *testing.T) {
-	doc := `if [ "${{inputs.expected-sha256}}" == "" ] && [ "${{inputs.expected-sha512}}" == "" ]; then
+	doc := `if [ -z "${{inputs.expected-sha256}}" ] && [ -z "${{inputs.expected-sha512}}" ]; then
   printf "One of expected-sha256 or expected-sha512 is required"
   exit 1
 fi`


### PR DESCRIPTION
- When using `[` for testing, the operand for equality comparison is `=`, not `==`.

- Empty string checks can be done with `-z`; non-empty string checks can be done with `-n`.