### PR TITLE
pre-commit: drop .git suffix from repo URL

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
-  - repo: https://github.com/jessp01/pre-commit-golang.git
+  - repo: https://github.com/jessp01/pre-commit-golang
     rev: v0.5.7
     hooks:
       - id: go-fmt


### PR DESCRIPTION
The `Zizmor` workflow started failing on unrelated PRs, e.g. [this dependabot run](https://github.com/chainguard-dev/melange/actions/runs/33648313153/job/100622908640):

```
fatal: no audit was performed
'ref-confusion' audit failed on file://./.pre-commit-config.yaml

Caused by:
    0: error in 'ref-confusion' audit
    1: couldn't list branches for jessp01/pre-commit-golang.git
    2: can't access jessp01/pre-commit-golang.git: missing or you have no access
```

zizmor v1.30.0 regressed repo-slug parsing for pre-commit configs: it no longer strips a trailing `.git`, so the `ref-confusion` audit asks the GitHub API for `repos/jessp01/pre-commit-golang.git/branches`, gets a 404, and aborts the entire run. All twelve workflow and action files audit clean before it bails.

`zizmorcore/zizmor-action` pulls `ghcr.io/zizmorcore/zizmor:latest`, so this landed on its own when v1.30.0 (released 2026-08-30) reached the tag — v1.29.0 runs from the same tree pass.

pre-commit treats both URL forms as the same repo, so dropping the suffix is a no-op for hook resolution (verified locally: the hooks re-initialize and run fine) and it is the workaround the zizmor maintainers recommend.

Upstream bug: https://github.com/zizmorcore/zizmor/issues/2358

🤖 Generated with [Claude Code](https://claude.com/claude-code)