### PR TITLE
git-checkout: disable git auto background maintenance

### DIFF
--- a/e2e-tests/git-checkout-build.yaml
+++ b/e2e-tests/git-checkout-build.yaml
@@ -318,6 +318,11 @@ pipeline:
       [ "$status" == "## 1.x...origin/1.x [ahead 2]" ]
       # for-cherry-pick.txt should exist as a file
       [ -f for-cherry-pick.txt ]
+      # auto maintenance must be disabled so no fetch (like the unshallow
+      # fetch for cherry-picks) spawns a detached 'git maintenance run'
+      # that outlives the pipeline step.
+      [ "$(git config --get maintenance.auto)" = "false" ]
+      [ "$(git config --get gc.auto)" = "0" ]
       cd ..
       rm -R cherry-pick-test
 

--- a/pkg/build/pipelines/git-checkout.yaml
+++ b/pkg/build/pipelines/git-checkout.yaml
@@ -320,6 +320,15 @@ pipeline:
           vr git config --global --add safe.directory "$workdir"
           vr git config --global --add safe.directory "$dest_fullpath"
 
+          # Never spawn background maintenance: on git >= 2.47 every fetch
+          # spawns 'git maintenance run --auto --detach', which daemonizes,
+          # outlives this pipeline step, and races with later steps reading
+          # .git (e.g. its lock file vanishing mid-tar).  The repo is
+          # ephemeral, so auto maintenance has no value here.  gc.auto covers
+          # code paths that still consult the legacy setting.
+          vr git config --global maintenance.auto false
+          vr git config --global gc.auto 0
+
           msg "Attempting git clone with retry (max_retries=$max_retries, initial_backoff=${initial_backoff}s, max_backoff=${max_backoff}s)"
           # shellcheck disable=SC2086
           retry_with_backoff "$max_retries" "$initial_backoff" "$max_backoff" \


### PR DESCRIPTION
On git >= 2.47 every "git fetch" spawns "git maintenance run --auto --no-quiet --detach" as a child process. The --detach flag makes the maintenance process daemonize, so it outlives the fetch, the pipeline step that ran it, and the session. While running it holds .git/objects/maintenance.lock and deletes it on exit.

This detached process leaks into subsequent, unrelated pipeline steps of a package build and races with any step that reads the source tree including .git. Observed in the wild: a cherry-picks unshallow fetch finished shortly before a user step copied the tree with "tar". The detached maintenance process deleted its lock file between tar's readdir and open, tar exited 2 on the vanished file, and the build failed under "set -eo pipefail".

While checkout times improve slightly, this is not a performance improvement per se: The problem is that a build step and an unscheduled background process overlap at all. Any step that copies or enumerates .git (tar, cp -a, rsync, find, etc.) can race the lock file's creation/deletion. How much the detached process actually does, and how wide or narrow the window for the race is, depends on the git version: Through git 2.53 the default auto strategy ran only the gc task, whose thresholds a fresh clone never meets, so it exited after a few ms of logical work. Since git 2.54 the default strategy for fetch-spawned maintenance is "geometric", which also enables commit-graph and geometric-repack. A freshly unshallowed large repository triggers their auto conditions, so the detached process can spend seconds of real work mutating .git mid-build.

Disabling auto maintenance pins the behavior and avoids leaking tasks into the next build step. Nothing of value is lost, since the build workspace is discarded after the build and does not benefit from maintenance.

Set maintenance.auto=false in the global git config before the first git command so every later invocation inherits it, and set gc.auto=0 for code paths that still consult the legacy setting.