### PR TITLE
fix(source): Confine source paths to the workspace directory

### DIFF
--- a/pkg/source/fetch.go
+++ b/pkg/source/fetch.go
@@ -38,7 +38,8 @@ import (
 // filename, and argv elements.
 type FetchOptions struct {
 	URI             string
-	Directory       string // where to extract; relative to the current working directory
+	Directory       string // where to extract; relative to WorkspaceDir
+	WorkspaceDir    string // root that the download and extraction are confined to
 	StripComponents int
 	Extract         bool
 	ExpectedSHA256  string
@@ -46,11 +47,30 @@ type FetchOptions struct {
 	Delete          bool
 }
 
-// Fetch downloads the artifact named by opts.URI into the current working
-// directory, optionally verifies its checksum, and optionally extracts it. The
-// URI is parsed and used as data (never passed to a shell).
+// Fetch downloads the artifact named by opts.URI into the workspace directory,
+// optionally verifies its checksum, and optionally extracts it. The URI is
+// parsed and used as data (never passed to a shell), and the extraction
+// directory is confined to the workspace.
 func Fetch(ctx context.Context, opts *FetchOptions) error {
 	log := clog.FromContext(ctx)
+
+	workDir := opts.WorkspaceDir
+	if workDir == "" {
+		var err error
+		if workDir, err = os.Getwd(); err != nil {
+			return fmt.Errorf("determining working directory: %w", err)
+		}
+	}
+
+	// Resolve the extraction directory up front so an unusable `directory:`
+	// fails before anything is written to disk.
+	extractDir := workDir
+	if opts.Extract && opts.Directory != "" {
+		var err error
+		if extractDir, err = secureJoin(workDir, opts.Directory, "fetch directory"); err != nil {
+			return err
+		}
+	}
 
 	u, err := url.Parse(opts.URI)
 	if err != nil {
@@ -70,27 +90,25 @@ func Fetch(ctx context.Context, opts *FetchOptions) error {
 		return fmt.Errorf("could not determine a filename from uri %q", opts.URI)
 	}
 
+	archive := filepath.Join(workDir, base)
+
 	log.Infof("Fetching %s", opts.URI)
-	if err := download(ctx, opts.URI, base); err != nil {
+	if err := download(ctx, opts.URI, archive); err != nil {
 		return err
 	}
 
-	if err := verifyChecksum(base, opts.ExpectedSHA256, opts.ExpectedSHA512); err != nil {
+	if err := verifyChecksum(archive, opts.ExpectedSHA256, opts.ExpectedSHA512); err != nil {
 		return err
 	}
 
 	if opts.Extract {
-		dir := opts.Directory
-		if dir == "" {
-			dir = "."
-		}
 		// tar is invoked with an explicit argv, so the filename and directory
 		// are passed as plain arguments. tar auto-detects the compression
 		// format, matching the built-in pipeline.
-		// #nosec G204 - argv-only invocation; args are validated data, not shell
+		// #nosec G204 - argv-only invocation; extractDir resolves inside the workspace
 		cmd := exec.CommandContext(ctx, "tar", "-x",
 			fmt.Sprintf("--strip-components=%d", opts.StripComponents),
-			"--no-same-owner", "-C", dir, "-f", base)
+			"--no-same-owner", "-C", extractDir, "-f", archive)
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 		if err := cmd.Run(); err != nil {
@@ -99,7 +117,7 @@ func Fetch(ctx context.Context, opts *FetchOptions) error {
 	}
 
 	if opts.Delete {
-		if err := os.Remove(base); err != nil {
+		if err := os.Remove(archive); err != nil {
 			return fmt.Errorf("deleting %q: %w", base, err)
 		}
 	}
@@ -175,17 +193,14 @@ func applyPatchStep(ctx context.Context, patches string, stripComponents, fuzz i
 
 	for patch := range strings.FieldsSeq(patches) {
 		// Keep patch paths within the workspace directory.
-		if filepath.IsAbs(patch) {
-			return fmt.Errorf("absolute patch paths are not allowed: %q", patch)
-		}
-		patchPath := filepath.Join(workDir, patch)
-		if rel, err := filepath.Rel(workDir, patchPath); err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
-			return fmt.Errorf("patch path %q escapes the workspace directory", patch)
+		patchPath, err := secureJoin(workDir, patch, "patch")
+		if err != nil {
+			return err
 		}
 
 		log.Infof("Applying patch %s", patchPath)
 
-		f, err := os.Open(patchPath) // #nosec G304 G703 - patch path validated to stay within the workspace dir
+		f, err := os.Open(patchPath) // #nosec G304 G703 - patch path resolves inside the workspace dir
 		if err != nil {
 			return fmt.Errorf("opening patch %q: %w", patchPath, err)
 		}

--- a/pkg/source/git.go
+++ b/pkg/source/git.go
@@ -21,12 +21,18 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/chainguard-dev/clog"
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
 )
+
+// commitIDRE matches the commit id form the git-checkout pipeline documents
+// for cherry-picks. Values in any other form are rejected rather than passed
+// through to git.
+var commitIDRE = regexp.MustCompile(`^[0-9a-fA-F]{7,64}$`)
 
 type GitCheckoutOptions struct {
 	Repository        string
@@ -87,7 +93,11 @@ func GitCheckout(ctx context.Context, opts *GitCheckoutOptions) error {
 
 	if opts.RecurseSubmodules {
 		log.Infof("Initializing submodules")
-		subCmd := exec.CommandContext(ctx, "git", "submodule", "update", "--init", "--recursive")
+		// Submodule sources are expected to be remote, so disable the local
+		// file transport instead of relying on the git default.
+		subCmd := exec.CommandContext(ctx, "git",
+			"-c", "protocol.file.allow=never",
+			"submodule", "update", "--init", "--recursive")
 		subCmd.Dir = opts.Destination
 		subCmd.Stdout = os.Stdout
 		subCmd.Stderr = os.Stderr
@@ -147,6 +157,12 @@ func parseCherryPicks(input string) ([]string, error) {
 		// path.Base handles this correctly for paths like "release/1.23/COMMIT-ID".
 		commit := path.Base(pickSpec)
 
+		// The pipeline documents this input as a commit id. Enforcing that
+		// keeps a leading '-' from reaching `git cherry-pick` as an option.
+		if !commitIDRE.MatchString(commit) {
+			return nil, fmt.Errorf("invalid cherry-pick commit id %q: expected a hex commit id", commit)
+		}
+
 		commits = append(commits, commit)
 	}
 
@@ -178,10 +194,14 @@ func parsePatchList(input string) []string {
 
 func applyPatches(ctx context.Context, repoPath string, workspaceDir string, patches []string) error {
 	for _, patch := range patches {
-		// Resolve patch path relative to workspace directory
+		// Resolve the patch path relative to the workspace directory, and keep
+		// it there.
 		patchPath := patch
-		if workspaceDir != "" && !filepath.IsAbs(patch) {
-			patchPath = filepath.Join(workspaceDir, patch)
+		if workspaceDir != "" {
+			var err error
+			if patchPath, err = secureJoin(workspaceDir, patch, "patch"); err != nil {
+				return err
+			}
 		}
 
 		if err := applyOnePatch(ctx, repoPath, patchPath, patch); err != nil {

--- a/pkg/source/paths.go
+++ b/pkg/source/paths.go
@@ -1,0 +1,105 @@
+// Copyright 2026 Chainguard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package source
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// secureJoin resolves a path from a pipeline input against the workspace root
+// and returns the absolute location it names. Source steps operate on the
+// workspace, so absolute paths and `../` traversal are rejected and the result
+// is always inside root.
+//
+// Pipeline steps run in sequence against the same workspace, which means a
+// relative path may name a symlink an earlier step created. Symlinks along the
+// path are therefore resolved before the containment check, rather than
+// comparing lexically.
+//
+// The named path need not exist; only the components that do exist are
+// resolved. A symlink whose target cannot be resolved is an error, since there
+// is nothing to compare against root.
+func secureJoin(root, p, what string) (string, error) {
+	if filepath.IsAbs(p) {
+		return "", fmt.Errorf("absolute %s paths are not allowed: %q", what, p)
+	}
+
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		return "", fmt.Errorf("resolving workspace directory %q: %w", root, err)
+	}
+	// The workspace root itself may legitimately sit behind a symlink (macOS
+	// puts /tmp behind /private/tmp), so resolve it before comparing.
+	if resolved, err := filepath.EvalSymlinks(absRoot); err == nil {
+		absRoot = resolved
+	}
+
+	joined := filepath.Join(absRoot, p)
+	if !within(absRoot, joined) {
+		return "", fmt.Errorf("%s path %q escapes the workspace directory", what, p)
+	}
+
+	resolved, err := evalExistingPrefix(joined)
+	if err != nil {
+		return "", fmt.Errorf("resolving %s path %q: %w", what, p, err)
+	}
+	if !within(absRoot, resolved) {
+		return "", fmt.Errorf("%s path %q escapes the workspace directory via a symlink", what, p)
+	}
+
+	return resolved, nil
+}
+
+// within reports whether path is root itself or lies underneath it. Both
+// arguments must already be absolute and lexically clean.
+func within(root, path string) bool {
+	rel, err := filepath.Rel(root, path)
+	if err != nil {
+		return false
+	}
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}
+
+// evalExistingPrefix resolves symlinks over the longest prefix of p that
+// exists, then re-appends the components that do not exist yet. A component
+// that exists but cannot be resolved (a dangling symlink) is an error: its
+// target is unknown, so there is nothing to check.
+func evalExistingPrefix(p string) (string, error) {
+	cur, rest := p, ""
+	for {
+		resolved, err := filepath.EvalSymlinks(cur)
+		if err == nil {
+			return filepath.Join(resolved, rest), nil
+		}
+		if !os.IsNotExist(err) {
+			return "", err
+		}
+		// EvalSymlinks reports ENOENT both for "does not exist" and for a
+		// symlink whose target does not exist. Lstat tells the two apart.
+		if _, lerr := os.Lstat(cur); lerr == nil {
+			return "", fmt.Errorf("%q is a symlink that cannot be resolved", cur)
+		}
+
+		parent := filepath.Dir(cur)
+		if parent == cur {
+			return "", fmt.Errorf("%q could not be resolved", p)
+		}
+		rest = filepath.Join(filepath.Base(cur), rest)
+		cur = parent
+	}
+}

--- a/pkg/source/paths_test.go
+++ b/pkg/source/paths_test.go
@@ -1,0 +1,96 @@
+// Copyright 2026 Chainguard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package source
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSecureJoin(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+
+	if err := os.MkdirAll(filepath.Join(root, "sub", "nested"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Symlinks of the kind an earlier pipeline step could have created in the
+	// workspace: one leaving the root, one unresolvable, one staying inside.
+	if err := os.Symlink(outside, filepath.Join(root, "outward-link")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(filepath.Join(outside, "does-not-exist"), filepath.Join(root, "dangling")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(filepath.Join(root, "sub"), filepath.Join(root, "inside-link")); err != nil {
+		t.Fatal(err)
+	}
+
+	// realRoot is what secureJoin returns paths relative to, since it resolves
+	// the root itself (t.TempDir() sits behind /private on macOS).
+	realRoot, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	allowed := map[string]string{
+		"":                     realRoot,
+		".":                    realRoot,
+		"sub":                  filepath.Join(realRoot, "sub"),
+		"sub/nested":           filepath.Join(realRoot, "sub", "nested"),
+		"sub/../sub":           filepath.Join(realRoot, "sub"),
+		"does/not/exist/yet":   filepath.Join(realRoot, "does", "not", "exist", "yet"),
+		"inside-link":          filepath.Join(realRoot, "sub"),
+		"inside-link/nested":   filepath.Join(realRoot, "sub", "nested"),
+		"./sub/./nested/../..": realRoot,
+	}
+	for in, want := range allowed {
+		t.Run("allow/"+in, func(t *testing.T) {
+			got, err := secureJoin(root, in, "test")
+			if err != nil {
+				t.Fatalf("secureJoin(%q) = error %v, want %q", in, err, want)
+			}
+			if got != want {
+				t.Errorf("secureJoin(%q) = %q, want %q", in, got, want)
+			}
+		})
+	}
+
+	rejected := []string{
+		outside,                             // absolute
+		"/etc",                              // absolute
+		"..",                                // traversal
+		"../..",                             // traversal
+		"sub/../../elsewhere",               // traversal after cleaning
+		"outward-link",                      // symlink leaving the root
+		"outward-link/file",                 // path under a symlink leaving the root
+		"inside-link/../outward-link",       // traversal onto a symlink leaving the root
+		"dangling",                          // symlink with an unresolvable target
+		filepath.Join(outside, "no-such-x"), // absolute, nonexistent
+	}
+	for _, in := range rejected {
+		t.Run("reject/"+in, func(t *testing.T) {
+			got, err := secureJoin(root, in, "test")
+			if err == nil {
+				t.Fatalf("secureJoin(%q) = %q, want an error", in, got)
+			}
+			if !strings.Contains(err.Error(), "test") {
+				t.Errorf("error %q does not name the input kind", err)
+			}
+		})
+	}
+}

--- a/pkg/source/source.go
+++ b/pkg/source/source.go
@@ -54,7 +54,7 @@ func runStep(ctx context.Context, step config.Pipeline, sm *build.SubstitutionMa
 
 	switch step.Uses {
 	case "fetch":
-		return runFetchStep(ctx, resolve)
+		return runFetchStep(ctx, resolve, destDir)
 	case "git-checkout":
 		return runGitCheckoutStep(ctx, resolve, destDir)
 	case "patch":
@@ -64,7 +64,7 @@ func runStep(ctx context.Context, step config.Pipeline, sm *build.SubstitutionMa
 	}
 }
 
-func runFetchStep(ctx context.Context, resolve func(string) (string, error)) error {
+func runFetchStep(ctx context.Context, resolve func(string) (string, error), destDir string) error {
 	get := func(dst *string, key string) error {
 		v, err := resolve(key)
 		if err != nil {
@@ -74,7 +74,7 @@ func runFetchStep(ctx context.Context, resolve func(string) (string, error)) err
 		return nil
 	}
 
-	opts := &FetchOptions{}
+	opts := &FetchOptions{WorkspaceDir: destDir}
 	var stripRaw, extractRaw, deleteRaw string
 	for dst, key := range map[*string]string{
 		&opts.URI:            "uri",
@@ -106,11 +106,11 @@ func runGitCheckoutStep(ctx context.Context, resolve func(string) (string, error
 	if err != nil {
 		return err
 	}
-	switch {
-	case dest == "" || dest == ".":
+	// Keep the clone destination inside the workspace.
+	if dest == "" || dest == "." {
 		dest = destDir
-	case !filepath.IsAbs(dest):
-		dest = filepath.Join(destDir, dest)
+	} else if dest, err = secureJoin(destDir, dest, "git-checkout destination"); err != nil {
+		return err
 	}
 	expectedCommit, err := resolve("expected-commit")
 	if err != nil {
@@ -157,14 +157,11 @@ func runPatchStep(ctx context.Context, resolve func(string) (string, error), des
 	// comments). Fold it into the patch list when no explicit patches are given.
 	if strings.TrimSpace(patches) == "" && strings.TrimSpace(series) != "" {
 		// Keep the series path within the workspace directory.
-		if filepath.IsAbs(series) {
-			return fmt.Errorf("absolute series paths are not allowed: %q", series)
+		seriesPath, err := secureJoin(destDir, series, "series")
+		if err != nil {
+			return err
 		}
-		seriesPath := filepath.Join(destDir, series)
-		if rel, err := filepath.Rel(destDir, seriesPath); err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
-			return fmt.Errorf("series path %q escapes the workspace directory", series)
-		}
-		data, err := os.ReadFile(seriesPath) // #nosec G304 - series path validated to stay within the workspace dir
+		data, err := os.ReadFile(seriesPath) // #nosec G304 - series path resolves inside the workspace dir
 		if err != nil {
 			return fmt.Errorf("reading series file %q: %w", seriesPath, err)
 		}

--- a/pkg/source/source_test.go
+++ b/pkg/source/source_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"chainguard.dev/melange/pkg/build"
@@ -234,5 +235,134 @@ pipeline:
 				t.Fatalf("input was not treated as literal data (marker file %s was created)", marker)
 			}
 		})
+	}
+}
+
+// TestFetchSourceFromMelange_pathsConfinedToWorkspace asserts that the path
+// inputs of the source steps resolve inside the workspace: absolute values and
+// `../` traversal are rejected, and the step leaves nothing behind outside the
+// destination directory.
+func TestFetchSourceFromMelange_pathsConfinedToWorkspace(t *testing.T) {
+	tmpDir := t.TempDir()
+	outsideDir := filepath.Join(tmpDir, "outside")
+	if err := os.MkdirAll(outsideDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	header := `package:
+  name: example
+  version: "1.0.0"
+  epoch: 0
+  copyright:
+    - license: MIT
+pipeline:
+`
+
+	configs := map[string]string{
+		"fetch-directory-absolute": header + `  - uses: fetch
+    with:
+      uri: https://example.invalid/archive.tar.gz
+      directory: ` + outsideDir + `
+`,
+		"fetch-directory-traversal": header + `  - uses: fetch
+    with:
+      uri: https://example.invalid/archive.tar.gz
+      directory: ../outside
+`,
+		"git-checkout-destination-absolute": header + `  - uses: git-checkout
+    with:
+      repository: https://example.invalid/repo.git
+      destination: ` + outsideDir + `
+`,
+		"git-checkout-destination-traversal": header + `  - uses: git-checkout
+    with:
+      repository: https://example.invalid/repo.git
+      destination: ../outside
+`,
+		"patch-absolute": header + `  - uses: patch
+    with:
+      patches: /etc/passwd
+`,
+		"patch-traversal": header + `  - uses: patch
+    with:
+      patches: ../outside/x.patch
+`,
+		"series-traversal": header + `  - uses: patch
+    with:
+      series: ../outside/series
+`,
+	}
+
+	for name, content := range configs {
+		t.Run(name, func(t *testing.T) {
+			cfgPath := filepath.Join(tmpDir, name+".yaml")
+			if err := os.WriteFile(cfgPath, []byte(content), 0o600); err != nil {
+				t.Fatalf("failed to write config: %v", err)
+			}
+
+			workspace := filepath.Join(tmpDir, name+"-out")
+			_, err := FetchSourceFromMelange(context.Background(), cfgPath, workspace)
+			if err == nil {
+				t.Fatalf("expected a path-confinement error, got nil")
+			}
+			// The step must be rejected on the path, not merely fail later on
+			// an unreachable host.
+			if !strings.Contains(err.Error(), "escapes the workspace") &&
+				!strings.Contains(err.Error(), "are not allowed") {
+				t.Fatalf("expected a path-confinement error, got: %v", err)
+			}
+
+			entries, readErr := os.ReadDir(outsideDir)
+			if readErr != nil {
+				t.Fatal(readErr)
+			}
+			if len(entries) != 0 {
+				t.Fatalf("wrote %d entries outside the workspace: %v", len(entries), entries)
+			}
+		})
+	}
+}
+
+// TestFetchSourceFromMelange_symlinkedDirectoryRejected covers a `directory:`
+// that is relative and lexically inside the workspace but names a symlink
+// pointing out of it, as an earlier step in the same pipeline could have
+// created. Containment is checked after resolving symlinks, so it is rejected.
+func TestFetchSourceFromMelange_symlinkedDirectoryRejected(t *testing.T) {
+	tmpDir := t.TempDir()
+	outsideDir := filepath.Join(tmpDir, "outside")
+	workspace := filepath.Join(tmpDir, "workspace")
+	for _, d := range []string{outsideDir, workspace} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Stands in for a symlink a previous fetch step extracted.
+	if err := os.Symlink(outsideDir, filepath.Join(workspace, "outward-link")); err != nil {
+		t.Fatal(err)
+	}
+
+	content := `package:
+  name: example
+  version: "1.0.0"
+  epoch: 0
+  copyright:
+    - license: MIT
+pipeline:
+  - uses: fetch
+    with:
+      uri: https://example.invalid/archive.tar.gz
+      directory: outward-link
+`
+	cfgPath := filepath.Join(tmpDir, "symlink.yaml")
+	if err := os.WriteFile(cfgPath, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := FetchSourceFromMelange(context.Background(), cfgPath, workspace)
+	if err == nil {
+		t.Fatalf("expected a path-confinement error, got nil")
+	}
+	if !strings.Contains(err.Error(), "escapes the workspace") {
+		t.Fatalf("expected a path-confinement error, got: %v", err)
 	}
 }


### PR DESCRIPTION
Source steps resolve several path inputs against the workspace: the fetch `directory`, the git-checkout `destination`, and the patch `patches` and `series`. Route all of them through one secureJoin helper that rejects absolute paths and `../` traversal.

The helper resolves symlinks before checking containment rather than comparing lexically. Pipeline steps run in sequence against a shared workspace, so a relative path may name a symlink an earlier step created, which a lexical comparison would accept.

Fetch now takes an explicit WorkspaceDir and writes the download there instead of depending on the caller having chdir'd into it.

Also tighten two git-checkout inputs: cherry-pick values must be commit ids, matching what the pipeline documents, so other forms are not passed through to git; and submodule init disables the local file transport, since submodule sources are expected to be remote.