### PR TITLE
Remove stale SHA-1 signature references

### DIFF
--- a/pkg/build/package.go
+++ b/pkg/build/package.go
@@ -296,10 +296,6 @@ func (pc *PackageBuild) generateControlSection(ctx context.Context) ([]byte, err
 	return buf.Bytes(), nil
 }
 
-func (pc *PackageBuild) SignatureName() string {
-	return fmt.Sprintf(".SIGN.RSA.%s.pub", filepath.Base(pc.Build.SigningKey))
-}
-
 // removeSelfProvidedDeps removes dependencies which are provided by the package itself.
 func removeSelfProvidedDeps(runtimeDeps, providedDeps []string) []string {
 	providedDepsMap := map[string]bool{}

--- a/pkg/sign/apk.go
+++ b/pkg/sign/apk.go
@@ -155,7 +155,7 @@ func EmitSignature(signer ApkSigner, controlData []byte, sde time.Time) ([]byte,
 	return sigbuf.Bytes(), nil
 }
 
-// Key base signature (normal) uses a SHA-1 hash on the control digest.
+// Key base signature (normal) uses a SHA-256 hash on the control digest.
 type KeyApkSigner struct {
 	KeyFile       string
 	KeyPassphrase string


### PR DESCRIPTION
APK signing has used RSA-SHA256 since `KeyApkSigner` switched to `crypto.SHA256`, but two SHA-1-era leftovers remained.

- **`PackageBuild.SignatureName` (`pkg/build/package.go`)** returned the old `.SIGN.RSA.<key>.pub` name. It has no callers — the tar entry name comes from `KeyApkSigner.SignatureName` (`pkg/sign/apk.go:172`), which emits `.SIGN.RSA256.<key>.pub`. Deleted.
- **`KeyApkSigner` doc comment (`pkg/sign/apk.go:158`)** still claimed "uses a SHA-1 hash on the control digest," contradicting `Sign` directly below it, which hashes and signs with `crypto.SHA256`. Corrected.

No behavior change — the deleted method was dead code and the other change is a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)