### PR TITLE
feat(ci): use matrix for E2E Jobs; tidy up actionlint/shellcheck findings

### DIFF
--- a/.chainguard/source.yaml
+++ b/.chainguard/source.yaml
@@ -8,6 +8,9 @@ spec:
         identities:
           - issuer: https://accounts.google.com
           - issuer: https://github.com/login/oauth
+          # allow the digest bump commits gitsign-signed by the digestabot workflow
+          - issuer: https://token.actions.githubusercontent.com
+            subject: https://github.com/chainguard-dev/melange/.github/workflows/digestabot.yaml@refs/heads/main
     - key:
         # allow commits signed by GitHub, e.g. the UI
         kms: https://github.com/web-flow.gpg

--- a/.github/chainguard/digestabot.sts.yaml
+++ b/.github/chainguard/digestabot.sts.yaml
@@ -1,0 +1,8 @@
+issuer: https://token.actions.githubusercontent.com
+subject: repo:chainguard-dev/melange:ref:refs/heads/main
+claim_pattern:
+  workflow_ref: chainguard-dev/melange/.github/workflows/digestabot.yaml@refs/heads/main
+
+permissions:
+  contents: write
+  pull_requests: write

--- a/.github/workflows/actionlint.yaml
+++ b/.github/workflows/actionlint.yaml
@@ -44,7 +44,8 @@ jobs:
         id: get_yamls
         run: |
           set -ex
-          mapfile -t yamls < <(find .github/workflows -name "*.y*ml" | grep -v dependabot.)
+          found="$(find .github/workflows -name "*.y*ml" -not -name "dependabot.*")"
+          mapfile -t yamls <<< "${found}"
           echo "files=${yamls[*]}" >> "${GITHUB_OUTPUT}"
 
       - name: Action lint

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -42,6 +42,9 @@ jobs:
         with:
           go-version-file: "./go.mod"
           check-latest: true
+          # This job feeds goreleaser, so don't let a cache restored from
+          # another ref influence what it builds.
+          cache: false
 
       - name: build
         run: |

--- a/.github/workflows/digestabot.yaml
+++ b/.github/workflows/digestabot.yaml
@@ -1,0 +1,62 @@
+# Copyright 2026 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+name: Image digest update
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "17 1 * * *"
+
+permissions: {}
+
+jobs:
+  image-update:
+    name: Image digest update
+    runs-on: ubuntu-latest
+    if: github.repository == 'chainguard-dev/melange'
+
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            *.blob.core.windows.net:443
+            *.githubapp.com:443
+            api.github.com:443
+            auth.docker.io:443
+            fulcio.sigstore.dev:443
+            github.com:443
+            index.docker.io:443
+            objects.githubusercontent.com:443
+            octo-sts.dev:443
+            production.cloudflare.docker.com:443
+            registry-1.docker.io:443
+            rekor.sigstore.dev:443
+            release-assets.githubusercontent.com:443
+            tuf-repo-cdn.sigstore.dev:443
+
+      # .chainguard/source.yaml requires commits to be signed.
+      - uses: chainguard-dev/actions/setup-gitsign@9d631658f55713e5f63ca0cc21ee168f81301fd9 # v1.6.30
+
+      - uses: octo-sts/action@f603d3be9d8dd9871a265776e625a27b00effe05 # v1.1.1
+        id: octo-sts
+        with:
+          scope: ${{ github.repository }}
+          identity: digestabot
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        # zizmor: ignore[artipacked] - credentials needed for digestabot to push and create PRs
+        with:
+          token: ${{ steps.octo-sts.outputs.token }}
+
+      # Only the workflows pin image digests today; the melange configs under
+      # examples/ and e2e-tests/ reference apk packages, not images.
+      - uses: chainguard-dev/digestabot@33d0b78e580aa0c83fe188eb3dfad6611b662479 # v1.3.2
+        with:
+          token: ${{ steps.octo-sts.outputs.token }}
+          include-files: ".github/workflows/*.yaml"

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -33,9 +33,16 @@ jobs:
           - melange.yaml # special; builds melange itself
 
     container:
-      image: alpine:latest
+      image: alpine:latest@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
       options: |
         --cap-add NET_ADMIN --cap-add SYS_ADMIN --security-opt seccomp=unconfined --security-opt apparmor:unconfined
+
+    # alpine has no bash, so the default 'bash' shell already falls back to sh.
+    # Say so explicitly, so shellcheck lints these scripts as the shell that
+    # actually runs them.
+    defaults:
+      run:
+        shell: sh
 
     steps:
       - uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
@@ -63,11 +70,11 @@ jobs:
         env:
           MATRIX_CFG: ${{ matrix.cfg }}
         run: |
-          path=examples/$MATRIX_CFG
-          if [ "$MATRIX_CFG" == "melange.yaml" ]; then
+          path="examples/${MATRIX_CFG}"
+          if [ "${MATRIX_CFG}" = "melange.yaml" ]; then
             path="melange.yaml"
           fi
-          ./melange build "$path" --arch=x86_64 --namespace=wolfi
+          ./melange build "${path}" --arch=x86_64 --namespace=wolfi
 
       - name: Rebuild package
         run: |

--- a/.github/workflows/melange-test-pipelines.yaml
+++ b/.github/workflows/melange-test-pipelines.yaml
@@ -8,10 +8,85 @@ on:
 
 permissions: {}
 
+# Each push to a PR fans out one 8-core runner per e2e test, so don't leave
+# superseded runs going.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
-  build-melange:
-    name: Build melange and add to artifact cache
+  # Cheap and checkout-only, so the Go matrix isn't gated on the melange build
+  # and the kernel fetch. Both matrices are discovered rather than hand-listed,
+  # so adding a test or a package needs no workflow change.
+  discover:
+    name: Discover test matrices
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    outputs:
+      tests: ${{ steps.e2e.outputs.tests }}
+      gopkgs: ${{ steps.gopkgs.outputs.gopkgs }}
+
+    steps:
+      - uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            *.blob.core.windows.net:443
+            *.githubapp.com:443
+            api.github.com:443
+            github.com:443
+            objects.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Find e2e pipeline tests
+        id: e2e
+        working-directory: e2e-tests
+        run: |
+          # run-tests defaults to '*.yaml', so match that: anything else in
+          # this directory (*.yaml-DISABLED, for example) is not a test.
+          tests="$(find . -maxdepth 1 -name '*.yaml' -printf '%f\n' | sort | jq -Rsc 'split("\n") | map(select(length > 0))')"
+          count="$(jq 'length' <<< "${tests}")"
+          if [[ "${count}" -eq 0 ]]; then
+            echo "found no e2e tests in e2e-tests/; matrix would be empty" >&2
+            exit 1
+          fi
+          echo "tests=${tests}" >> "${GITHUB_OUTPUT}"
+          echo "discovered ${count} e2e pipeline tests:"
+          jq . <<< "${tests}"
+
+      - name: Find Go packages to generate and test
+        id: gopkgs
+        run: |
+          # Packages holding tests, plus packages holding //go:generate
+          # directives, so between them the jobs still cover everything a
+          # 'go generate ./...' would. Matching 'go list' without needing a Go
+          # toolchain in this job.
+          dirs="$(
+            {
+              find . -name '*_test.go' -not -path './.git/*' -printf '%h\n'
+              grep -rl '^//go:generate' --include='*.go' . | sed 's|/[^/]*$||'
+            } | sed 's|^\./||' | sort -u
+          )"
+          gopkgs="$(jq -Rsc 'split("\n") | map(select(length > 0))' <<< "${dirs}")"
+          count="$(jq 'length' <<< "${gopkgs}")"
+          if [[ "${count}" -eq 0 ]]; then
+            echo "found no Go packages to test; matrix would be empty" >&2
+            exit 1
+          fi
+          echo "gopkgs=${gopkgs}" >> "${GITHUB_OUTPUT}"
+          echo "discovered ${count} Go packages:"
+          jq . <<< "${gopkgs}"
+
+  build-melange:
+    name: Build melange and fetch the qemu kernel
+    runs-on: ubuntu-latest-8-core
 
     permissions:
       contents: read
@@ -24,6 +99,7 @@ jobs:
             *.blob.core.windows.net:443
             *.githubapp.com:443
             api.github.com:443
+            dl-cdn.alpinelinux.org:443
             dl.google.com:443
             github.com:443
             go.dev:443
@@ -53,14 +129,41 @@ jobs:
           path: ${{ github.workspace }}/melange
           retention-days: 1
 
+      # Fetch the qemu kernel once and hand the same one to every test job.
+      # Pulling it per-job would hammer the Alpine CDN and, because 'chosen'
+      # resolves to the latest edge build, could hand different jobs different
+      # kernels within a single run.
+      - name: Fetch qemu kernel
+        run: |
+          make fetch-kernel
+
+      # Tar rather than uploading kernel/ directly: the modules tree has
+      # symlinks in it, and upload-artifact dereferences them.
+      - name: Package kernel
+        run: |
+          tar -czf kernel.tar.gz kernel
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: kernel-${{ github.run_id }}
+          path: ${{ github.workspace }}/kernel.tar.gz
+          retention-days: 1
+          compression-level: 0 # already gzipped
+
   test-packages:
-    name: Test packages
+    name: Test ${{ matrix.test }}
     needs:
+      - discover
       - build-melange
     runs-on: ubuntu-latest-8-core
 
     permissions:
       contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        test: ${{ fromJSON(needs.discover.outputs.tests) }}
 
     steps:
       - uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
@@ -121,22 +224,27 @@ jobs:
       - env:
           GITHUB_WORKSPACE: ${{ github.workspace }}
         run: |
-          sudo mv "$GITHUB_WORKSPACE"/.melange-dir/melange /usr/bin/melange
+          sudo mv "${GITHUB_WORKSPACE}"/.melange-dir/melange /usr/bin/melange
           sudo chmod a+x /usr/bin/melange
           melange version
+
+      # And the kernel, so this job doesn't have to fetch its own.
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: kernel-${{ github.run_id }}
+          path: ${{ github.workspace }}/.kernel-dir
+          run-id: ${{ github.run_id }}
+
+      - env:
+          GITHUB_WORKSPACE: ${{ github.workspace }}
+        run: |
+          tar -xzf "${GITHUB_WORKSPACE}"/.kernel-dir/kernel.tar.gz
+          arch="$(uname -m)"
+          test -f "kernel/${arch}/vmlinuz"
 
       - run: |
           sudo apt-get -y install bubblewrap
       - uses: ./.github/actions/setup-bubblewrap
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
-        with:
-          go-version-file: "./go.mod"
-          check-latest: true
-
-      - uses: cue-lang/setup-cue@a93fa358375740cd8b0078f76355512b9208acb1 # v1.0.1
 
       - name: Install QEMU/KVM
         run: |
@@ -149,6 +257,128 @@ jobs:
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
 
-      - name: Run e2e-tests
+      - name: Run e2e test
+        env:
+          E2E_TEST: ${{ matrix.test }}
         run: |
-          make test-e2e
+          make test-e2e-pipelines MELANGE_BIN=/usr/bin/melange E2E_TESTS="${E2E_TEST}"
+
+  test-go:
+    name: Go tests ${{ matrix.pkg }}
+    needs:
+      - discover
+    runs-on: ubuntu-latest-8-core
+
+    permissions:
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        pkg: ${{ fromJSON(needs.discover.outputs.gopkgs) }}
+
+    steps:
+      - uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: block
+          # Same allowlist as the test-packages job: 'go generate' builds the
+          # sca testdata packages, so it reaches the same places a build does.
+          allowed-endpoints: >
+            *.blob.core.windows.net:443
+            *.githubapp.com:443
+            9236a389bd48b984df91adc1bc924620.r2.cloudflarestorage.com:443
+            _http._tcp.azure.archive.ubuntu.com:443
+            _https._tcp.dl.google.com:443
+            _https._tcp.esm.ubuntu.com:443
+            _https._tcp.motd.ubuntu.com:443
+            _https._tcp.packages.microsoft.com:443
+            api.github.com:443
+            apk.cgr.dev:443
+            auth.docker.io:443
+            azure.archive.ubuntu.com:80
+            dl-cdn.alpinelinux.org:443
+            dl.google.com:443
+            esm.ubuntu.com:443
+            files.pythonhosted.org:443
+            git.netfilter.org:443
+            github.com:443
+            go.dev:443
+            index.docker.io:443
+            motd.ubuntu.com:443
+            objects.githubusercontent.com:443
+            packages.microsoft.com:443
+            packages.wolfi.dev:443
+            ppa.launchpadcontent.net:443
+            production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
+            proxy.golang.org:443
+            pypi.org:443
+            raw.githubusercontent.com:443
+            registry-1.docker.io:443
+            release-assets.githubusercontent.com:443
+            storage.googleapis.com:443
+            sum.golang.org:443
+            time1.google.com:123
+            time2.google.com:123
+            time3.google.com:123
+            time4.google.com:123
+            us.download.nvidia.com:443
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: "./go.mod"
+          check-latest: true
+
+      - uses: cue-lang/setup-cue@a93fa358375740cd8b0078f76355512b9208acb1 # v1.0.1
+
+      # 'make test-e2e-unit' runs 'go generate', which builds the sca testdata
+      # packages with the bwrap runner.
+      - run: |
+          sudo apt-get -y install bubblewrap
+      - uses: ./.github/actions/setup-bubblewrap
+
+      - name: Run Go e2e tests
+        env:
+          E2E_PKG: ${{ matrix.pkg }}
+        run: |
+          make test-e2e-unit E2E_PKG="./${E2E_PKG}"
+
+  e2e-complete:
+    name: e2e tests complete
+    runs-on: ubuntu-latest
+    if: always()
+    needs:
+      - discover
+      - build-melange
+      - test-packages
+      - test-go
+
+    permissions: {}
+
+    steps:
+      - uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+
+      # A single check to require in branch protection, since the matrix job
+      # names change whenever a test is added or removed.
+      - name: Check job results
+        env:
+          RESULTS: ${{ join(needs.*.result, ' ') }}
+        run: |
+          echo "results: ${RESULTS}"
+          case "${RESULTS}" in
+            *failure*|*cancelled*|*skipped*)
+              echo "one or more e2e jobs did not succeed"
+              exit 1
+              ;;
+            *)
+              echo "all e2e jobs succeeded"
+              ;;
+          esac

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -56,18 +56,18 @@ jobs:
         run: |
           git fetch --tags  # no creds needed: repo is public; if this ever goes private, pass token explicitly here
           TAG=$(git tag --points-at HEAD)
-          if [ -z "$TAG" ]; then
+          if [[ -z "${TAG}" ]]; then
             echo "No tag points at HEAD, so we need a new tag and then a new release."
-            echo "need_release=yes" >> "$GITHUB_OUTPUT"
+            echo "need_release=yes" >> "${GITHUB_OUTPUT}"
           else
-            RELEASE=$(gh release view "$TAG" --json tagName --jq '.tagName' || echo "none")
-            if [ "$RELEASE" == "$TAG" ]; then
-              echo "A release exists for tag $TAG, which has the latest changes, so no need for a new tag or release."
-              echo "need_release=no" >> "$GITHUB_OUTPUT"
+            RELEASE=$(gh release view "${TAG}" --json tagName --jq '.tagName' || echo "none")
+            if [[ "${RELEASE}" == "${TAG}" ]]; then
+              echo "A release exists for tag ${TAG}, which has the latest changes, so no need for a new tag or release."
+              echo "need_release=no" >> "${GITHUB_OUTPUT}"
             else
-              echo "Tag $TAG exists, but no release is associated. Need a new release."
-              echo "need_release=yes" >> "$GITHUB_OUTPUT"
-              echo "existing_tag=$TAG" >> "$GITHUB_OUTPUT"
+              echo "Tag ${TAG} exists, but no release is associated. Need a new release."
+              echo "need_release=yes" >> "${GITHUB_OUTPUT}"
+              echo "existing_tag=${TAG}" >> "${GITHUB_OUTPUT}"
             fi
           fi
 
@@ -89,6 +89,9 @@ jobs:
         with:
           go-version-file: "./go.mod"
           check-latest: true
+          # Release artifacts are published from this job, so don't let a
+          # cache restored from another ref influence what goreleaser builds.
+          cache: false
 
       # Cosign is used by goreleaser to sign release artifacts.
       - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2

--- a/.github/workflows/wolfi-presubmit.yaml
+++ b/.github/workflows/wolfi-presubmit.yaml
@@ -176,7 +176,7 @@ jobs:
       - env:
           GITHUB_WORKSPACE: ${{ github.workspace }}
         run: |
-          sudo mv "$GITHUB_WORKSPACE"/.melange-dir/melange /usr/bin/melange
+          sudo mv "${GITHUB_WORKSPACE}"/.melange-dir/melange /usr/bin/melange
           sudo chmod a+x /usr/bin/melange
           melange version
 
@@ -189,7 +189,7 @@ jobs:
       - env:
           MATRIX_PACKAGE: ${{ matrix.package }}
         run: |
-          wolfictl bump "$MATRIX_PACKAGE"
+          wolfictl bump "${MATRIX_PACKAGE}"
 
       - if: matrix.runner == 'bubblewrap'
         run: |
@@ -205,18 +205,18 @@ jobs:
         env:
           MATRIX_PACKAGE: ${{ matrix.package }}
         run: |
-          make SHELL="/bin/bash" MELANGE="sudo melange" MELANGE_RUNNER="bubblewrap" MELANGE_EXTRA_OPTS="--generate-provenance" package/"$MATRIX_PACKAGE"
+          make SHELL="/bin/bash" MELANGE="sudo melange" MELANGE_RUNNER="bubblewrap" MELANGE_EXTRA_OPTS="--generate-provenance" package/"${MATRIX_PACKAGE}"
       - if: matrix.runner == 'bubblewrap'
         env:
           MATRIX_PACKAGE: ${{ matrix.package }}
         run: |
-          make SHELL="/bin/bash" MELANGE="sudo melange" MELANGE_RUNNER="docker" test/"$MATRIX_PACKAGE"
+          make SHELL="/bin/bash" MELANGE="sudo melange" MELANGE_RUNNER="docker" test/"${MATRIX_PACKAGE}"
 
       - name: Download kernel for VMs
         if: matrix.runner == 'qemu'
         run: |
           KERNEL_PKG="$(curl -sL https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/APKINDEX.tar.gz | tar -Oxz APKINDEX | awk -F':' '$1 == "P" {printf "%s-", $2} $1 == "V" {printf "%s.apk\n", $2}' | grep "linux-virt" | grep -v dev)"
-          curl -LSo linux-virt.apk "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/$KERNEL_PKG"
+          curl -LSo linux-virt.apk "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/${KERNEL_PKG}"
           mkdir -p /tmp/kernel
           tar -xf ./linux-virt.apk -C /tmp/kernel/
 
@@ -244,7 +244,7 @@ jobs:
             QEMU_KERNEL_MODULES=/tmp/kernel/lib/modules/ \
             MELANGE="/usr/bin/melange" \
             MELANGE_EXTRA_OPTS="--runner qemu --generate-provenance" \
-            package/"$MATRIX_PACKAGE"
+            package/"${MATRIX_PACKAGE}"
 
       - name: Output SLSA provenance
         run: |
@@ -260,7 +260,7 @@ jobs:
         env:
           MATRIX_PACKAGE: ${{ matrix.package }}
         run: |
-          make SHELL="/bin/bash" MELANGE="sudo melange" MELANGE_RUNNER="bubblewrap" test/"$MATRIX_PACKAGE"
+          make SHELL="/bin/bash" MELANGE="sudo melange" MELANGE_RUNNER="bubblewrap" test/"${MATRIX_PACKAGE}"
 
       - name: Run tests with QEMU runner
         if: matrix.runner == 'qemu'
@@ -273,7 +273,7 @@ jobs:
             QEMU_KERNEL_MODULES=/tmp/kernel/lib/modules/ \
             MELANGE="/usr/bin/melange" \
             MELANGE_EXTRA_OPTS="--runner qemu" \
-            test/"$MATRIX_PACKAGE"
+            test/"${MATRIX_PACKAGE}"
 
       - name: Check package ${{ matrix.package }} xattrs for QEMU-built package
         if: matrix.runner == 'qemu' && matrix.package == 'fping'
@@ -295,17 +295,20 @@ jobs:
         env:
           MATRIX_PACKAGE: ${{ matrix.package }}
         run: |
-          if [[ "$MATRIX_PACKAGE" == "fping" ]]; then
-            docker run --rm -v "$(pwd)":/work --workdir /work cgr.dev/chainguard/wolfi-base /bin/sh -c "sed 's|=.*||' -i /etc/apk/world; apk add --allow-untrusted -X ./packages/ packages/x86_64/$MATRIX_PACKAGE-*.apk; apk add libcap-utils; getcap /usr/sbin/fping"
-          elif [[ "$MATRIX_PACKAGE" == "sudo" ]]; then
-            docker run --rm -v "$(pwd)":/work --workdir /work cgr.dev/chainguard/wolfi-base /bin/sh -c "sed 's|=.*||' -i /etc/apk/world; apk add --allow-untrusted -X ./packages/ packages/x86_64/$MATRIX_PACKAGE-*.apk; ls -hal /usr/bin/sudo"
-          elif [[ "$MATRIX_PACKAGE" == "postfix" ]]; then
-            docker run --rm -v "$(pwd)":/work --workdir /work cgr.dev/chainguard/wolfi-base /bin/sh -c "sed 's|=.*||' -i /etc/apk/world; apk add --allow-untrusted -X ./packages/ packages/x86_64/$MATRIX_PACKAGE-*.apk; ls -hal /var/spool/postfix; ls -hal /var/lib/postfix"
-          else
-            docker run --rm -v "$(pwd)":/work --workdir /work cgr.dev/chainguard/wolfi-base /bin/sh -c "sed 's|=.*||' -i /etc/apk/world; apk add --allow-untrusted -X ./packages/ packages/x86_64/$MATRIX_PACKAGE-*.apk"
-          fi
+          # Install the package we just built, then run a package-specific
+          # check that its mode bits / xattrs / directories survived.
+          install="sed 's|=.*||' -i /etc/apk/world; apk add --allow-untrusted -X ./packages/ packages/x86_64/${MATRIX_PACKAGE}-*.apk"
+          case "${MATRIX_PACKAGE}" in
+            fping)   verify="apk add libcap-utils; getcap /usr/sbin/fping";;
+            sudo)    verify="ls -hal /usr/bin/sudo";;
+            postfix) verify="ls -hal /var/spool/postfix; ls -hal /var/lib/postfix";;
+            *)       verify="true";;
+          esac
+          docker run --rm -v "${PWD}":/work --workdir /work \
+            cgr.dev/chainguard/wolfi-base /bin/sh -c "${install}; ${verify}"
+
           # There is a huge fixed cost for every wolfictl scan invocation for grype DB init.
           # Do this outside of the loop in one invocation with every package.
           wolfictl scan \
-          packages/x86_64/"$MATRIX_PACKAGE"-*.apk \
+          packages/x86_64/"${MATRIX_PACKAGE}"-*.apk \
           2> /dev/null # The error message renders strangely on GitHub Actions, and the important information is already being sent to stdout.

--- a/Makefile
+++ b/Makefile
@@ -205,14 +205,38 @@ kernel/%/vmlinuz: kernel/%/linux.apk
 		rc=$$?; rm -Rf $$tmpd; exit $$rc
 	touch $@
 
-.PHONY: test-e2e
-test-e2e: kernel/$(ARCH)/vmlinuz melange generate # This is invoked by a separate GHA workflow, so not combining it with the other test targets.
-	go test -tags e2e ./... -race
+# melange binary the e2e pipeline tests run against. Override it to use a
+# prebuilt binary (CI downloads one instead of rebuilding it in every job).
+MELANGE_BIN ?= $(TOP_D)/melange
+
+# Space-separated list of yaml files under e2e-tests/ to run. Empty means all
+# of them; CI sets it to a single file so each test gets its own job.
+E2E_TESTS ?=
+
+# Go package(s) to generate and test. Defaults to everything; CI sets it to a
+# single package so each one gets its own job. Scoping the codegen matters as
+# much as scoping the test: most of the runtime here is 'go generate' building
+# the pkg/sca testdata, and only pkg/sca needs it.
+E2E_PKG ?= ./...
+
+.PHONY: test-e2e-unit
+test-e2e-unit: ## Run the Go tests behind the 'e2e' build tag
+	go generate $(E2E_PKG)
+	go test -tags e2e $(E2E_PKG) -race
+
+.PHONY: test-e2e-pipelines
+test-e2e-pipelines: kernel/$(ARCH)/vmlinuz ## Run the e2e-tests/ yamls under the qemu runner
 	cd e2e-tests && \
 	QEMU_KERNEL_IMAGE=$(TOP_D)/kernel/$(ARCH)/vmlinuz \
 	QEMU_KERNEL_MODULES=$(TOP_D)/kernel/$(ARCH)/modules/ \
-	MELANGE=$(TOP_D)/melange \
-	./run-tests
+	MELANGE=$(MELANGE_BIN) \
+	./run-tests $(E2E_TESTS)
+
+# Recipe lines rather than prerequisites so the ordering holds under 'make -j'.
+.PHONY: test-e2e
+test-e2e: melange # This is invoked by a separate GHA workflow, so not combining it with the other test targets.
+	$(MAKE) test-e2e-unit
+	$(MAKE) test-e2e-pipelines
 
 .PHONY: clean
 clean: ## Clean the workspace

--- a/e2e-tests/README.md
+++ b/e2e-tests/README.md
@@ -11,3 +11,9 @@ Melange options are based on yaml file name.
     If the yaml file name matches '*-nopkg', then the flag `--test-package-append`
     will be appended for `busybox` and `python-3`.  The intent of these tests
     is to verify that the test-package-append works.
+
+CI discovers these files automatically and runs each one in its own job, so
+they must not depend on artifacts produced by any of the others. To run a
+subset locally:
+
+    make test-e2e-pipelines E2E_TESTS="greeter-build-test.yaml"


### PR DESCRIPTION
The E2E tests run serially and can take ~15 minutes per commit; this PR builds out a matrix of E2E Jobs so that we can run them concurrently.

There were also a few outstanding actionlint/shellcheck findings that needed to be addressed and part of that entailed pinning image digests which a new Digestabot Workflow will keep updated.