### PR TITLE
build: keep setuid/setgid/sticky on unpacked directories

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -1100,6 +1100,10 @@ func isValidPath(targetPath, baseDir string) error {
 	return nil
 }
 
+// specialModeBits are the mode bits that Mkdir/MkdirAll cannot set, since
+// they take only permission bits.
+const specialModeBits = os.ModeSetuid | os.ModeSetgid | os.ModeSticky
+
 // retrieveWorkspace retrieves the workspace from the container and unpacks it
 // to the workspace directory. The workspace retrieved from the runner is in a
 // tar stream containing the workspace contents rooted at ./melange-out
@@ -1159,8 +1163,17 @@ func (b *Build) retrieveWorkspace(ctx context.Context, fs apkofs.FullFS) error {
 				}
 			}
 
-			if err := fs.MkdirAll(hdr.Name, hdr.FileInfo().Mode().Perm()); err != nil {
+			mode := hdr.FileInfo().Mode()
+			if err := fs.MkdirAll(hdr.Name, mode.Perm()); err != nil {
 				return fmt.Errorf("unable to create directory %s: %w", hdr.Name, err)
+			}
+
+			// MkdirAll carries only permission bits, so setuid/setgid/sticky
+			// have to be applied separately.
+			if special := mode & specialModeBits; special != 0 {
+				if err := fs.Chmod(hdr.Name, mode.Perm()|special); err != nil {
+					return fmt.Errorf("unable to chmod directory %s: %w", hdr.Name, err)
+				}
 			}
 
 			if err := fs.Chown(hdr.Name, uid, gid); err != nil {

--- a/pkg/build/workspace_test.go
+++ b/pkg/build/workspace_test.go
@@ -1,0 +1,121 @@
+// Copyright 2026 Chainguard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build
+
+import (
+	"archive/tar"
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"testing"
+
+	apkofs "chainguard.dev/apko/pkg/apk/fs"
+	apko_build "chainguard.dev/apko/pkg/build"
+
+	"chainguard.dev/melange/pkg/config"
+	"chainguard.dev/melange/pkg/container"
+)
+
+// tarRunner is a container.Runner that only implements WorkspaceTar, returning
+// a canned tar stream.
+type tarRunner struct {
+	tarball []byte
+}
+
+func (t *tarRunner) WorkspaceTar(context.Context, *container.Config, []string) (io.ReadCloser, error) {
+	return io.NopCloser(bytes.NewReader(t.tarball)), nil
+}
+
+func (t *tarRunner) Close() error                                      { return nil }
+func (t *tarRunner) Name() string                                      { return "tar-runner" }
+func (t *tarRunner) TestUsability(context.Context) bool                { return true }
+func (t *tarRunner) OCIImageLoader() container.Loader                  { return nil }
+func (t *tarRunner) StartPod(context.Context, *container.Config) error { return nil }
+func (t *tarRunner) Run(context.Context, *container.Config, map[string]string, ...string) error {
+	return nil
+}
+func (t *tarRunner) TerminatePod(context.Context, *container.Config) error { return nil }
+func (t *tarRunner) TempDir() string                                       { return "" }
+func (t *tarRunner) GetReleaseData(context.Context, *container.Config) (*apko_build.ReleaseData, error) {
+	return nil, nil
+}
+
+var _ container.Runner = (*tarRunner)(nil)
+
+// TestRetrieveWorkspaceSpecialModeBits verifies that setuid, setgid and sticky
+// bits survive the trip through retrieveWorkspace. Regression test for
+// https://github.com/chainguard-dev/melange/issues/2642, where directories
+// were created with Mode().Perm() and nothing set the special bits after.
+func TestRetrieveWorkspaceSpecialModeBits(t *testing.T) {
+	entries := []struct {
+		name     string
+		typeflag byte
+		mode     int64
+	}{
+		{"melange-out/pkg/", tar.TypeDir, 0o755},
+		{"melange-out/pkg/tmp/", tar.TypeDir, 0o1777},
+		{"melange-out/pkg/var/", tar.TypeDir, 0o755},
+		{"melange-out/pkg/var/tmp/", tar.TypeDir, 0o1777},
+		{"melange-out/pkg/usr/", tar.TypeDir, 0o755},
+		{"melange-out/pkg/usr/mail/", tar.TypeDir, 0o2755},
+		{"melange-out/pkg/usr/setuid-dir/", tar.TypeDir, 0o4755},
+		{"melange-out/pkg/usr/postdrop", tar.TypeReg, 0o2755},
+	}
+
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	for _, e := range entries {
+		if err := tw.WriteHeader(&tar.Header{
+			Name:     e.name,
+			Typeflag: e.typeflag,
+			Mode:     e.mode,
+		}); err != nil {
+			t.Fatalf("writing header %s: %v", e.name, err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("closing tar: %v", err)
+	}
+
+	ctx := context.Background()
+	workspaceDir := t.TempDir()
+	b := &Build{
+		Configuration: &config.Configuration{},
+		WorkspaceDir:  workspaceDir,
+		Runner:        &tarRunner{tarball: buf.Bytes()},
+	}
+	fsys := apkofs.DirFS(ctx, workspaceDir)
+
+	if err := b.retrieveWorkspace(ctx, fsys); err != nil {
+		t.Fatalf("retrieveWorkspace: %v", err)
+	}
+
+	for _, e := range entries {
+		// Let archive/tar do the mode conversion, so the expectation is in
+		// terms of os.ModeSetuid/Setgid/Sticky rather than raw octal.
+		hdr := tar.Header{Name: e.name, Typeflag: e.typeflag, Mode: e.mode}
+		want := hdr.FileInfo().Mode() & (os.ModePerm | specialModeBits)
+
+		fi, err := fsys.Stat(e.name)
+		if err != nil {
+			t.Errorf("stat %s: %v", e.name, err)
+			continue
+		}
+		if got := fi.Mode() & (os.ModePerm | specialModeBits); got != want {
+			t.Errorf("%s: got mode %v (%04o), want %v (%04o)", e.name, got, got.Perm(), want, want.Perm())
+		}
+	}
+}

--- a/pkg/container/bubblewrap_runner.go
+++ b/pkg/container/bubblewrap_runner.go
@@ -42,6 +42,10 @@ var _ Debugger = (*bubblewrap)(nil)
 const (
 	BubblewrapName = "bubblewrap"
 	buildUserID    = "1000"
+
+	// specialModeBits are the mode bits that Mkdir/MkdirAll cannot set,
+	// since they take only permission bits.
+	specialModeBits = os.ModeSetuid | os.ModeSetgid | os.ModeSticky
 )
 
 // defaultCapabilities is the set of Linux capabilities granted by the
@@ -325,8 +329,16 @@ func (b *bubblewrapOCILoader) LoadImage(ctx context.Context, layer v1.Layer, arc
 		}
 		switch hdr.Typeflag {
 		case tar.TypeDir:
-			if err := os.MkdirAll(fullname, hdr.FileInfo().Mode().Perm()); err != nil {
+			mode := hdr.FileInfo().Mode()
+			if err := os.MkdirAll(fullname, mode.Perm()); err != nil {
 				return ref, fmt.Errorf("failed to create directory %s: %w", fullname, err)
+			}
+			// MkdirAll carries only permission bits (and applies the umask),
+			// so setuid/setgid/sticky have to be applied separately.
+			if special := mode & specialModeBits; special != 0 {
+				if err := os.Chmod(fullname, mode.Perm()|special); err != nil {
+					return ref, fmt.Errorf("failed to chmod directory %s: %w", fullname, err)
+				}
 			}
 			continue
 		case tar.TypeReg:


### PR DESCRIPTION
Fixes #2642.

`retrieveWorkspace` created directories with
`MkdirAll(hdr.Name, hdr.FileInfo().Mode().Perm())`. `.Perm()` masks to
`0o777`, so `MkdirAll` cannot carry setuid/setgid/sticky, and nothing set
them afterwards — the ownership half was already handled by the `Chown`
right below, and the `tar.TypeReg` branch already passes the full mode to
`OpenFile`. Directories were the only entries losing metadata.

The observable effect: `wolfi-baselayout` explicitly `chmod 1777`s both
`/tmp` and `/var/tmp`, and the published apk records both as `0777`. `/tmp`
is masked downstream by luck (apko's `InitDB` creates it as 1777 first, and
apko won't let a package header downgrade an existing directory); `/var/tmp`
has no such backstop and ships world-writable with no sticky bit.

## What changed

- **`pkg/build/build.go`** — when the header carries any of
  setuid/setgid/sticky, `Chmod(hdr.Name, mode.Perm()|special)` after the
  `MkdirAll` and before the existing `Chown`. Guarding on the special bits
  keeps behavior identical for every other directory, notably the
  `melange-out/<pkg>` directories melange pre-creates itself.
- **`pkg/container/bubblewrap_runner.go`** — same shape when extracting the
  OCI layer into the guest rootfs, which left the build environment's own
  `/tmp` non-sticky. `os.MkdirAll` there also applies the umask, so plain
  `0777` was lost too; passing `mode.Perm()|special` to `os.Chmod` restores
  both. Lower stakes since it doesn't reach a shipped artifact, but it's the
  same defect.
- **`pkg/build/workspace_test.go`** (new) — `TestRetrieveWorkspaceSpecialModeBits`
  drives `retrieveWorkspace` through a minimal `container.Runner` returning a
  canned tar (1777 `tmp` and `var/tmp`, 2755 and 4755 directories, plain 0755
  directories, and a 2755 regular file) against a real `apkofs.DirFS`, then
  asserts the resulting modes.

Only the qemu runner is affected in practice: `WorkspaceTar` is a no-op for
bubblewrap and docker, which bind-mount the workspace.

## Testing

`go vet` and `go test ./pkg/build/ ./pkg/container/...` pass. The new test was
mutation-checked — with the `build.go` chmod removed it fails on exactly the
four special-bit directories, while the setgid *file* passes either way,
confirming the diagnosis that only the directory branch was broken:

```
melange-out/pkg/tmp/: got mode -rwxrwxrwx (0777), want trwxrwxrwx (0777)
melange-out/pkg/var/tmp/: got mode -rwxrwxrwx (0777), want trwxrwxrwx (0777)
melange-out/pkg/usr/mail/: got mode -rwxr-xr-x (0755), want grwxr-xr-x (0755)
melange-out/pkg/usr/setuid-dir/: got mode -rwxr-xr-x (0755), want urwxr-xr-x (0755)
```

## Related

apko had the identical defect in `pkg/tarfs`, fixed in
chainguard-dev/apko#2455, with chainguard-dev/apko#2456 tracking the remaining
apko-side install path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
