### PR TITLE
go/build/v2: honor vendor input

### DIFF
--- a/e2e-tests/go-build-v2-vendor-build-test.yaml
+++ b/e2e-tests/go-build-v2-vendor-build-test.yaml
@@ -1,0 +1,177 @@
+package:
+  name: go-build-v2-vendor-build-test
+  version: "1.0.0"
+  epoch: 0
+  description: Test vendored module and workspace builds with go/build/v2
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    packages:
+      - go-1.26
+  environment:
+    CGO_ENABLED: "0"
+
+pipeline:
+  - name: Create module fixtures
+    runs: |
+      mkdir -p module-app module-dep generated-app generated-dep
+
+      cat > module-dep/go.mod <<'EOF'
+      module example.com/module-dep
+
+      go 1.24
+      EOF
+      cat > module-dep/value.go <<'EOF'
+      package moduledep
+
+      const Value = "module"
+      EOF
+      cat > module-app/go.mod <<'EOF'
+      module example.com/module-app
+
+      go 1.24
+
+      require example.com/module-dep v0.0.0
+
+      replace example.com/module-dep => ../module-dep
+      EOF
+      cat > module-app/main.go <<'EOF'
+      package main
+
+      import (
+          "fmt"
+
+          moduledep "example.com/module-dep"
+      )
+
+      func main() {
+          fmt.Println(moduledep.Value)
+      }
+      EOF
+
+      (cd module-app && go mod vendor)
+      cat > module-app/vendor/example.com/module-dep/value.go <<'EOF'
+      package moduledep
+
+      const Value = "vendored"
+      EOF
+
+      cat > generated-dep/go.mod <<'EOF'
+      module example.com/generated-dep
+
+      go 1.24
+      EOF
+      cat > generated-dep/value.go <<'EOF'
+      package generateddep
+
+      const Value = "generated"
+      EOF
+      cat > generated-app/go.mod <<'EOF'
+      module example.com/generated-app
+
+      go 1.24
+
+      require example.com/generated-dep v0.0.0
+
+      replace example.com/generated-dep => ../generated-dep
+      EOF
+      cat > generated-app/main.go <<'EOF'
+      package main
+
+      import (
+          "fmt"
+
+          generateddep "example.com/generated-dep"
+      )
+
+      func main() {
+          fmt.Println(generateddep.Value)
+      }
+      EOF
+
+  - uses: go/build/v2
+    with:
+      modroot: module-app
+      output: module-vendor-enabled
+      vendor: true
+      # vendor: true must take precedence over a conflicting generic build flag.
+      extra-args: -mod=mod
+
+  - uses: go/build/v2
+    with:
+      modroot: module-app
+      output: module-vendor-disabled
+      extra-args: -mod=mod
+
+  - uses: go/build/v2
+    with:
+      modroot: generated-app
+      output: module-vendor-generated
+      vendor: true
+
+  - name: Verify missing module vendor tree was generated
+    runs: test -s generated-app/vendor/modules.txt
+
+  - name: Create workspace fixture
+    runs: |
+      mkdir -p workspace/app workspace/dep
+
+      cat > workspace/go.work <<'EOF'
+      go 1.24
+
+      use ./app
+      EOF
+      cat > workspace/dep/go.mod <<'EOF'
+      module example.com/workspace-dep
+
+      go 1.24
+      EOF
+      cat > workspace/dep/value.go <<'EOF'
+      package workspacedep
+
+      const Value = "workspace"
+      EOF
+      cat > workspace/app/go.mod <<'EOF'
+      module example.com/workspace-app
+
+      go 1.24
+
+      require example.com/workspace-dep v0.0.0
+
+      replace example.com/workspace-dep => ../dep
+      EOF
+      cat > workspace/app/main.go <<'EOF'
+      package main
+
+      import (
+          "fmt"
+
+          workspacedep "example.com/workspace-dep"
+      )
+
+      func main() {
+          fmt.Println(workspacedep.Value)
+      }
+      EOF
+
+  - uses: go/build/v2
+    with:
+      modroot: workspace/app
+      output: workspace-vendor-generated
+      vendor: true
+
+  - name: Verify missing workspace vendor tree was generated
+    runs: test -s workspace/vendor/modules.txt
+
+test:
+  environment:
+    contents:
+      packages:
+        - busybox
+  pipeline:
+    - runs: module-vendor-enabled | grep -Fx vendored
+    - runs: module-vendor-disabled | grep -Fx module
+    - runs: module-vendor-generated | grep -Fx generated
+    - runs: workspace-vendor-generated | grep -Fx workspace

--- a/pkg/build/pipelines/go/build/v2.yaml
+++ b/pkg/build/pipelines/go/build/v2.yaml
@@ -30,7 +30,8 @@ inputs:
 
   vendor:
     description: |
-      If true, the go mod command will also update the vendor directory
+      If true, build using vendored dependencies. An existing module or workspace
+      vendor tree is preserved; otherwise one is generated with go mod vendor or go work vendor.
     default: "false"
 
   modroot:
@@ -118,7 +119,23 @@ pipeline:
       # Take advantage of melange's buid cache for downloaded modules
       export GOMODCACHE=/var/cache/melange/gomodcache
 
-      GOAMD64="${{inputs.amd64}}" GOARM64="${{inputs.arm64}}" GOEXPERIMENT="${{inputs.experiments}}" go build -o "${{targets.contextdir}}"/${BASE_PATH} -tags "${{inputs.toolchaintags}},${{inputs.tags}}" -ldflags "${LDFLAGS}" -trimpath -buildmode ${{inputs.buildmode}} ${{inputs.extra-args}} ${{inputs.packages}}
+      set --
+      if [ "${{inputs.vendor}}" = "true" ]; then
+        # Preserve existing vendor trees because recipes may patch vendored sources.
+        # Generate one only when absent, using the active workspace when present.
+        GOWORK=$(go env GOWORK)
+        if [ -n "$GOWORK" ] && [ "$GOWORK" != "off" ]; then
+          VENDOR_DIR=$(dirname "$GOWORK")/vendor
+          if [ ! -f "$VENDOR_DIR/modules.txt" ]; then
+            go work vendor
+          fi
+        elif [ ! -f vendor/modules.txt ]; then
+          go mod vendor
+        fi
+        set -- -mod=vendor
+      fi
+
+      GOAMD64="${{inputs.amd64}}" GOARM64="${{inputs.arm64}}" GOEXPERIMENT="${{inputs.experiments}}" go build -o "${{targets.contextdir}}"/${BASE_PATH} -tags "${{inputs.toolchaintags}},${{inputs.tags}}" -ldflags "${LDFLAGS}" -trimpath -buildmode ${{inputs.buildmode}} ${{inputs.extra-args}} "$@" ${{inputs.packages}}
 
       # Clean up the gitignore file we created to avoid interfering with subsequent builds
       if [ "${{inputs.ignore-untracked-files}}" = "true" ]; then


### PR DESCRIPTION
## Summary

- make `go/build/v2` honor its existing `vendor` input
- preserve existing module or workspace vendor trees, including patched vendored sources
- generate a vendor tree only when one is missing, then force `go build` to consume it with `-mod=vendor`
- add an end-to-end regression test covering preserved, generated, disabled, and workspace vendoring

## Why

`go/build/v2` has declared `vendor` since it was introduced in #2538, but the input is never consumed. This surfaced while reviewing [chainguard-dev/stereo#268366](https://github.com/chainguard-dev/stereo/pull/268366#discussion_r3852545595).

Unconditionally regenerating `vendor/` is unsafe because callers can patch vendored source before building. Only forcing `-mod=vendor` is also insufficient for existing callers that set `vendor: true` without a pre-existing tree. This change handles both cases and leaves the default `vendor: false` behavior unchanged.

## Validation

- `go test ./pkg/build/...`
- compiled the new e2e recipe for `x86_64`
- validated YAML formatting/parsing and `git diff --check`
- exercised the fixture directly with Go 1.24, verifying:
  - an existing patched module vendor tree is preserved and consumed
  - `vendor: false` does not force vendor mode
  - a missing module vendor tree is generated
  - a missing workspace vendor tree is generated with `go work vendor`

The new `go-build-v2-vendor-build-test.yaml` job provides the same coverage in Melange's e2e suite.

## Melange Pull Request Template

### Functional Changes

- [ ] This change can build all of Wolfi without errors (describe results in notes)

Notes: Full Wolfi was not rebuilt locally. The change is opt-in and the focused module/workspace regression coverage is included in this PR.

### SCA Changes

- [ ] Examining several representative APKs show no regression / the desired effect (details in notes)

Notes: Not applicable; this does not change SCA behavior.

### Linter

- [ ] The new check is clean across Wolfi
- [ ] The new check is opt-in or a warning

Notes: Not applicable; this does not add or change a linter.
