### PR TITLE
Parallel subpackage builds

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -29,6 +29,7 @@ jobs:
           - minimal.yaml
           - npm-install.yaml
           - pnpm-install.yaml
+          - parallel-subpackages.yaml
 
           - melange.yaml # special; builds melange itself
 

--- a/examples/parallel-subpackages.yaml
+++ b/examples/parallel-subpackages.yaml
@@ -1,0 +1,74 @@
+package:
+  name: parallel-subpackages
+  version: 0.0.1
+  epoch: 0
+  description: exercises parallel subpackage builds and their isolated filesystem view
+
+# Cap concurrency so the batching + limit path is exercised as well.
+max-parallel-subpackages: 2
+
+environment:
+  contents:
+    repositories:
+      - https://packages.wolfi.dev/os
+    keyring:
+      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    packages:
+      - busybox
+
+pipeline:
+  - runs: |
+      mkdir -p "${{targets.destdir}}"
+      echo "from-main" > "${{targets.destdir}}/main-output"
+
+subpackages:
+  # First batch: three parallel subpackages built concurrently. Each writes a
+  # distinct file to its own subpkgdir; none may see the others' writes.
+  - name: parallel-a
+    parallel: true
+    description: writes its own file in isolation
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"
+          echo "a" > "${{targets.subpkgdir}}/a"
+
+  - name: parallel-b
+    parallel: true
+    description: writes its own file in isolation
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"
+          echo "b" > "${{targets.subpkgdir}}/b"
+
+  - name: parallel-reads-main
+    parallel: true
+    description: reads the main package output read-only from melange-out
+    pipeline:
+      - runs: |
+          # The main package output is visible read-only in melange-out.
+          got=$(cat "${{targets.outdir}}/parallel-subpackages/main-output")
+          [ "$got" = "from-main" ] || { echo "unexpected main output: $got"; exit 1; }
+          mkdir -p "${{targets.subpkgdir}}"
+          echo "$got" > "${{targets.subpkgdir}}/copied-from-main"
+
+  # Synchronization barrier: a non-parallel subpackage. It runs after the batch
+  # above completes and its output is copied into melange-out before the next
+  # batch starts.
+  - name: sync-barrier
+    description: sequential subpackage acting as a batch barrier
+    pipeline:
+      - runs: |
+          mkdir -p "${{targets.subpkgdir}}"
+          echo "barrier" > "${{targets.subpkgdir}}/barrier"
+
+  # Second batch: a parallel subpackage that reads a prior batch's output. All
+  # of melange-out as it stood at batch start is visible read-only.
+  - name: parallel-reads-prior
+    parallel: true
+    description: reads a prior batch's output read-only
+    pipeline:
+      - runs: |
+          got=$(cat "${{targets.outdir}}/sync-barrier/barrier")
+          [ "$got" = "barrier" ] || { echo "unexpected prior output: $got"; exit 1; }
+          mkdir -p "${{targets.subpkgdir}}"
+          echo "$got" > "${{targets.subpkgdir}}/copied-from-prior"

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -44,6 +44,7 @@ import (
 	"github.com/yookoala/realpath"
 	"github.com/zealic/xignore"
 	"go.opentelemetry.io/otel"
+	"golang.org/x/sync/errgroup"
 	"golang.org/x/sys/unix"
 	"sigs.k8s.io/release-utils/version"
 
@@ -615,6 +616,21 @@ func (b *Build) BuildPackage(ctx context.Context) error {
 	}
 	b.SBOMGroup = NewSBOMGroup(pkgNames...)
 
+	// Determine whether parallel subpackage builds are possible for this build.
+	hasParallel := slices.ContainsFunc(b.Configuration.Subpackages, func(sp config.Subpackage) bool {
+		return sp.Parallel
+	})
+	isolator, canIsolate := b.Runner.(container.IsolatedRunner)
+	if hasParallel && !canIsolate {
+		return fmt.Errorf("parallel subpackages require a runner that supports build isolation; runner %q does not", b.Runner.Name())
+	}
+	// Interactive debugging execs a shell into the shared pod on failure, which
+	// is incompatible with concurrent isolated builds, so fall back to sequential.
+	parallelAllowed := hasParallel && canIsolate && !b.Interactive && !b.DebugRunner
+	if hasParallel && (b.Interactive || b.DebugRunner) {
+		log.Warnf("parallel subpackages disabled: incompatible with interactive/debug-runner; building subpackages sequentially")
+	}
+
 	pr := &pipelineRunner{
 		interactive: b.Interactive,
 		debug:       b.Debug,
@@ -645,6 +661,9 @@ func (b *Build) BuildPackage(ctx context.Context) error {
 
 	linterQueue := []linterTarget{}
 	cfg := b.workspaceConfig(ctx)
+	// Grant runners that need extra privileges for isolation (e.g. docker) the
+	// opportunity to request them at pod start, but only when needed.
+	cfg.NeedsIsolation = parallelAllowed
 
 	imgRef, err := b.buildGuest(ctx, b.Configuration.Environment, b.GuestFS)
 	if err != nil {
@@ -679,26 +698,36 @@ func (b *Build) BuildPackage(ctx context.Context) error {
 	}
 	linterQueue = append(linterQueue, lintTarget)
 
-	// run any pipelines for subpackages
-	for _, sp := range b.Configuration.Subpackages {
-		if err := os.MkdirAll(filepath.Join(b.WorkspaceDir, melangeOutputDirName, sp.Name), 0o755); err != nil {
+	// Run subpackage pipelines. Consecutive subpackages marked parallel form a
+	// batch that runs concurrently in isolated filesystem views; every other
+	// subpackage runs sequentially in the shared environment, exactly as before.
+	// Declaration order is preserved, and a non-parallel subpackage acts as a
+	// synchronization barrier between batches.
+	for _, batch := range batchSubpackages(b.Configuration.Subpackages, parallelAllowed) {
+		if len(batch) == 1 {
+			sp := batch[0]
+			if err := os.MkdirAll(filepath.Join(b.WorkspaceDir, melangeOutputDirName, sp.Name), 0o755); err != nil {
+				return err
+			}
+
+			log.Infof("running pipeline for subpackage %s", sp.Name)
+
+			sctx := clog.WithLogger(ctx, log.With("subpackage", sp.Name))
+
+			if err := pr.runPipelines(sctx, sp.Pipeline); err != nil {
+				return fmt.Errorf("unable to run subpackage %s pipeline: %w", sp.Name, err)
+			}
+		} else if err := b.runParallelBatch(ctx, isolator, pr.config, batch); err != nil {
 			return err
 		}
 
-		log.Infof("running pipeline for subpackage %s", sp.Name)
-
-		ctx := clog.WithLogger(ctx, log.With("subpackage", sp.Name))
-
-		if err := pr.runPipelines(ctx, sp.Pipeline); err != nil {
-			return fmt.Errorf("unable to run subpackage %s pipeline: %w", sp.Name, err)
+		// add the subpackages to the linter queue, deterministically in order.
+		for _, sp := range batch {
+			linterQueue = append(linterQueue, linterTarget{
+				pkgName:  sp.Name,
+				disabled: sp.Checks.Disabled,
+			})
 		}
-
-		// add the subpackage to the linter queue
-		lintTarget := linterTarget{
-			pkgName:  sp.Name,
-			disabled: sp.Checks.Disabled,
-		}
-		linterQueue = append(linterQueue, lintTarget)
 	}
 
 	// Store metadata for use after the workspace is loaded into memory
@@ -915,6 +944,109 @@ func (b *Build) summarize(ctx context.Context) {
 	log.Infof("melange %s with runner %s is building:", version.GetVersionInfo().GitVersion, b.Runner.Name())
 	log.Debugf("  configuration file: %s", b.ConfigFile)
 	b.SummarizePaths(ctx)
+}
+
+// batchSubpackages groups subpackages into ordered batches for execution.
+// Consecutive subpackages marked Parallel (when parallelAllowed) are grouped
+// into a single batch that is later run concurrently; every other subpackage
+// becomes its own singleton batch that runs sequentially. Declaration order is
+// always preserved.
+func batchSubpackages(subpackages []config.Subpackage, parallelAllowed bool) [][]config.Subpackage {
+	batches := make([][]config.Subpackage, 0, len(subpackages))
+	var cur []config.Subpackage
+
+	flush := func() {
+		if len(cur) > 0 {
+			batches = append(batches, cur)
+			cur = nil
+		}
+	}
+
+	for _, sp := range subpackages {
+		if parallelAllowed && sp.Parallel {
+			cur = append(cur, sp)
+		} else {
+			flush()
+			batches = append(batches, []config.Subpackage{sp})
+		}
+	}
+	flush()
+
+	return batches
+}
+
+// runParallelBatch builds a batch of subpackages concurrently, each in its own
+// isolated filesystem view. Outputs are copied back into the shared workspace
+// after the whole batch completes, forming a barrier before the next batch and
+// before workspace retrieval.
+func (b *Build) runParallelBatch(ctx context.Context, isolator container.IsolatedRunner, base *container.Config, batch []config.Subpackage) error {
+	log := clog.FromContext(ctx)
+
+	// Pre-create the shared output dirs so copy-back has a destination.
+	for _, sp := range batch {
+		if err := os.MkdirAll(filepath.Join(b.WorkspaceDir, melangeOutputDirName, sp.Name), 0o755); err != nil {
+			return err
+		}
+	}
+
+	cfgs := make([]*container.Config, len(batch))
+	for i, sp := range batch {
+		id, err := container.NewIsolationID()
+		if err != nil {
+			return fmt.Errorf("generating isolation id for subpackage %s: %w", sp.Name, err)
+		}
+		cfgs[i] = base.ForIsolation(&container.Isolation{ID: id, SubpkgName: sp.Name})
+	}
+
+	g, gctx := errgroup.WithContext(ctx)
+	if limit := b.Configuration.MaxParallelSubpackages; limit > 0 {
+		g.SetLimit(limit)
+	}
+
+	// results[i] records the per-subpackage outcome so we only copy back
+	// successful builds; g.Wait() still returns the first error to fail the build.
+	results := make([]error, len(batch))
+	for i := range batch {
+		sp := batch[i]
+		g.Go(func() error {
+			sctx := clog.WithLogger(gctx, log.With("subpackage", sp.Name))
+			log.Infof("running pipeline for subpackage %s (parallel)", sp.Name)
+
+			if err := isolator.SetupIsolation(sctx, cfgs[i]); err != nil {
+				results[i] = fmt.Errorf("setting up isolation for subpackage %s: %w", sp.Name, err)
+				return results[i]
+			}
+
+			spr := &pipelineRunner{
+				interactive: false,
+				debug:       b.Debug,
+				config:      cfgs[i],
+				runner:      b.Runner,
+			}
+			if err := spr.runPipelines(sctx, sp.Pipeline); err != nil {
+				results[i] = fmt.Errorf("unable to run subpackage %s pipeline: %w", sp.Name, err)
+				return results[i]
+			}
+			return nil
+		})
+	}
+	waitErr := g.Wait()
+
+	// Copy back successful outputs and always tear down. Use WithoutCancel so
+	// cleanup runs even when gctx was cancelled by a failed sibling.
+	cleanupCtx := context.WithoutCancel(ctx)
+	for i, sp := range batch {
+		if results[i] == nil {
+			if err := isolator.CopyOutIsolation(cleanupCtx, cfgs[i]); err != nil {
+				log.Warnf("copying out isolated outputs for subpackage %s: %v", sp.Name, err)
+			}
+		}
+		if err := isolator.TeardownIsolation(cleanupCtx, cfgs[i]); err != nil {
+			log.Warnf("tearing down isolation for subpackage %s: %v", sp.Name, err)
+		}
+	}
+
+	return waitErr
 }
 
 // buildFlavor determines if a build context uses glibc or musl, it returns

--- a/pkg/build/parallel_subpackages_test.go
+++ b/pkg/build/parallel_subpackages_test.go
@@ -1,0 +1,116 @@
+// Copyright 2024 Chainguard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build
+
+import (
+	"testing"
+
+	"chainguard.dev/melange/pkg/config"
+)
+
+func names(batches [][]config.Subpackage) [][]string {
+	out := make([][]string, len(batches))
+	for i, b := range batches {
+		for _, sp := range b {
+			out[i] = append(out[i], sp.Name)
+		}
+	}
+	return out
+}
+
+func sub(name string, parallel bool) config.Subpackage {
+	return config.Subpackage{Name: name, Parallel: parallel}
+}
+
+func TestBatchSubpackages(t *testing.T) {
+	tests := []struct {
+		name            string
+		subpackages     []config.Subpackage
+		parallelAllowed bool
+		want            [][]string
+	}{
+		{
+			name:            "empty",
+			subpackages:     nil,
+			parallelAllowed: true,
+			want:            nil,
+		},
+		{
+			name:            "all sequential",
+			subpackages:     []config.Subpackage{sub("a", false), sub("b", false), sub("c", false)},
+			parallelAllowed: true,
+			want:            [][]string{{"a"}, {"b"}, {"c"}},
+		},
+		{
+			name:            "all parallel merge into one batch",
+			subpackages:     []config.Subpackage{sub("a", true), sub("b", true), sub("c", true)},
+			parallelAllowed: true,
+			want:            [][]string{{"a", "b", "c"}},
+		},
+		{
+			name: "parallel batches separated by a sync barrier",
+			subpackages: []config.Subpackage{
+				sub("a", true), sub("b", true),
+				sub("sync", false),
+				sub("c", true), sub("d", true),
+			},
+			parallelAllowed: true,
+			want:            [][]string{{"a", "b"}, {"sync"}, {"c", "d"}},
+		},
+		{
+			name: "leading and trailing sync",
+			subpackages: []config.Subpackage{
+				sub("s1", false),
+				sub("a", true), sub("b", true),
+				sub("s2", false),
+			},
+			parallelAllowed: true,
+			want:            [][]string{{"s1"}, {"a", "b"}, {"s2"}},
+		},
+		{
+			name:            "lone parallel is its own batch",
+			subpackages:     []config.Subpackage{sub("a", false), sub("b", true), sub("c", false)},
+			parallelAllowed: true,
+			want:            [][]string{{"a"}, {"b"}, {"c"}},
+		},
+		{
+			name: "parallel disabled forces sequential",
+			subpackages: []config.Subpackage{
+				sub("a", true), sub("b", true), sub("c", true),
+			},
+			parallelAllowed: false,
+			want:            [][]string{{"a"}, {"b"}, {"c"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := names(batchSubpackages(tt.subpackages, tt.parallelAllowed))
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %d batches %v, want %d batches %v", len(got), got, len(tt.want), tt.want)
+			}
+			for i := range got {
+				if len(got[i]) != len(tt.want[i]) {
+					t.Fatalf("batch %d: got %v, want %v", i, got[i], tt.want[i])
+				}
+				for j := range got[i] {
+					if got[i][j] != tt.want[i][j] {
+						t.Fatalf("batch %d: got %v, want %v", i, got[i], tt.want[i])
+					}
+				}
+			}
+		})
+	}
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -837,6 +837,11 @@ type Subpackage struct {
 	If string `json:"if,omitempty" yaml:"if,omitempty"`
 	// Optional: The iterable used to generate multiple subpackages
 	Range string `json:"range,omitempty" yaml:"range,omitempty"`
+	// Optional: When true, this subpackage's pipeline may run concurrently with
+	// adjacent parallel subpackages in an isolated filesystem view. It gets
+	// read-only access to melange-out as it stood at batch start; its writes to
+	// /home/build do not persist for or leak to other subpackages.
+	Parallel bool `json:"parallel,omitempty" yaml:"parallel,omitempty"`
 	// Required: Name of the subpackage
 	Name string `json:"name" yaml:"name"`
 	// Optional: The list of pipelines that produce subpackage.
@@ -893,6 +898,9 @@ type Configuration struct {
 	Pipeline []Pipeline `json:"pipeline,omitempty" yaml:"pipeline,omitempty"`
 	// Optional: The list of subpackages that this package also produces.
 	Subpackages []Subpackage `json:"subpackages,omitempty" yaml:"subpackages,omitempty"`
+	// Optional: Maximum number of parallel subpackages to build concurrently
+	// within a single batch. 0 (default) means unbounded.
+	MaxParallelSubpackages int `json:"max-parallel-subpackages,omitempty" yaml:"max-parallel-subpackages,omitempty"`
 	// Optional: An arbitrary list of data that can be used via templating in the
 	// pipeline
 	Data []RangeData `json:"data,omitempty" yaml:"data,omitempty"`

--- a/pkg/container/bubblewrap_runner.go
+++ b/pkg/container/bubblewrap_runner.go
@@ -37,7 +37,10 @@ import (
 	"go.opentelemetry.io/otel"
 )
 
-var _ Debugger = (*bubblewrap)(nil)
+var (
+	_ Debugger       = (*bubblewrap)(nil)
+	_ IsolatedRunner = (*bubblewrap)(nil)
+)
 
 const (
 	BubblewrapName = "bubblewrap"
@@ -125,7 +128,16 @@ func (bw *bubblewrap) cmd(ctx context.Context, cfg *Config, debug bool, envOverr
 	baseargs = append(baseargs, "--bind", cfg.ImgRef, "/")
 
 	for _, bind := range cfg.Mounts {
+		// For a parallel subpackage build the workspace bind is replaced by an
+		// overlay (see bubblewrapIsolationArgs) so writes to /home/build do not
+		// persist for or leak to other subpackages.
+		if cfg.Isolation != nil && bind.Destination == DefaultWorkspaceDir {
+			continue
+		}
 		baseargs = append(baseargs, "--bind", bind.Source, bind.Destination)
+	}
+	if cfg.Isolation != nil {
+		baseargs = append(baseargs, bubblewrapIsolationArgs(cfg)...)
 	}
 	// add the ref of the directory
 
@@ -257,6 +269,70 @@ func (bw *bubblewrap) TerminatePod(ctx context.Context, cfg *Config) error {
 // This is a noop for Bubblewrap, which uses bind-mounts to manage the workspace
 func (bw *bubblewrap) WorkspaceTar(ctx context.Context, cfg *Config, extraFiles []string) (io.ReadCloser, error) {
 	return nil, nil
+}
+
+// bubblewrapIsolationArgs returns the bwrap arguments that replace the workspace
+// bind with an isolated filesystem view for a parallel subpackage build:
+//   - /home/build is an overlay (lower = shared workspace, upper = private dir)
+//   - /home/build/melange-out is a read-only view of the shared outputs
+//   - /home/build/melange-out/<subpkg> is a read-write bind copied back later
+func bubblewrapIsolationArgs(cfg *Config) []string {
+	iso := cfg.Isolation
+	upper := filepath.Join(iso.BaseDir(), "upper")
+	work := filepath.Join(iso.BaseDir(), "work")
+	melangeOut := filepath.Join(cfg.WorkspaceDir, melangeOutDirName)
+	subDest := filepath.Join(DefaultWorkspaceDir, melangeOutDirName, iso.SubpkgName)
+
+	return []string{
+		"--overlay-src", cfg.WorkspaceDir,
+		"--overlay", upper, work, DefaultWorkspaceDir,
+		"--ro-bind", melangeOut, filepath.Join(DefaultWorkspaceDir, melangeOutDirName),
+		"--bind", iso.OutDir(), subDest,
+		"--tmpfs", "/tmp",
+	}
+}
+
+// SetupIsolation creates the host-side scratch directories for a parallel
+// subpackage build (bwrap runs on the host, so the isolation tree lives on the
+// host at Isolation.BaseDir()).
+func (bw *bubblewrap) SetupIsolation(ctx context.Context, cfg *Config) error {
+	if cfg.Isolation == nil {
+		return fmt.Errorf("bubblewrap: SetupIsolation called without an isolation config")
+	}
+	iso := cfg.Isolation
+	for _, d := range []string{iso.OutDir(), filepath.Join(iso.BaseDir(), "upper"), filepath.Join(iso.BaseDir(), "work")} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			return fmt.Errorf("bubblewrap: creating isolation dir %s: %w", d, err)
+		}
+	}
+	return os.MkdirAll(filepath.Join(cfg.WorkspaceDir, melangeOutDirName, iso.SubpkgName), 0o755)
+}
+
+// CopyOutIsolation copies the isolated outputs back into the shared
+// melange-out/<subpkg> directory on the host.
+func (bw *bubblewrap) CopyOutIsolation(ctx context.Context, cfg *Config) error {
+	if cfg.Isolation == nil {
+		return fmt.Errorf("bubblewrap: CopyOutIsolation called without an isolation config")
+	}
+	iso := cfg.Isolation
+	dst := filepath.Join(cfg.WorkspaceDir, melangeOutDirName, iso.SubpkgName)
+	if err := os.MkdirAll(dst, 0o755); err != nil {
+		return err
+	}
+	// #nosec G204 - paths are derived from the workspace dir and a random isolation id, not user input
+	execCmd := exec.CommandContext(ctx, "cp", "-a", iso.OutDir()+"/.", dst+"/")
+	if out, err := execCmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("bubblewrap: copying isolated outputs: %w: %s", err, string(out))
+	}
+	return nil
+}
+
+// TeardownIsolation removes the host-side isolation tree.
+func (bw *bubblewrap) TeardownIsolation(ctx context.Context, cfg *Config) error {
+	if cfg.Isolation == nil {
+		return fmt.Errorf("bubblewrap: TeardownIsolation called without an isolation config")
+	}
+	return os.RemoveAll(cfg.Isolation.BaseDir())
 }
 
 // GetReleaseData returns the OS information (os-release contents) for the Bubblewrap runner.

--- a/pkg/container/config.go
+++ b/pkg/container/config.go
@@ -86,4 +86,28 @@ type Config struct {
 	// was found in the initramfs CPIO during VM setup. When false,
 	// RetrieveObservabilityEvents returns immediately without probing the VM.
 	ObservabilityHook bool
+
+	// NeedsIsolation is set before StartPod when the build contains parallel
+	// subpackages. Runners that require extra privileges to construct isolated
+	// filesystem views (e.g. docker needs CAP_SYS_ADMIN to mount) use this to
+	// opt into those privileges only when isolation will actually be used.
+	NeedsIsolation bool
+
+	// Isolation, when non-nil, requests that Run execute inside a per-invocation
+	// isolated filesystem view (used for parallel subpackage builds). It is set
+	// on a per-subpackage clone of the base Config; the base pod's Config leaves
+	// it nil. Runners that do not implement IsolatedRunner ignore it.
+	Isolation *Isolation
+}
+
+// ForIsolation returns a shallow copy of the Config with the given Isolation
+// set (and PackageName updated to the subpackage). The copy shares the live pod
+// handles (SSH clients, PodID, image ref, workspace/cache dirs) with the base
+// Config so concurrent isolated Run calls all target the same running pod; only
+// the per-subpackage isolation state differs.
+func (c *Config) ForIsolation(iso *Isolation) *Config {
+	clone := *c
+	clone.Isolation = iso
+	clone.PackageName = iso.SubpkgName
+	return &clone
 }

--- a/pkg/container/docker/docker_runner.go
+++ b/pkg/container/docker/docker_runner.go
@@ -23,7 +23,9 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strconv"
+	"strings"
 
 	"go.opentelemetry.io/otel"
 	"golang.org/x/sync/errgroup"
@@ -40,6 +42,7 @@ import (
 	"github.com/docker/docker/pkg/stdcopy"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/empty"
+	"github.com/kballard/go-shellquote"
 	image_spec "github.com/opencontainers/image-spec/specs-go/v1"
 
 	"chainguard.dev/melange/internal/contextreader"
@@ -47,12 +50,17 @@ import (
 	mcontainer "chainguard.dev/melange/pkg/container"
 )
 
-var _ mcontainer.Debugger = (*docker)(nil)
+var (
+	_ mcontainer.Debugger       = (*docker)(nil)
+	_ mcontainer.IsolatedRunner = (*docker)(nil)
+)
 
 const (
 	DockerName = "docker"
 
 	runnerWorkdir = "/home/build"
+
+	melangeOutDirName = "melange-out"
 )
 
 // docker is a Runner implementation that uses the docker library.
@@ -105,9 +113,15 @@ func (dk *docker) StartPod(ctx context.Context, cfg *mcontainer.Config) error {
 	hostConfig := &container.HostConfig{
 		Mounts: mounts,
 	}
+	// Parallel subpackage builds construct isolated filesystem views with
+	// unshare(2)/mount(2) inside the container, which require CAP_SYS_ADMIN.
+	// Only grant it when isolation will actually be used.
+	if cfg.NeedsIsolation {
+		hostConfig.CapAdd = append(hostConfig.CapAdd, "SYS_ADMIN")
+	}
 	// Add process kernel capabilities to the container if configured.
 	if len(cfg.Capabilities.Add) > 0 {
-		hostConfig.CapAdd = cfg.Capabilities.Add
+		hostConfig.CapAdd = append(hostConfig.CapAdd, cfg.Capabilities.Add...)
 	}
 	// Drop process kernel capabilities from the container if configured.
 	if len(cfg.Capabilities.Drop) > 0 {
@@ -225,8 +239,19 @@ func (dk *docker) Run(ctx context.Context, cfg *mcontainer.Config, envOverride m
 		environ = append(environ, fmt.Sprintf("%s=%s", k, v))
 	}
 
+	// For a parallel subpackage build, wrap the command in an unshare(2) mount
+	// namespace that constructs the isolated filesystem view (see Isolation).
+	// mount(2) requires privileges, so the exec runs as root; outputs written to
+	// melange-out/<subpkg> land on the host workspace bind and are chowned back
+	// to the build user during CopyOutIsolation.
+	user := cfg.RunAsUID
+	if cfg.Isolation != nil {
+		args = dockerIsolationCommand(cfg.Isolation, args)
+		user = "0"
+	}
+
 	taskIDResp, err := dk.cli.ContainerExecCreate(ctx, cfg.PodID, container.ExecOptions{
-		User:         cfg.RunAsUID,
+		User:         user,
 		Cmd:          args,
 		WorkingDir:   runnerWorkdir,
 		Env:          environ,
@@ -366,6 +391,79 @@ func (dk *docker) Debug(ctx context.Context, cfg *mcontainer.Config, envOverride
 // This is a noop for Docker, which uses bind-mounts to manage the workspace
 func (dk *docker) WorkspaceTar(ctx context.Context, cfg *mcontainer.Config, extraFiles []string) (io.ReadCloser, error) {
 	return nil, nil
+}
+
+// dockerIsolationCommand wraps a build command in an unshare(2) mount namespace
+// that constructs the per-subpackage isolated filesystem view before exec'ing
+// the original command. The mount namespace (and thus the whole view) is torn
+// down automatically when the exec process exits, so each pipeline step re-runs
+// the setup. Writes to melange-out/<subpkg> are bind-mounted through to the host
+// workspace so they persist; writes elsewhere under /home/build do not.
+func dockerIsolationCommand(iso *mcontainer.Isolation, command []string) []string {
+	q := shellquote.Join
+	base := iso.BaseDir()
+	hostOut := filepath.Join(base, "hostout")
+	upper := filepath.Join(base, "upper")
+	work := filepath.Join(base, "work")
+	melangeOut := filepath.Join(runnerWorkdir, melangeOutDirName)
+	hostSub := filepath.Join(hostOut, iso.SubpkgName)
+
+	setup := strings.Join([]string{
+		"set -e",
+		"mount --make-rprivate /",
+		"mkdir -p " + q(hostOut) + " " + q(upper) + " " + q(work),
+		// Capture the shared melange-out before overlaying /home/build hides it.
+		"mount --bind " + q(melangeOut) + " " + q(hostOut),
+		"mkdir -p " + q(hostSub),
+		// /home/build = overlay(upper=private, lower=shared workspace).
+		fmt.Sprintf("mount -t overlay overlay -o lowerdir=%s,upperdir=%s,workdir=%s %s",
+			runnerWorkdir, upper, work, q(runnerWorkdir)),
+		// melange-out is a read-only view of the shared outputs at batch start.
+		"mount --bind " + q(hostOut) + " " + q(melangeOut),
+		"mount -o remount,ro,bind " + q(melangeOut),
+		// This subpackage's own output dir writes through to the host workspace.
+		"mount --bind " + q(hostSub) + " " + q(filepath.Join(melangeOut, iso.SubpkgName)),
+	}, "\n")
+
+	full := setup + "\nexec " + shellquote.Join(command...)
+	return []string{"unshare", "-m", "/bin/sh", "-c", full}
+}
+
+// SetupIsolation ensures the shared destination directory exists on the host
+// workspace bind. The isolated mount view itself is (re)constructed per exec in
+// Run, so there is nothing else to set up here.
+func (dk *docker) SetupIsolation(ctx context.Context, cfg *mcontainer.Config) error {
+	if cfg.Isolation == nil {
+		return fmt.Errorf("docker: SetupIsolation called without an isolation config")
+	}
+	return os.MkdirAll(filepath.Join(cfg.WorkspaceDir, melangeOutDirName, cfg.Isolation.SubpkgName), 0o755)
+}
+
+// CopyOutIsolation restores ownership of the outputs (written as root inside the
+// isolated view) back to the build user. The outputs themselves already live on
+// the host workspace via the bind mount, so no copy is required.
+func (dk *docker) CopyOutIsolation(ctx context.Context, cfg *mcontainer.Config) error {
+	if cfg.Isolation == nil {
+		return fmt.Errorf("docker: CopyOutIsolation called without an isolation config")
+	}
+	uid := cfg.RunAsUID
+	if uid == "" {
+		return nil
+	}
+	gid := cfg.RunAsGID
+	if gid == "" {
+		gid = uid
+	}
+	sub := filepath.Join(runnerWorkdir, melangeOutDirName, cfg.Isolation.SubpkgName)
+	return dk.Run(ctx, &mcontainer.Config{PodID: cfg.PodID, RunAsUID: "0"}, nil,
+		"chown", "-R", fmt.Sprintf("%s:%s", uid, gid), sub)
+}
+
+// TeardownIsolation is a noop for Docker: the isolated mount namespace is torn
+// down when each exec exits, and the private overlay layers live in the
+// container's ephemeral filesystem which is removed with the pod.
+func (dk *docker) TeardownIsolation(ctx context.Context, cfg *mcontainer.Config) error {
+	return nil
 }
 
 // GetReleaseData returns the OS information (os-release contents) for the Docker runner.

--- a/pkg/container/docker/isolation_test.go
+++ b/pkg/container/docker/isolation_test.go
@@ -1,0 +1,49 @@
+// Copyright 2024 Chainguard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package docker
+
+import (
+	"strings"
+	"testing"
+
+	mcontainer "chainguard.dev/melange/pkg/container"
+)
+
+func TestDockerIsolationCommand(t *testing.T) {
+	iso := &mcontainer.Isolation{ID: "abc123", SubpkgName: "foo-dev"}
+	cmd := dockerIsolationCommand(iso, []string{"/bin/sh", "-c", "echo hi"})
+
+	// The command runs inside an unshare(2) mount namespace.
+	if len(cmd) < 4 || cmd[0] != "unshare" || cmd[1] != "-m" {
+		t.Fatalf("expected unshare -m prefix, got %v", cmd[:min(4, len(cmd))])
+	}
+
+	script := cmd[len(cmd)-1]
+	for _, s := range []string{
+		"mount --make-rprivate /",
+		// overlay for /home/build.
+		"lowerdir=/home/build,upperdir=/tmp/parallel-build-abc123/upper,workdir=/tmp/parallel-build-abc123/work",
+		// read-only bind of the captured shared melange-out.
+		"mount -o remount,ro,bind /home/build/melange-out",
+		// read-write bind of this subpackage onto the host workspace.
+		"mount --bind /tmp/parallel-build-abc123/hostout/foo-dev /home/build/melange-out/foo-dev",
+		// finally exec the original command.
+		"exec /bin/sh -c 'echo hi'",
+	} {
+		if !strings.Contains(script, s) {
+			t.Errorf("isolation script missing %q\nfull script:\n%s", s, script)
+		}
+	}
+}

--- a/pkg/container/isolation.go
+++ b/pkg/container/isolation.go
@@ -1,0 +1,92 @@
+// Copyright 2024 Chainguard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package container
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"path"
+)
+
+// parallelBuildDirPrefix is the path prefix (inside the runner's build
+// environment) under which each parallel subpackage's isolated filesystem view
+// is constructed, e.g. /tmp/parallel-build-<id>.
+const parallelBuildDirPrefix = "/tmp/parallel-build-"
+
+// melangeOutDirName is the directory (under the workspace) where (sub)package
+// outputs are staged. It mirrors build.melangeOutputDirName.
+const melangeOutDirName = "melange-out"
+
+// Isolation describes a per-invocation isolated filesystem view requested for a
+// parallel subpackage build. When Config.Isolation is non-nil, a Runner that
+// implements IsolatedRunner executes commands inside this isolated view:
+//
+//   - /home/build is an overlay whose upper layer is a private tmpfs, so writes
+//     do not persist for or leak to other subpackages.
+//   - /home/build/melange-out is a read-only view of the shared outputs as they
+//     stood at batch start (the main package plus any earlier-batch subpackages).
+//   - /home/build/melange-out/<SubpkgName> is a read-write bind whose contents
+//     are copied back into the shared workspace once the batch completes.
+type Isolation struct {
+	// ID is unique per parallel subpackage; it namespaces the isolation tree.
+	ID string
+	// SubpkgName is the subpackage being built; melange-out/<SubpkgName> is the
+	// read-write target that is copied back after the batch completes.
+	SubpkgName string
+}
+
+// BaseDir returns the root of the isolation tree, e.g. /tmp/parallel-build-<id>.
+func (i *Isolation) BaseDir() string {
+	return parallelBuildDirPrefix + i.ID
+}
+
+// ChrootDir returns the directory the build chroots into.
+func (i *Isolation) ChrootDir() string {
+	return path.Join(i.BaseDir(), "root")
+}
+
+// OutDir returns the private read-write output directory whose contents are
+// copied back into melange-out/<SubpkgName> after the batch completes.
+func (i *Isolation) OutDir() string {
+	return path.Join(i.BaseDir(), "out")
+}
+
+// IsolatedRunner is implemented by Runners that support per-subpackage build
+// isolation (see Isolation). The build layer type-asserts a Runner to this
+// interface before scheduling a parallel batch; Runners that do not implement
+// it cannot run parallel subpackages.
+type IsolatedRunner interface {
+	// SetupIsolation constructs the isolated filesystem view described by
+	// cfg.Isolation.
+	SetupIsolation(ctx context.Context, cfg *Config) error
+	// CopyOutIsolation copies the isolated outputs back into the shared
+	// melange-out/<SubpkgName>. It is only called for subpackages that built
+	// successfully.
+	CopyOutIsolation(ctx context.Context, cfg *Config) error
+	// TeardownIsolation unmounts and removes the isolated filesystem view. It is
+	// always called, even when the build failed, and should be tolerant of a
+	// partially-constructed view.
+	TeardownIsolation(ctx context.Context, cfg *Config) error
+}
+
+// NewIsolationID returns a random hex identifier for an isolation tree.
+func NewIsolationID() (string, error) {
+	var buf [8]byte
+	if _, err := rand.Read(buf[:]); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(buf[:]), nil
+}

--- a/pkg/container/isolation_test.go
+++ b/pkg/container/isolation_test.go
@@ -1,0 +1,129 @@
+// Copyright 2024 Chainguard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package container
+
+import (
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestIsolationPaths(t *testing.T) {
+	iso := &Isolation{ID: "deadbeef", SubpkgName: "foo-dev"}
+
+	if got, want := iso.BaseDir(), "/tmp/parallel-build-deadbeef"; got != want {
+		t.Errorf("BaseDir() = %q, want %q", got, want)
+	}
+	if got, want := iso.ChrootDir(), "/tmp/parallel-build-deadbeef/root"; got != want {
+		t.Errorf("ChrootDir() = %q, want %q", got, want)
+	}
+	if got, want := iso.OutDir(), "/tmp/parallel-build-deadbeef/out"; got != want {
+		t.Errorf("OutDir() = %q, want %q", got, want)
+	}
+}
+
+func TestNewIsolationIDUnique(t *testing.T) {
+	a, err := NewIsolationID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := NewIsolationID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if a == "" || a == b {
+		t.Errorf("expected two distinct non-empty ids, got %q and %q", a, b)
+	}
+}
+
+func TestQemuIsolationSetupScript(t *testing.T) {
+	iso := &Isolation{ID: "abc123", SubpkgName: "foo-dev"}
+	script := qemuIsolationSetupScript(iso)
+
+	wantSubstrings := []string{
+		"set -e",
+		// overlay for /home/build backed by the private tmpfs upper layer.
+		"lowerdir=/mount/home/build,upperdir=/mount/tmp/parallel-build-abc123/tmp/upper,workdir=/mount/tmp/parallel-build-abc123/tmp/work",
+		// read-only bind of the shared melange-out.
+		"mount --bind /mount/home/build/melange-out /mount/tmp/parallel-build-abc123/root/home/build/melange-out",
+		"mount -o remount,ro,bind /mount/tmp/parallel-build-abc123/root/home/build/melange-out",
+		// read-write bind of this subpackage's private out dir.
+		"mount --bind /mount/tmp/parallel-build-abc123/out /mount/tmp/parallel-build-abc123/root/home/build/melange-out/foo-dev",
+		// private /tmp.
+		"mount -t tmpfs tmpfs /mount/tmp/parallel-build-abc123/root/tmp",
+	}
+	for _, s := range wantSubstrings {
+		if !strings.Contains(script, s) {
+			t.Errorf("setup script missing %q\nfull script:\n%s", s, script)
+		}
+	}
+}
+
+func TestQemuIsolationCopyOutScript(t *testing.T) {
+	iso := &Isolation{ID: "abc123", SubpkgName: "foo-dev"}
+	script := qemuIsolationCopyOutScript(iso, "build")
+
+	for _, s := range []string{
+		"cp -a /mount/tmp/parallel-build-abc123/out/. /mount/home/build/melange-out/foo-dev/",
+		"chown -R build /mount/home/build/melange-out/foo-dev",
+	} {
+		if !strings.Contains(script, s) {
+			t.Errorf("copyout script missing %q\nfull script:\n%s", s, script)
+		}
+	}
+
+	// With no user, no chown line is emitted.
+	if strings.Contains(qemuIsolationCopyOutScript(iso, ""), "chown") {
+		t.Errorf("expected no chown when user is empty")
+	}
+}
+
+func TestQemuIsolationTeardownScript(t *testing.T) {
+	iso := &Isolation{ID: "abc123", SubpkgName: "foo-dev"}
+	script := qemuIsolationTeardownScript(iso)
+
+	for _, s := range []string{
+		"umount -R /mount/tmp/parallel-build-abc123/root",
+		"rm -rf /mount/tmp/parallel-build-abc123",
+	} {
+		if !strings.Contains(script, s) {
+			t.Errorf("teardown script missing %q\nfull script:\n%s", s, script)
+		}
+	}
+}
+
+func TestBubblewrapIsolationArgs(t *testing.T) {
+	cfg := &Config{
+		WorkspaceDir: "/host/ws",
+		Isolation:    &Isolation{ID: "abc123", SubpkgName: "foo-dev"},
+	}
+	args := bubblewrapIsolationArgs(cfg)
+
+	// overlay lower is the shared workspace, dest is /home/build.
+	if i := slices.Index(args, "--overlay-src"); i < 0 || args[i+1] != "/host/ws" {
+		t.Errorf("expected --overlay-src /host/ws, got %v", args)
+	}
+	if i := slices.Index(args, "--overlay"); i < 0 || args[i+3] != DefaultWorkspaceDir {
+		t.Errorf("expected --overlay ... %s, got %v", DefaultWorkspaceDir, args)
+	}
+	// melange-out is a read-only bind.
+	if i := slices.Index(args, "--ro-bind"); i < 0 || args[i+1] != "/host/ws/melange-out" {
+		t.Errorf("expected --ro-bind /host/ws/melange-out, got %v", args)
+	}
+	// subpackage out dir is a read-write bind onto melange-out/<subpkg>.
+	if i := slices.Index(args, "--bind"); i < 0 || args[i+2] != "/home/build/melange-out/foo-dev" {
+		t.Errorf("expected --bind onto /home/build/melange-out/foo-dev, got %v", args)
+	}
+}

--- a/pkg/container/qemu_runner.go
+++ b/pkg/container/qemu_runner.go
@@ -63,7 +63,10 @@ import (
 	"chainguard.dev/melange/pkg/license"
 )
 
-var _ Debugger = (*qemu)(nil)
+var (
+	_ Debugger       = (*qemu)(nil)
+	_ IsolatedRunner = (*qemu)(nil)
+)
 
 const QemuName = "qemu"
 
@@ -113,8 +116,19 @@ func (bw *qemu) Run(ctx context.Context, cfg *Config, envOverride map[string]str
 	defer stdout.Close()
 	defer stderr.Close()
 
+	// For a parallel subpackage build, run the command inside the per-subpackage
+	// chroot via the privileged (control) build client. The command runs as root
+	// within the chroot; its outputs are chowned back to the build user during
+	// CopyOutIsolation. Subpackage pipelines are split operations for which this
+	// is acceptable.
+	client := cfg.SSHBuildClient
+	if cfg.Isolation != nil {
+		client = cfg.SSHControlBuildClient
+		args = append([]string{"chroot", cfg.Isolation.ChrootDir()}, args...)
+	}
+
 	err := sendSSHCommand(ctx,
-		cfg.SSHBuildClient,
+		client,
 		cfg,
 		envOverride,
 		stderr,
@@ -127,6 +141,130 @@ func (bw *qemu) Run(ctx context.Context, cfg *Config, envOverride map[string]str
 	}
 
 	return nil
+}
+
+// runControlScript runs a /bin/sh script via the given SSH client, streaming
+// output to the logger.
+func (bw *qemu) runControlScript(ctx context.Context, client *ssh.Client, cfg *Config, script string) error {
+	log := clog.FromContext(ctx)
+	stdout, stderr := logwriter.New(log.Info), logwriter.New(log.Warn)
+	defer stdout.Close()
+	defer stderr.Close()
+
+	return sendSSHCommand(ctx, client, cfg, nil, stderr, stdout, false, []string{"sh", "-c", script})
+}
+
+// SetupIsolation constructs the isolated filesystem view for a parallel
+// subpackage build. See Isolation for the resulting layout.
+func (bw *qemu) SetupIsolation(ctx context.Context, cfg *Config) error {
+	if cfg.Isolation == nil {
+		return fmt.Errorf("qemu: SetupIsolation called without an isolation config")
+	}
+	return bw.runControlScript(ctx, cfg.SSHControlClient, cfg, qemuIsolationSetupScript(cfg.Isolation))
+}
+
+// CopyOutIsolation copies the isolated outputs back into the shared
+// melange-out/<subpkg> directory.
+func (bw *qemu) CopyOutIsolation(ctx context.Context, cfg *Config) error {
+	if cfg.Isolation == nil {
+		return fmt.Errorf("qemu: CopyOutIsolation called without an isolation config")
+	}
+	user := ""
+	if cfg.SSHBuildClient != nil {
+		user = cfg.SSHBuildClient.User()
+	}
+	return bw.runControlScript(ctx, cfg.SSHControlClient, cfg, qemuIsolationCopyOutScript(cfg.Isolation, user))
+}
+
+// TeardownIsolation unmounts and removes the isolated filesystem view. It is
+// tolerant of a partially-constructed view.
+func (bw *qemu) TeardownIsolation(ctx context.Context, cfg *Config) error {
+	if cfg.Isolation == nil {
+		return fmt.Errorf("qemu: TeardownIsolation called without an isolation config")
+	}
+	return bw.runControlScript(ctx, cfg.SSHControlClient, cfg, qemuIsolationTeardownScript(cfg.Isolation))
+}
+
+// The guest runs the build chrooted at /mount, so the control client sees the
+// isolation tree at /mount/<Isolation.BaseDir()> while the (already chrooted)
+// build client sees it at <Isolation.BaseDir()>.
+const qemuGuestMount = "/mount"
+
+// qemuIsolationSetupScript builds the shell script (run by the unchrooted
+// control client) that constructs the isolated filesystem view.
+func qemuIsolationSetupScript(iso *Isolation) string {
+	q := shellquote.Join
+	base := filepath.Join(qemuGuestMount, iso.BaseDir())
+	tmpDir := filepath.Join(base, "tmp")
+	upper := filepath.Join(tmpDir, "upper")
+	work := filepath.Join(tmpDir, "work")
+	outDir := filepath.Join(base, "out")
+	chrootRoot := filepath.Join(base, "root")
+	chrootHomeBuild := filepath.Join(chrootRoot, "home", "build")
+	chrootMelangeOut := filepath.Join(chrootHomeBuild, "melange-out")
+	chrootSubDir := filepath.Join(chrootMelangeOut, iso.SubpkgName)
+	chrootTmp := filepath.Join(chrootRoot, "tmp")
+
+	sharedMelangeOut := filepath.Join(qemuGuestMount, "home", "build", "melange-out")
+	sharedSubDir := filepath.Join(sharedMelangeOut, iso.SubpkgName)
+
+	lines := []string{
+		"set -e",
+		// Ensure the shared destination exists so it is visible in the read-only
+		// bind and can be used as the read-write bind mountpoint.
+		"mkdir -p " + q(sharedSubDir),
+		"mkdir -p " + q(tmpDir) + " " + q(outDir) + " " + q(chrootRoot),
+		// Private tmpfs backing the overlay upper layer.
+		"mount -t tmpfs tmpfs " + q(tmpDir),
+		"mkdir -p " + q(upper) + " " + q(work),
+		// Chroot root is a recursive bind of the guest rootfs so binaries/libs
+		// are available; /home/build and /tmp are then replaced below.
+		"mount --rbind " + q(qemuGuestMount) + " " + q(chrootRoot),
+		"mount --make-rslave " + q(chrootRoot),
+		// /home/build = overlay(upper=private tmpfs, lower=shared /home/build).
+		fmt.Sprintf("mount -t overlay overlay -o lowerdir=%s,upperdir=%s,workdir=%s %s",
+			filepath.Join(qemuGuestMount, "home", "build"), upper, work, q(chrootHomeBuild)),
+		// melange-out is a read-only view of the shared outputs at batch start.
+		"mount --bind " + q(sharedMelangeOut) + " " + q(chrootMelangeOut),
+		"mount -o remount,ro,bind " + q(chrootMelangeOut),
+		// This subpackage's own output dir is read-write, over the read-only bind.
+		"mount --bind " + q(outDir) + " " + q(chrootSubDir),
+		// Private /tmp so scratch files do not leak or collide.
+		"mount -t tmpfs tmpfs " + q(chrootTmp),
+	}
+	return strings.Join(lines, "\n")
+}
+
+// qemuIsolationCopyOutScript builds the shell script that copies the isolated
+// outputs back into the shared workspace and restores ownership.
+func qemuIsolationCopyOutScript(iso *Isolation, user string) string {
+	q := shellquote.Join
+	base := filepath.Join(qemuGuestMount, iso.BaseDir())
+	outDir := filepath.Join(base, "out")
+	sharedSubDir := filepath.Join(qemuGuestMount, "home", "build", "melange-out", iso.SubpkgName)
+
+	lines := []string{
+		"set -e",
+		"mkdir -p " + q(sharedSubDir),
+		"cp -a " + q(outDir+"/.") + " " + q(sharedSubDir+"/"),
+	}
+	if user != "" {
+		lines = append(lines, "chown -R "+q(user)+" "+q(sharedSubDir))
+	}
+	return strings.Join(lines, "\n")
+}
+
+// qemuIsolationTeardownScript builds the shell script that unmounts and removes
+// the isolated filesystem view.
+func qemuIsolationTeardownScript(iso *Isolation) string {
+	q := shellquote.Join
+	base := filepath.Join(qemuGuestMount, iso.BaseDir())
+	lines := []string{
+		"umount -R " + q(filepath.Join(base, "root")) + " 2>/dev/null || true",
+		"umount -R " + q(filepath.Join(base, "tmp")) + " 2>/dev/null || true",
+		"rm -rf " + q(base),
+	}
+	return strings.Join(lines, "\n")
 }
 
 func (bw *qemu) Debug(ctx context.Context, cfg *Config, envOverride map[string]string, args ...string) error {


### PR DESCRIPTION
Adds an opt-in `parallel: true` flag to subpackages. Consecutive parallel subpackages form a batch that builds concurrently, each in an isolated filesystem view; a non-parallel subpackage acts as a synchronization barrier. Concurrency is unbounded unless the config sets `max-parallel-subpackages`.

Each parallel subpackage gets `/home/build` as an overlay backed by a private upper layer, a read-only view of `melange-out` as it stood at batch start, and a read-write `melange-out/<subpkg>` that is copied back after the batch completes (before workspace retrieval, so linting/SBOM/emit are unaffected). Isolation is implemented for the qemu, bubblewrap, and docker runners.

Interactive/debug-runner builds fall back to sequential.

🤖 Generated with [Claude Code](https://claude.com/claude-code)