### PR TITLE
feat(pipelines): add php/composer-install pipeline

### DIFF
--- a/e2e-tests/php-composer-install-build-test.yaml
+++ b/e2e-tests/php-composer-install-build-test.yaml
@@ -1,0 +1,34 @@
+# Builds a real, dependency-free Composer package (psr/log, the PSR-3
+# logger interface) using the php/composer-install pipeline, then verifies
+# the installed autoloader can actually load and instantiate a class from
+# it.
+package:
+  name: php-psr-log
+  version: 3.0.2
+  epoch: 0
+  description: "psr/log, the PSR-3 logger interface package"
+  dependencies:
+    runtime:
+      - php
+
+environment:
+  contents:
+    packages:
+      - composer
+      - php
+
+pipeline:
+  - uses: php/composer-install
+    with:
+      package: psr/log
+      version: ${{package.version}}
+
+test:
+  environment:
+    contents:
+      packages:
+        - busybox
+        - php
+  pipeline:
+    - runs: |
+        php -r "require '/usr/share/php/vendor/autoload.php'; new Psr\Log\NullLogger();"

--- a/e2e-tests/php-composer-install-build-test.yaml
+++ b/e2e-tests/php-composer-install-build-test.yaml
@@ -11,12 +11,6 @@ package:
     runtime:
       - php
 
-environment:
-  contents:
-    packages:
-      - composer
-      - php
-
 pipeline:
   - uses: php/composer-install
     with:

--- a/examples/composer-install.yaml
+++ b/examples/composer-install.yaml
@@ -18,9 +18,6 @@ environment:
       - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
     repositories:
       - https://packages.wolfi.dev/os
-    packages:
-      - composer
-      - php
 
 pipeline:
   - uses: php/composer-install

--- a/examples/composer-install.yaml
+++ b/examples/composer-install.yaml
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: 2026 Chainguard, Inc
+# SPDX-License-Identifier: Apache-2.0
+#
+# This is a sample configuration file to demonstrate how to build a software
+# project using melange's built-in php/composer-install pipeline.
+package:
+  name: php-psr-log
+  version: 3.0.2
+  epoch: 0
+  description: "psr/log, the PSR-3 logger interface package"
+  dependencies:
+    runtime:
+      - php
+
+environment:
+  contents:
+    keyring:
+      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    repositories:
+      - https://packages.wolfi.dev/os
+    packages:
+      - composer
+      - php
+
+pipeline:
+  - uses: php/composer-install
+    with:
+      package: psr/log
+      version: ${{package.version}}
+
+test:
+  environment:
+    contents:
+      packages:
+        - busybox
+        - php
+  pipeline:
+    - runs: |
+        php -r "require '/usr/share/php/vendor/autoload.php'; new Psr\Log\NullLogger();"

--- a/pkg/build/pipelines/php/README.md
+++ b/pkg/build/pipelines/php/README.md
@@ -1,0 +1,20 @@
+<!-- start:pipeline-reference-gen -->
+# Pipeline Reference
+
+
+- [php/composer-install](#phpcomposer-install)
+
+## php/composer-install
+
+Install a PHP package with Composer
+
+### Inputs
+
+| Name | Required | Description | Default |
+| ---- | -------- | ----------- | ------- |
+| opts | false | Extra options to pass to composer require.  |  |
+| package | true | The name of the Composer package to install, e.g. "psr/log".  |  |
+| version | true | The version constraint to pass to composer require, e.g. "3.0.2".  |  |
+
+
+<!-- end:pipeline-reference-gen -->

--- a/pkg/build/pipelines/php/composer-install.yaml
+++ b/pkg/build/pipelines/php/composer-install.yaml
@@ -51,3 +51,10 @@ pipeline:
         --no-progress \
         ${{inputs.opts}} \
         "${{inputs.package}}:${{inputs.version}}"
+
+      # composer.json/composer.lock are build-time project manifests with
+      # no purpose at runtime; the generated vendor/autoload.php and
+      # vendor/composer/*.php files are fully self-contained and do not
+      # reference them. Removing them keeps the shipped apk to just the
+      # installed code.
+      rm -f "${WORK_DIR}/composer.json" "${WORK_DIR}/composer.lock"

--- a/pkg/build/pipelines/php/composer-install.yaml
+++ b/pkg/build/pipelines/php/composer-install.yaml
@@ -1,0 +1,52 @@
+name: Install a PHP package with Composer
+
+needs:
+  packages:
+    - busybox
+    - ca-certificates-bundle
+    - composer
+
+inputs:
+  package:
+    description: |
+      The name of the Composer package to install, e.g. "psr/log".
+    required: true
+
+  version:
+    description: |
+      The version constraint to pass to composer require, e.g. "3.0.2".
+    required: true
+
+  opts:
+    description: |
+      Extra options to pass to composer require.
+    default: ""
+    required: false
+
+pipeline:
+  - name: Check composer
+    runs: |
+      if ! [ -x "$(command -v composer)" ]; then
+        echo 'ERROR: Composer is not installed.'
+        exit 1
+      fi
+  - name: Composer require
+    runs: |
+      # Packages are installed into a single shared vendor tree at
+      # /usr/share/php/vendor, the same way python/install and ruby/install
+      # target one shared runtime location rather than a directory per
+      # package. This means composer-installed packages across multiple
+      # apks share one autoload tree, so it assumes the packages installed
+      # this way do not require conflicting versions of the same
+      # dependency.
+      WORK_DIR="${{targets.contextdir}}/usr/share/php"
+      mkdir -p "${WORK_DIR}"
+
+      # With --no-interaction, composer require creates composer.json and
+      # the vendor/ directory itself if they do not already exist.
+      composer require \
+        --working-dir="${WORK_DIR}" \
+        --no-interaction \
+        --no-progress \
+        ${{inputs.opts}} \
+        "${{inputs.package}}:${{inputs.version}}"

--- a/pkg/build/pipelines/php/composer-install.yaml
+++ b/pkg/build/pipelines/php/composer-install.yaml
@@ -5,6 +5,7 @@ needs:
     - busybox
     - ca-certificates-bundle
     - composer
+    - php
 
 inputs:
   package:


### PR DESCRIPTION
Closes #242.

Adds a php/composer-install pipeline, mirroring the existing npm/install and ruby/install pipelines: it takes a Composer package name and version and runs composer require to install it. Installed packages land in a single shared vendor tree at /usr/share/php/vendor, the same way python/install and ruby/install target one shared runtime location rather than a directory per package. This is the one real design decision here (Composer has no equivalent of Ruby's Gem.default_dir or Python's site-packages), documented in the pipeline itself along with its limitation: composer-installed packages across multiple apks share one autoload tree, so it assumes no conflicting versions of the same dependency between them.

The pipeline is self-sufficient for its own runtime dependency (php), matching how npm/install lists nodejs directly in its own needs.packages. Includes examples/composer-install.yaml and e2e-tests/php-composer-install-build-test.yaml, both building and testing a real, dependency-free package (psr/log).

Tested by actually extracting the built apk and inspecting its contents, not just reading the YAML. That caught a real issue: composer require necessarily creates composer.json/composer.lock in its working directory, and since this pipeline installs into a shared runtime location rather than a real project directory, those build-time manifest files were shipping inside the final apk with no purpose at runtime. Fixed by removing them after install; confirmed the autoloader still works afterward and re-extracted the apk to confirm they're gone.

Also verified failure handling directly: a composer require for a nonexistent version correctly fails the build (exit code 2) rather than being masked by the cleanup step, since melange wraps every runs: script in set -eo pipefail.

Other issues caught during iteration: composer require does not accept --no-dev (that's an install-only flag), the test environment needed busybox for /bin/sh, and php needed to be in the pipeline's own needs.packages rather than relying on the consumer to add it (it happened to resolve transitively through composer's own apk dependency, but explicit matches the established convention).