### PR TITLE
feat(build): cache `uses:` pipeline definitions; allow script normalization to be skipped

### DIFF
--- a/pkg/build/compile.go
+++ b/pkg/build/compile.go
@@ -25,7 +25,6 @@ import (
 	"strings"
 
 	"github.com/chainguard-dev/clog"
-	"gopkg.in/yaml.v3"
 	"mvdan.cc/sh/v3/syntax"
 
 	"chainguard.dev/melange/pkg/cond"
@@ -34,6 +33,27 @@ import (
 )
 
 const unidentifiablePipeline = "???"
+
+// CompileOption adjusts what a Compile produces.
+type CompileOption func(*Compiled)
+
+// WithDependenciesOnly narrows compilation to what a caller resolving build
+// dependencies needs, which is the `uses:` tree and the packages it pulls in.
+//
+// The compiled pipelines are not runnable: each step's `runs:` keeps the
+// comments and formatting it was written with, because normalizing it is the
+// single most expensive part of compiling and a caller that only reads
+// .environment.contents.packages discards it. Everything else — substitution,
+// validation, conditionals and the resolved dependency list — is unchanged, so
+// a definition that fails to compile still fails the same way.
+//
+// Do not use this to produce a configuration that will be built or recorded:
+// use a plain Compile for that.
+func WithDependenciesOnly() CompileOption {
+	return func(c *Compiled) {
+		c.dependenciesOnly = true
+	}
+}
 
 func (t *Test) Compile(ctx context.Context) error {
 	cfg := t.Configuration
@@ -122,16 +142,14 @@ func (t *Test) Compile(ctx context.Context) error {
 }
 
 // Compile compiles all configuration, including tests, by loading any pipelines and substituting all variables.
-func (b *Build) Compile(ctx context.Context) error {
+func (b *Build) Compile(ctx context.Context, opts ...CompileOption) error {
 	cfg := b.Configuration
 	sm, err := NewSubstitutionMap(cfg, b.Arch, b.buildFlavor(), b.EnabledBuildOptions)
 	if err != nil {
 		return err
 	}
 
-	c := &Compiled{
-		PipelineDirs: b.PipelineDirs,
-	}
+	c := newCompiled(b.PipelineDirs, opts)
 
 	if err := c.CompilePipelines(ctx, sm, cfg.Pipeline); err != nil {
 		return fmt.Errorf("compiling %q pipelines: %w", cfg.Package.Name, err)
@@ -155,9 +173,7 @@ func (b *Build) Compile(ctx context.Context) error {
 			continue
 		}
 
-		tc := &Compiled{
-			PipelineDirs: b.PipelineDirs,
-		}
+		tc := newCompiled(b.PipelineDirs, opts)
 		if err := tc.CompilePipelines(ctx, sm, sp.Test.Pipeline); err != nil {
 			return fmt.Errorf("compiling subpackage %q tests: %w", sp.Name, err)
 		}
@@ -178,9 +194,7 @@ func (b *Build) Compile(ctx context.Context) error {
 	ic.Packages = append(ic.Packages, c.Needs...)
 
 	if cfg.Test != nil {
-		tc := &Compiled{
-			PipelineDirs: b.PipelineDirs,
-		}
+		tc := newCompiled(b.PipelineDirs, opts)
 
 		if err := tc.CompilePipelines(ctx, sm, cfg.Test.Pipeline); err != nil {
 			return fmt.Errorf("compiling %q test pipelines: %w", cfg.Package.Name, err)
@@ -202,6 +216,19 @@ func (b *Build) Compile(ctx context.Context) error {
 type Compiled struct {
 	PipelineDirs []string
 	Needs        []string
+
+	// dependenciesOnly skips producing runnable `runs:` bodies. See
+	// WithDependenciesOnly.
+	dependenciesOnly bool
+}
+
+func newCompiled(pipelineDirs []string, opts []CompileOption) *Compiled {
+	c := &Compiled{PipelineDirs: pipelineDirs}
+	for _, opt := range opts {
+		opt(c)
+	}
+
+	return c
 }
 
 func (c *Compiled) CompilePipelines(ctx context.Context, sm *SubstitutionMap, pipelines []config.Pipeline) error {
@@ -219,7 +246,6 @@ func (c *Compiled) CompilePipelines(ctx context.Context, sm *SubstitutionMap, pi
 }
 
 func (c *Compiled) compilePipeline(ctx context.Context, sm *SubstitutionMap, pipeline *config.Pipeline, parent map[string]string) error {
-	log := clog.FromContext(ctx)
 	name, uses, with := pipeline.Name, pipeline.Uses, maps.Clone(pipeline.With)
 
 	// When compiling an already-compiled config, `uses` will be redundant and FYI only,
@@ -230,34 +256,18 @@ func (c *Compiled) compilePipeline(ctx context.Context, sm *SubstitutionMap, pip
 			return fmt.Errorf("invalid pipeline 'uses' value %q: must not contain absolute paths or '..' sequences", uses)
 		}
 
-		var data []byte
-		// Set this to fail up front in case there are no pipeline dirs specified
-		// and we can't find them.
-		err := fmt.Errorf("could not find 'uses' pipeline %q", uses)
-
-		for _, pd := range c.PipelineDirs {
-			log.Debugf("trying to load pipeline %q from %q", uses, pd)
-			target := filepath.Join(pd, uses+".yaml")
-			// Verify the resolved path is still within the pipeline directory.
-			if rel, err := filepath.Rel(pd, filepath.Clean(target)); err != nil || strings.HasPrefix(rel, "..") {
-				return fmt.Errorf("pipeline 'uses' value %q resolves outside pipeline directory %q", uses, pd)
-			}
-			data, err = os.ReadFile(target) // #nosec G304 - Loading pipeline definition from configured directory
-			if err == nil {
-				log.Debugf("Found pipeline %s", string(data))
-				break
-			}
-		}
+		// Reading and parsing the definition only happens the first time it
+		// is used; see usesDocument.
+		doc, err := usesDocument(c.PipelineDirs, uses, func() ([]byte, error) {
+			return c.readUses(ctx, uses)
+		})
 		if err != nil {
-			log.Debugf("trying to load pipeline %q from embedded fs pipelines/%q.yaml", uses, uses)
-			data, err = PipelinesFS.ReadFile("pipelines/" + uses + ".yaml")
-			if err != nil {
-				return fmt.Errorf("unable to load pipeline: %w", err)
-			}
+			return err
 		}
-
-		if err := yaml.Unmarshal(data, pipeline); err != nil {
-			return fmt.Errorf("unable to parse pipeline %q: %w", uses, err)
+		if doc != nil {
+			if err := doc.Decode(pipeline); err != nil {
+				return fmt.Errorf("unable to parse pipeline %q: %w", uses, err)
+			}
 		}
 
 		for k := range with {
@@ -308,10 +318,14 @@ func (c *Compiled) compilePipeline(ctx context.Context, sm *SubstitutionMap, pip
 		return fmt.Errorf("mutating runs: %w", err)
 	}
 
-	// Drop any comments to avoid leaking things into .melange.json.
-	pipeline.Runs, err = stripComments(pipeline.Runs)
-	if err != nil {
-		return fmt.Errorf("stripping runs comments: %w", err)
+	// Drop any comments to avoid leaking things into .melange.json. Parsing
+	// the script to do it costs more than the rest of compiling the step, so
+	// a caller that is only resolving dependencies skips it.
+	if !c.dependenciesOnly {
+		pipeline.Runs, err = stripComments(pipeline.Runs)
+		if err != nil {
+			return fmt.Errorf("stripping runs comments: %w", err)
+		}
 	}
 
 	if pipeline.If != "" {
@@ -354,6 +368,40 @@ func (c *Compiled) compilePipeline(ctx context.Context, sm *SubstitutionMap, pip
 	pipeline.Inputs = nil
 
 	return nil
+}
+
+// readUses reads the definition named by uses from the configured pipeline
+// directories, falling back to the ones built into melange.
+func (c *Compiled) readUses(ctx context.Context, uses string) ([]byte, error) {
+	log := clog.FromContext(ctx)
+
+	var data []byte
+	// Set this to fail up front in case there are no pipeline dirs specified
+	// and we can't find them.
+	err := fmt.Errorf("could not find 'uses' pipeline %q", uses)
+
+	for _, pd := range c.PipelineDirs {
+		log.Debugf("trying to load pipeline %q from %q", uses, pd)
+		target := filepath.Join(pd, uses+".yaml")
+		// Verify the resolved path is still within the pipeline directory.
+		if rel, err := filepath.Rel(pd, filepath.Clean(target)); err != nil || strings.HasPrefix(rel, "..") {
+			return nil, fmt.Errorf("pipeline 'uses' value %q resolves outside pipeline directory %q", uses, pd)
+		}
+		data, err = os.ReadFile(target) // #nosec G304 - Loading pipeline definition from configured directory
+		if err == nil {
+			log.Debugf("Found pipeline %s", string(data))
+			break
+		}
+	}
+	if err != nil {
+		log.Debugf("trying to load pipeline %q from embedded fs pipelines/%q.yaml", uses, uses)
+		data, err = PipelinesFS.ReadFile("pipelines/" + uses + ".yaml")
+		if err != nil {
+			return nil, fmt.Errorf("unable to load pipeline: %w", err)
+		}
+	}
+
+	return data, nil
 }
 
 func identity(p *config.Pipeline) string {

--- a/pkg/build/usescache.go
+++ b/pkg/build/usescache.go
@@ -1,0 +1,96 @@
+/*
+Copyright 2026 Chainguard, Inc.
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package build
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+
+	"gopkg.in/yaml.v3"
+)
+
+// usesCache memoizes the parsed form of the pipeline definitions loaded by
+// `uses:`.
+//
+// A definition is resolved from the same pipeline directories every time, and
+// compiling a tree of package definitions asks for the same few of them over
+// and over: a repository whose packages mostly `uses: go/build` parses that
+// one file once per package that names it. Parsing the YAML is the expensive
+// half of loading it, so the parsed document is what is kept.
+//
+// What is cached is the document, not a compiled pipeline. Compilation
+// substitutes each package's own variables into the definition, so the result
+// differs per package and only the parse is shared.
+//
+// The cache lives for the life of the process and assumes the pipeline
+// directories do not change underneath it, which holds for a melange build and
+// for the tools that compile a checked-out tree. Nothing invalidates it.
+//
+// sync.Map rather than a guarded map: once the definitions in use have been
+// seen, every access is a read, and callers compile packages in parallel. A
+// mutex — even an RWMutex, whose read path still writes a shared counter —
+// would put every one of those reads through the same cache line.
+var usesCache sync.Map // map[string]*yaml.Node, nil for an empty definition
+
+// usesKey identifies a pipeline definition by the directories it is looked up
+// in and the name it is looked up by, which is everything that determines
+// which file wins.
+func usesKey(pipelineDirs []string, uses string) string {
+	return strings.Join(pipelineDirs, "\x00") + "\x00\x00" + uses
+}
+
+// usesDocument returns the parsed document for the pipeline definition named
+// by uses, calling load to read it only the first time it is asked for.
+//
+// A nil document means the definition was empty, which yaml.Unmarshal treats
+// as a no-op and so does the caller.
+//
+// Callers decode the returned document onto their own pipeline rather than
+// receiving a copy. Decoding a document onto an existing value applies the keys
+// the document sets and leaves the rest alone — the same as yaml.Unmarshal, and
+// what the caller depends on, since a step's own `with`, `if` and `workdir` have
+// to survive loading the definition it names.
+func usesDocument(pipelineDirs []string, uses string, load func() ([]byte, error)) (*yaml.Node, error) {
+	key := usesKey(pipelineDirs, uses)
+
+	if cached, ok := usesCache.Load(key); ok {
+		return cached.(*yaml.Node), nil
+	}
+
+	data, err := load()
+	if err != nil {
+		return nil, err
+	}
+
+	var doc yaml.Node
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return nil, fmt.Errorf("unable to parse pipeline %q: %w", uses, err)
+	}
+
+	// An empty definition parses to a document with no content, which Decode
+	// rejects. Record it so it is not read again, and let the caller skip it.
+	if doc.Kind == 0 || (doc.Kind == yaml.DocumentNode && len(doc.Content) == 0) {
+		usesCache.Store(key, (*yaml.Node)(nil))
+		return nil, nil
+	}
+
+	usesCache.Store(key, &doc)
+
+	return &doc, nil
+}

--- a/pkg/build/usescache_test.go
+++ b/pkg/build/usescache_test.go
@@ -1,0 +1,249 @@
+/*
+Copyright 2026 Chainguard, Inc.
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package build
+
+import (
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+
+	"chainguard.dev/melange/pkg/config"
+)
+
+// definition is a pipeline definition of the shape `uses:` loads: it names
+// some keys and leaves others out.
+const definition = `name: definition name
+inputs:
+  version:
+    description: the version
+    default: "1.0"
+needs:
+  packages:
+    - busybox
+pipeline:
+  - runs: echo hi
+`
+
+// loadUses does what compilePipeline does with a document: fetch it, then
+// decode it onto the pipeline.
+func loadUses(dirs []string, uses string, load func() ([]byte, error), pipeline *config.Pipeline) error {
+	doc, err := usesDocument(dirs, uses, load)
+	if err != nil {
+		return err
+	}
+	if doc == nil {
+		return nil
+	}
+
+	return doc.Decode(pipeline)
+}
+
+func serve(data string, calls *atomic.Int64) func() ([]byte, error) {
+	return func() ([]byte, error) {
+		if calls != nil {
+			calls.Add(1)
+		}
+
+		return []byte(data), nil
+	}
+}
+
+// TestUsesDocumentMatchesUnmarshal pins that loading a definition through the
+// cache leaves the target in the state yaml.Unmarshal would, on both the parse
+// and the cached path, and that the definition is only read once. Keys the
+// definition sets are applied; the ones it omits keep the values the step
+// brought with it.
+func TestUsesDocumentMatchesUnmarshal(t *testing.T) {
+	step := func() *config.Pipeline {
+		return &config.Pipeline{
+			Uses:    "some/pipeline",
+			With:    map[string]string{"version": "2.0"},
+			If:      "true",
+			WorkDir: "/home/build",
+		}
+	}
+
+	want := step()
+	if err := yaml.Unmarshal([]byte(definition), want); err != nil {
+		t.Fatalf("yaml.Unmarshal: %v", err)
+	}
+
+	dirs := []string{t.TempDir()}
+	var calls atomic.Int64
+
+	for _, when := range []string{"parsed", "cached"} {
+		got := step()
+		if err := loadUses(dirs, "some/pipeline", serve(definition, &calls), got); err != nil {
+			t.Fatalf("%s: %v", when, err)
+		}
+
+		if got.Name != want.Name {
+			t.Errorf("%s: name: got = %q, want = %q", when, got.Name, want.Name)
+		}
+		if got.WorkDir != want.WorkDir {
+			t.Errorf("%s: workdir: got = %q, want = %q", when, got.WorkDir, want.WorkDir)
+		}
+		if got.If != want.If {
+			t.Errorf("%s: if: got = %q, want = %q", when, got.If, want.If)
+		}
+		if len(got.With) != len(want.With) || got.With["version"] != want.With["version"] {
+			t.Errorf("%s: with: got = %v, want = %v", when, got.With, want.With)
+		}
+		if len(got.Inputs) != len(want.Inputs) {
+			t.Errorf("%s: inputs: got = %d, want = %d", when, len(got.Inputs), len(want.Inputs))
+		}
+		if got.Needs == nil || len(got.Needs.Packages) != 1 || got.Needs.Packages[0] != "busybox" {
+			t.Errorf("%s: needs: got = %v, want = [busybox]", when, got.Needs)
+		}
+		if len(got.Pipeline) != 1 || got.Pipeline[0].Runs != "echo hi" {
+			t.Errorf("%s: pipeline: got = %v", when, got.Pipeline)
+		}
+	}
+
+	// The point of the cache: the definition is read from disk once, not once
+	// per package that names it.
+	if got := calls.Load(); got != 1 {
+		t.Errorf("loads: got = %d, want = 1", got)
+	}
+}
+
+// TestUsesDocumentKeyedByPipelineDirs checks that two pipeline directory sets
+// resolving the same name to different definitions do not share an entry.
+func TestUsesDocumentKeyedByPipelineDirs(t *testing.T) {
+	first := []string{t.TempDir()}
+	second := []string{t.TempDir()}
+
+	one := &config.Pipeline{}
+	if err := loadUses(first, "shared", serve("name: one\n", nil), one); err != nil {
+		t.Fatal(err)
+	}
+
+	two := &config.Pipeline{}
+	if err := loadUses(second, "shared", serve("name: two\n", nil), two); err != nil {
+		t.Fatal(err)
+	}
+
+	if one.Name != "one" {
+		t.Errorf("first dirs: got = %q, want = %q", one.Name, "one")
+	}
+	if two.Name != "two" {
+		t.Errorf("second dirs: got = %q, want = %q", two.Name, "two")
+	}
+}
+
+// TestUsesDocumentEmptyDefinition checks that an empty definition is the no-op
+// yaml.Unmarshal makes of it rather than an error, and that it is not read a
+// second time.
+func TestUsesDocumentEmptyDefinition(t *testing.T) {
+	for _, data := range []string{"", "\n", "# just a comment\n"} {
+		want := &config.Pipeline{Uses: "empty"}
+		if err := yaml.Unmarshal([]byte(data), want); err != nil {
+			t.Fatalf("yaml.Unmarshal(%q): %v", data, err)
+		}
+
+		dirs := []string{t.TempDir()}
+		var calls atomic.Int64
+
+		for range 2 {
+			got := &config.Pipeline{Uses: "empty"}
+			if err := loadUses(dirs, "empty", serve(data, &calls), got); err != nil {
+				t.Errorf("%q: %v", data, err)
+				continue
+			}
+			if got.Uses != want.Uses {
+				t.Errorf("%q: uses: got = %q, want = %q", data, got.Uses, want.Uses)
+			}
+		}
+
+		if got := calls.Load(); got != 1 {
+			t.Errorf("%q: loads: got = %d, want = 1", data, got)
+		}
+	}
+}
+
+// TestUsesDocumentLoadError checks that a definition that cannot be read
+// reports the loader's own error and is not cached.
+func TestUsesDocumentLoadError(t *testing.T) {
+	dirs := []string{t.TempDir()}
+	want := errors.New("could not find 'uses' pipeline")
+
+	for range 2 {
+		_, err := usesDocument(dirs, "missing", func() ([]byte, error) { return nil, want })
+		if !errors.Is(err, want) {
+			t.Fatalf("got = %v, want = %v", err, want)
+		}
+	}
+
+	// A failure must not be remembered as an empty definition.
+	got := &config.Pipeline{}
+	if err := loadUses(dirs, "missing", serve("name: recovered\n", nil), got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Name != "recovered" {
+		t.Errorf("name: got = %q, want = %q", got.Name, "recovered")
+	}
+}
+
+// TestUsesDocumentConcurrent decodes one cached definition from many goroutines
+// at once. Cached documents are shared across the goroutines that compile a
+// tree of packages in parallel, so decoding must not write to the document it
+// decodes from. Run under -race for this to mean anything.
+func TestUsesDocumentConcurrent(t *testing.T) {
+	dirs := []string{t.TempDir()}
+
+	// Seed the entry so every goroutine below takes the cached path.
+	if err := loadUses(dirs, "concurrent", serve(definition, nil), &config.Pipeline{}); err != nil {
+		t.Fatal(err)
+	}
+
+	const goroutines = 32
+	results := make([]*config.Pipeline, goroutines)
+	errs := make([]error, goroutines)
+
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	for i := range goroutines {
+		wg.Go(func() {
+			<-start
+			p := &config.Pipeline{Uses: "concurrent", WorkDir: "/home/build"}
+			errs[i] = loadUses(dirs, "concurrent", serve(definition, nil), p)
+			results[i] = p
+		})
+	}
+	close(start)
+	wg.Wait()
+
+	for i := range goroutines {
+		if errs[i] != nil {
+			t.Fatalf("goroutine %d: %v", i, errs[i])
+		}
+		got := results[i]
+		if got.Name != "definition name" || got.WorkDir != "/home/build" {
+			t.Errorf("goroutine %d: got name = %q workdir = %q", i, got.Name, got.WorkDir)
+		}
+		if got.Needs == nil || len(got.Needs.Packages) != 1 {
+			t.Errorf("goroutine %d: needs: got = %v", i, got.Needs)
+		}
+		if len(got.Pipeline) != 1 || got.Pipeline[0].Runs != "echo hi" {
+			t.Errorf("goroutine %d: pipeline: got = %v", i, got.Pipeline)
+		}
+	}
+}


### PR DESCRIPTION
Compiling reads and parses a pipeline definition behind every `uses:` step. This is fine for a single package [definition] but wasteful in scenarios which compile an entire repository of package definitions solely to work out its dependency graph.

Definitions can number in the hundreds or thousands and each is read and parsed once per package. `usesDocument` now keeps the parsed YAML document, keyed by the pipeline directories and the `uses` name, with the file read behind the same cache so a also hit costs no syscalls.

The document is cached as opposed to the compiled pipeline. Downstream consumers decode it onto their own pipeline, which then applies the keys the definition sets and leaves the rest alone, exactly as `yaml.Unmarshal` onto an existing value does. A step's own `with`, `if` and `workdir` need to survive loading the definition it names since a cached copy cannot distinguish between "absent" and "present and zero". 

The second change updates `Compile` to support options, and `WithDependenciesOnly()` skips `stripComments`. Dropping comments from a `runs:` body means shell-parsing and re-printing it, which is the single most expensive part of compiling a step. A caller that compiles only to learn what `.environment.contents.packages` resolves to discards that body entirely. 

Substitution, validation, conditionals and the resolved dependency list are unchanged, so a definition that fails to compile still fails the same way. Nothing in this repository passes the option and it exists explicitly for `wolfictl`'s `dag.NewPackages` and any tooling built on it, which is a one-line change there plus a version bump. The `uses` cache needs no caller change at all.

Measured over ~10,000 package definitions across several directories:

| | compile | total runtime | vs baseline |
| -- | -- | -- | -- |
| baseline | 18.54s | 22.54s | — |
| `uses` cache | 10.45s | 14.62s | 1.8× |
| `uses` cache + `WithDependenciesOnly` | 2.55s | 6.54s | 7.3× |

Both changes individually reduce runtime compared to the baseline timing. On a single directory, the cache alone takes 6.55s to 4.25s, the option alone takes it to 3.45s, and together they reach 1.40s. `Compile` is no longer the dominant term and at 2.55s it now sits below `config.ParseConfiguration`.

A local test compiled all ~10,000 definitions and verified each resulting configuration. The `uses` cache produces zero differences against the baseline, so nothing a package records changes, and `WithDependenciesOnly` produces zero differences in resolved dependency lists against a full compile, which is all its callers read. 

Cached documents are shared across goroutines, so `TestUsesDocumentConcurrent` decodes one entry from 32 at once, and the whole corpus was compiled at `GOMAXPROCS=$(nproc)` under `-race` with no races. A load failure is not cached, so an unreadable definition is retried rather than remembered as empty; an empty definition is cached.
