### PR TITLE
Fetch license-check sources with native handlers

### DIFF
--- a/pkg/source/fetch.go
+++ b/pkg/source/fetch.go
@@ -1,0 +1,209 @@
+// Copyright 2026 Chainguard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package source
+
+import (
+	"context"
+	"crypto/sha256"
+	"crypto/sha512"
+	"encoding/hex"
+	"fmt"
+	"hash"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/chainguard-dev/clog"
+)
+
+// FetchOptions describes a native equivalent of the built-in `fetch` pipeline.
+// Values come from the melange config and are used only as data: a URL, a
+// filename, and argv elements.
+type FetchOptions struct {
+	URI             string
+	Directory       string // where to extract; relative to the current working directory
+	StripComponents int
+	Extract         bool
+	ExpectedSHA256  string
+	ExpectedSHA512  string
+	Delete          bool
+}
+
+// Fetch downloads the artifact named by opts.URI into the current working
+// directory, optionally verifies its checksum, and optionally extracts it. The
+// URI is parsed and used as data (never passed to a shell).
+func Fetch(ctx context.Context, opts *FetchOptions) error {
+	log := clog.FromContext(ctx)
+
+	u, err := url.Parse(opts.URI)
+	if err != nil {
+		return fmt.Errorf("invalid fetch uri %q: %w", opts.URI, err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return fmt.Errorf("invalid fetch uri %q: only http and https schemes are supported", opts.URI)
+	}
+	if u.Host == "" {
+		return fmt.Errorf("invalid fetch uri %q: missing host", opts.URI)
+	}
+
+	// Derive the local filename from the URL path only (not the raw string), so
+	// query strings or crafted values can't influence the on-disk name.
+	base := path.Base(u.Path)
+	if base == "" || base == "." || base == ".." || base == "/" {
+		return fmt.Errorf("could not determine a filename from uri %q", opts.URI)
+	}
+
+	log.Infof("Fetching %s", opts.URI)
+	if err := download(ctx, opts.URI, base); err != nil {
+		return err
+	}
+
+	if err := verifyChecksum(base, opts.ExpectedSHA256, opts.ExpectedSHA512); err != nil {
+		return err
+	}
+
+	if opts.Extract {
+		dir := opts.Directory
+		if dir == "" {
+			dir = "."
+		}
+		// tar is invoked with an explicit argv, so the filename and directory
+		// are passed as plain arguments. tar auto-detects the compression
+		// format, matching the built-in pipeline.
+		// #nosec G204 - argv-only invocation; args are validated data, not shell
+		cmd := exec.CommandContext(ctx, "tar", "-x",
+			fmt.Sprintf("--strip-components=%d", opts.StripComponents),
+			"--no-same-owner", "-C", dir, "-f", base)
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			return fmt.Errorf("extracting %q: %w", base, err)
+		}
+	}
+
+	if opts.Delete {
+		if err := os.Remove(base); err != nil {
+			return fmt.Errorf("deleting %q: %w", base, err)
+		}
+	}
+
+	return nil
+}
+
+// download streams uri to the file named dest in the current working directory.
+func download(ctx context.Context, uri, dest string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, uri, nil)
+	if err != nil {
+		return fmt.Errorf("creating request for %s: %w", uri, err)
+	}
+
+	resp, err := http.DefaultClient.Do(req) // #nosec G107 - uri scheme validated to http(s) by caller
+	if err != nil {
+		return fmt.Errorf("fetching %s: %w", uri, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("fetching %s: unexpected status %d", uri, resp.StatusCode)
+	}
+
+	// #nosec G304 - dest is a sanitized basename written into the workspace dir
+	f, err := os.Create(dest)
+	if err != nil {
+		return fmt.Errorf("creating %q: %w", dest, err)
+	}
+	defer f.Close()
+
+	if _, err := io.Copy(f, resp.Body); err != nil {
+		return fmt.Errorf("writing %q: %w", dest, err)
+	}
+
+	return nil
+}
+
+// verifyChecksum checks the downloaded file against the expected digests, when
+// provided. A missing checksum is not fatal here, as license-check is
+// best-effort.
+func verifyChecksum(file, expectedSHA256, expectedSHA512 string) error {
+	check := func(h hash.Hash, expected, algo string) error {
+		f, err := os.Open(file) // #nosec G304 - file is a sanitized basename in the workspace dir
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+		if _, err := io.Copy(h, f); err != nil {
+			return err
+		}
+		got := hex.EncodeToString(h.Sum(nil))
+		if !strings.EqualFold(got, strings.TrimSpace(expected)) {
+			return fmt.Errorf("%s mismatch for %q: expected %s, got %s", algo, file, expected, got)
+		}
+		return nil
+	}
+
+	if expectedSHA256 != "" {
+		return check(sha256.New(), expectedSHA256, "sha256")
+	}
+	if expectedSHA512 != "" {
+		return check(sha512.New(), expectedSHA512, "sha512")
+	}
+	return nil
+}
+
+// applyPatchStep applies patch files, a native equivalent of the built-in
+// `patch` pipeline. Each patch path is resolved relative to workDir, opened in
+// Go, and fed to `patch` on stdin.
+func applyPatchStep(ctx context.Context, patches string, stripComponents, fuzz int, workDir string) error {
+	log := clog.FromContext(ctx)
+
+	for patch := range strings.FieldsSeq(patches) {
+		// Keep patch paths within the workspace directory.
+		if filepath.IsAbs(patch) {
+			return fmt.Errorf("absolute patch paths are not allowed: %q", patch)
+		}
+		patchPath := filepath.Join(workDir, patch)
+		if rel, err := filepath.Rel(workDir, patchPath); err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			return fmt.Errorf("patch path %q escapes the workspace directory", patch)
+		}
+
+		log.Infof("Applying patch %s", patchPath)
+
+		f, err := os.Open(patchPath) // #nosec G304 G703 - patch path validated to stay within the workspace dir
+		if err != nil {
+			return fmt.Errorf("opening patch %q: %w", patchPath, err)
+		}
+
+		// #nosec G204 - argv-only invocation; strip/fuzz are ints, no shell
+		cmd := exec.CommandContext(ctx, "patch",
+			fmt.Sprintf("-p%d", stripComponents),
+			fmt.Sprintf("--fuzz=%d", fuzz))
+		cmd.Dir = workDir
+		cmd.Stdin = f
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		err = cmd.Run()
+		f.Close()
+		if err != nil {
+			return fmt.Errorf("applying patch %q: %w", patchPath, err)
+		}
+	}
+
+	return nil
+}

--- a/pkg/source/source.go
+++ b/pkg/source/source.go
@@ -156,11 +156,15 @@ func runPatchStep(ctx context.Context, resolve func(string) (string, error), des
 	// A quilt-style series file lists patch filenames, one per line (with '#'
 	// comments). Fold it into the patch list when no explicit patches are given.
 	if strings.TrimSpace(patches) == "" && strings.TrimSpace(series) != "" {
-		seriesPath := series
-		if !filepath.IsAbs(seriesPath) {
-			seriesPath = filepath.Join(destDir, series)
+		// Keep the series path within the workspace directory.
+		if filepath.IsAbs(series) {
+			return fmt.Errorf("absolute series paths are not allowed: %q", series)
 		}
-		data, err := os.ReadFile(seriesPath) // #nosec G304 - series path resolved within the workspace dir
+		seriesPath := filepath.Join(destDir, series)
+		if rel, err := filepath.Rel(destDir, seriesPath); err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			return fmt.Errorf("series path %q escapes the workspace directory", series)
+		}
+		data, err := os.ReadFile(seriesPath) // #nosec G304 - series path validated to stay within the workspace dir
 		if err != nil {
 			return fmt.Errorf("reading series file %q: %w", seriesPath, err)
 		}

--- a/pkg/source/source.go
+++ b/pkg/source/source.go
@@ -16,14 +16,13 @@ package source
 
 import (
 	"archive/tar"
-	"bytes"
 	"compress/gzip"
 	"context"
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	apkofs "chainguard.dev/apko/pkg/apk/fs"
@@ -31,27 +30,176 @@ import (
 
 	"chainguard.dev/melange/pkg/build"
 	"chainguard.dev/melange/pkg/config"
+	"chainguard.dev/melange/pkg/util"
 )
 
-// Variable to allow mocking the runCommand function in tests.
-var sourceRunPipelineStep = runPipelineStep
+// sourceRunStep dispatches a single source-fetching pipeline step to its native
+// handler. It is a package variable so tests can stub it out.
+var sourceRunStep = runStep
 
-// Simple wrapper for executing pipeline steps.
-func runPipelineStep(ctx context.Context, step config.Pipeline) error {
-	var stdout, stderr io.Writer
-	outputBuf := &bytes.Buffer{}
-	log := clog.FromContext(ctx)
-	stdout = outputBuf
-	stderr = outputBuf
+// runStep executes one supported source-fetching step (fetch, git-checkout, or
+// patch) natively in Go. Input values are resolved through the substitution map
+// (so `${{package.version}}` and friends still work) and are then used as data:
+// a URL, a git remote, and argv elements.
+func runStep(ctx context.Context, step config.Pipeline, sm *build.SubstitutionMap, _ bool, destDir string) error {
+	// resolve returns the substituted value for a `with:` input, or "" if the
+	// input was not provided. The result is used as data.
+	resolve := func(key string) (string, error) {
+		v, ok := step.With[key]
+		if !ok {
+			return "", nil
+		}
+		return util.MutateStringFromMap(sm.Substitutions, v)
+	}
 
-	cmd := []string{"/bin/sh", "-c", step.Pipeline[0].Runs}
-	// #nosec G204 - Executing pipeline step from trusted melange configuration
-	proc := exec.Command(cmd[0], cmd[1:]...)
-	proc.Stdout = stdout
-	proc.Stderr = stderr
-	log.Debugf("Command output:\n%s", outputBuf.String())
+	switch step.Uses {
+	case "fetch":
+		return runFetchStep(ctx, resolve)
+	case "git-checkout":
+		return runGitCheckoutStep(ctx, resolve, destDir)
+	case "patch":
+		return runPatchStep(ctx, resolve, destDir)
+	default:
+		return fmt.Errorf("unsupported source step %q", step.Uses)
+	}
+}
 
-	return proc.Run()
+func runFetchStep(ctx context.Context, resolve func(string) (string, error)) error {
+	get := func(dst *string, key string) error {
+		v, err := resolve(key)
+		if err != nil {
+			return err
+		}
+		*dst = v
+		return nil
+	}
+
+	opts := &FetchOptions{}
+	var stripRaw, extractRaw, deleteRaw string
+	for dst, key := range map[*string]string{
+		&opts.URI:            "uri",
+		&opts.Directory:      "directory",
+		&opts.ExpectedSHA256: "expected-sha256",
+		&opts.ExpectedSHA512: "expected-sha512",
+		&stripRaw:            "strip-components",
+		&extractRaw:          "extract",
+		&deleteRaw:           "delete",
+	} {
+		if err := get(dst, key); err != nil {
+			return err
+		}
+	}
+
+	opts.StripComponents = parseIntDefault(stripRaw, 1)
+	opts.Extract = parseBoolDefault(extractRaw, true)
+	opts.Delete = parseBoolDefault(deleteRaw, false)
+
+	return Fetch(ctx, opts)
+}
+
+func runGitCheckoutStep(ctx context.Context, resolve func(string) (string, error), destDir string) error {
+	repo, err := resolve("repository")
+	if err != nil {
+		return err
+	}
+	dest, err := resolve("destination")
+	if err != nil {
+		return err
+	}
+	switch {
+	case dest == "" || dest == ".":
+		dest = destDir
+	case !filepath.IsAbs(dest):
+		dest = filepath.Join(destDir, dest)
+	}
+	expectedCommit, err := resolve("expected-commit")
+	if err != nil {
+		return err
+	}
+	cherryPicks, err := resolve("cherry-picks")
+	if err != nil {
+		return err
+	}
+	recurse, err := resolve("recurse-submodules")
+	if err != nil {
+		return err
+	}
+
+	return GitCheckout(ctx, &GitCheckoutOptions{
+		Repository:        repo,
+		Destination:       dest,
+		ExpectedCommit:    expectedCommit,
+		CherryPicks:       cherryPicks,
+		WorkspaceDir:      destDir,
+		RecurseSubmodules: parseBoolDefault(recurse, false),
+	})
+}
+
+func runPatchStep(ctx context.Context, resolve func(string) (string, error), destDir string) error {
+	patches, err := resolve("patches")
+	if err != nil {
+		return err
+	}
+	series, err := resolve("series")
+	if err != nil {
+		return err
+	}
+	stripRaw, err := resolve("strip-components")
+	if err != nil {
+		return err
+	}
+	fuzzRaw, err := resolve("fuzz")
+	if err != nil {
+		return err
+	}
+
+	// A quilt-style series file lists patch filenames, one per line (with '#'
+	// comments). Fold it into the patch list when no explicit patches are given.
+	if strings.TrimSpace(patches) == "" && strings.TrimSpace(series) != "" {
+		seriesPath := series
+		if !filepath.IsAbs(seriesPath) {
+			seriesPath = filepath.Join(destDir, series)
+		}
+		data, err := os.ReadFile(seriesPath) // #nosec G304 - series path resolved within the workspace dir
+		if err != nil {
+			return fmt.Errorf("reading series file %q: %w", seriesPath, err)
+		}
+		var names []string
+		for line := range strings.SplitSeq(string(data), "\n") {
+			line = strings.TrimSpace(line)
+			if line == "" || strings.HasPrefix(line, "#") {
+				continue
+			}
+			names = append(names, line)
+		}
+		patches = strings.Join(names, " ")
+	}
+
+	if strings.TrimSpace(patches) == "" {
+		return fmt.Errorf("patch step: neither 'patches' nor 'series' was set")
+	}
+
+	return applyPatchStep(ctx, patches, parseIntDefault(stripRaw, 1), parseIntDefault(fuzzRaw, 2), destDir)
+}
+
+func parseIntDefault(s string, def int) int {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return def
+	}
+	n, err := strconv.Atoi(s)
+	if err != nil {
+		return def
+	}
+	return n
+}
+
+func parseBoolDefault(s string, def bool) bool {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return def
+	}
+	return s == "true"
 }
 
 // Function to extract the .melange.yaml from an apk package.
@@ -139,44 +287,13 @@ func FetchSourceFromMelange(ctx context.Context, filePath, destDir string) (*con
 		return nil, fmt.Errorf("failed to parse melange config: %w", err)
 	}
 
-	// Temporarily copy out the embedded files and directories from f into a
-	// temporary directory. We want to pass it later on to the pipeline
-	// compilation.
-	err = os.CopyFS(tmpDir, build.PipelinesFS)
-	if err != nil {
-		return nil, fmt.Errorf("failed to copy embedded pilelines: %w", err)
-	}
-
-	// Prepare the substitution map and compile the pipelines, making sure that
-	// the resulting pipeline run statements are all substituted with the
-	// correct values and ready for execution.
-	c := &build.Compiled{
-		PipelineDirs: []string{tmpDir},
-	}
-
-	// Now also try looking if the base directory of filePath has a pipelines
-	// directory. Add those to the list of directories to search for pipelines.
-	absFilePath, err := filepath.Abs(filePath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get absolute path of file: %w", err)
-	}
-	baseDir := filepath.Dir(absFilePath)
-	pipelinesDir := filepath.Join(baseDir, "pipelines")
-
-	if _, err := os.Stat(pipelinesDir); err == nil {
-		log.Infof("Found pipelines directory in base directory: %s", pipelinesDir)
-		c.PipelineDirs = append(c.PipelineDirs, pipelinesDir)
-	} else if !os.IsNotExist(err) {
-		return nil, fmt.Errorf("error checking pipelines directory: %w", err)
-	}
-
+	// Prepare the substitution map so that input values referencing built-in
+	// variables (e.g. ${{package.version}}) resolve correctly. The supported
+	// source steps are dispatched to native Go handlers below, which treat
+	// every substituted value as data.
 	sm, err := build.NewSubstitutionMap(cfg, "amd64", "gnu", nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create substitution map: %w", err)
-	}
-	err = c.CompilePipelines(ctx, sm, cfg.Pipeline)
-	if err != nil {
-		return nil, fmt.Errorf("failed to compile pipelines: %w", err)
 	}
 
 	// During command execution we change the working directory. We need to
@@ -207,12 +324,12 @@ func FetchSourceFromMelange(ctx context.Context, filePath, destDir string) (*con
 
 	// Iterate over the pipeline steps and look for any source fetching steps.
 	for _, step := range cfg.Pipeline {
-		if step.Uses == "patch" && isApk {
-			log.Warnf("Skipping patch step as we do not have patches available inside apk metadata yet.")
+		if step.Uses != "git-checkout" && step.Uses != "fetch" && step.Uses != "patch" {
 			continue
 		}
 
-		if step.Uses != "git-checkout" && step.Uses != "fetch" && step.Uses != "patch" {
+		if step.Uses == "patch" && isApk {
+			log.Warnf("Skipping patch step as we do not have patches available inside apk metadata yet.")
 			continue
 		}
 
@@ -226,7 +343,7 @@ func FetchSourceFromMelange(ctx context.Context, filePath, destDir string) (*con
 		if err != nil {
 			return nil, fmt.Errorf("failed to change directory: %w", err)
 		}
-		err = sourceRunPipelineStep(ctx, step)
+		err = sourceRunStep(ctx, step, sm, isApk, destDir)
 		if err != nil {
 			return nil, fmt.Errorf("failed to run step: %w", err)
 		}

--- a/pkg/source/source_test.go
+++ b/pkg/source/source_test.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"chainguard.dev/melange/pkg/build"
 	"chainguard.dev/melange/pkg/config"
 )
 
@@ -105,13 +106,13 @@ func TestExtractMelangeYamlFromTarball_noMelange(t *testing.T) {
 	}
 }
 
-// TestFetchSourceFromMelange tests the FetchSourceFromMelange function with mocked sourceRunCommand
+// TestFetchSourceFromMelange tests the FetchSourceFromMelange function with a mocked step dispatcher
 func TestFetchSourceFromMelange(t *testing.T) {
-	// Mock the sourceRunCommand function
+	// Mock the step dispatcher so the test stays hermetic (no network/git).
 	stepsRun := []string{}
-	originalSourceRunPipelineStep := sourceRunPipelineStep
-	defer func() { sourceRunPipelineStep = originalSourceRunPipelineStep }()
-	sourceRunPipelineStep = func(ctx context.Context, step config.Pipeline) error {
+	originalSourceRunStep := sourceRunStep
+	defer func() { sourceRunStep = originalSourceRunStep }()
+	sourceRunStep = func(ctx context.Context, step config.Pipeline, sm *build.SubstitutionMap, isApk bool, destDir string) error {
 		fmt.Printf("Running step: %s\n", step.Uses)
 		stepsRun = append(stepsRun, step.Uses)
 		return nil
@@ -172,6 +173,65 @@ func TestFetchSourceFromMelange(t *testing.T) {
 				if _, err := os.Stat(filePath); os.IsNotExist(err) {
 					t.Errorf("Expected file %s to exist in %s, but it does not", file, destDir)
 				}
+			}
+		})
+	}
+}
+
+// TestFetchSourceFromMelange_inputsTreatedAsData runs the real (unmocked)
+// dispatcher against configs whose inputs contain shell-like syntax, and
+// asserts those inputs are treated as literal data: the fetch/checkout fails
+// (the value is not a valid URL or git remote) and no side-effect file is
+// produced.
+func TestFetchSourceFromMelange_inputsTreatedAsData(t *testing.T) {
+	tmpDir := t.TempDir()
+	marker := filepath.Join(tmpDir, "marker")
+
+	// If a value were ever evaluated by a shell, it would create the marker
+	// file. As literal data (a URL / git remote) it cannot.
+	configs := map[string]string{
+		"fetch-uri": `package:
+  name: example
+  version: "1.0.0"
+  epoch: 0
+  copyright:
+    - license: MIT
+pipeline:
+  - uses: fetch
+    with:
+      uri: "$(touch ` + marker + `; echo x)"
+      expected-none: "true"
+`,
+		"git-checkout-repository": `package:
+  name: example
+  version: "1.0.0"
+  epoch: 0
+  copyright:
+    - license: MIT
+pipeline:
+  - uses: git-checkout
+    with:
+      repository: "$(touch ` + marker + `; echo x)"
+`,
+	}
+
+	for name, content := range configs {
+		t.Run(name, func(t *testing.T) {
+			_ = os.Remove(marker)
+
+			cfgPath := filepath.Join(tmpDir, name+".yaml")
+			if err := os.WriteFile(cfgPath, []byte(content), 0o600); err != nil {
+				t.Fatalf("failed to write config: %v", err)
+			}
+
+			// The value is not a valid URL/remote, so fetching fails.
+			_, err := FetchSourceFromMelange(context.Background(), cfgPath, filepath.Join(tmpDir, name+"-out"))
+			if err == nil {
+				t.Errorf("expected an error fetching from an invalid uri/repository, got nil")
+			}
+
+			if _, statErr := os.Stat(marker); statErr == nil {
+				t.Fatalf("input was not treated as literal data (marker file %s was created)", marker)
 			}
 		})
 	}


### PR DESCRIPTION
Dispatch fetch/git-checkout/patch source steps to native Go handlers that take inputs as data (URL, git remote, argv) instead of compiling them into a shell script.