### PR TITLE
fix(linter): detect DWARF sections in the strip linter

### DIFF
--- a/pkg/linter/linters/strip.go
+++ b/pkg/linter/linters/strip.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"io/fs"
 	"path/filepath"
+	"strings"
 
 	"chainguard.dev/melange/pkg/config"
 	"chainguard.dev/melange/pkg/linter/types"
@@ -92,9 +93,16 @@ func StrippedLinter(ctx context.Context, _ *config.Configuration, pkgname string
 		}
 		defer file.Close()
 
-		// No debug sections allowed
-		if file.Section(".debug") != nil || file.Section(".zdebug") != nil {
-			unstrippedBinaries = append(unstrippedBinaries, path)
+		// No debug sections allowed. Match on prefix rather than an exact
+		// name: DWARF is emitted as .debug_info, .debug_str, .debug_line and
+		// friends, and compressed DWARF as .zdebug_*. A section named exactly
+		// ".debug" is a legacy convention almost nothing emits, so looking
+		// only for that reported every modern unstripped binary as clean.
+		for _, s := range file.Sections {
+			if strings.HasPrefix(s.Name, ".debug") || strings.HasPrefix(s.Name, ".zdebug") {
+				unstrippedBinaries = append(unstrippedBinaries, path)
+				break
+			}
 		}
 		return nil
 	})

--- a/pkg/linter/linters/strip_test.go
+++ b/pkg/linter/linters/strip_test.go
@@ -1,0 +1,211 @@
+// Copyright 2025 Chainguard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package linters
+
+import (
+	"debug/elf"
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/chainguard-dev/clog/slogtest"
+)
+
+// elfWithSections builds a minimal little-endian ELF64 executable whose
+// section header table names exactly the given sections (plus the mandatory
+// null section and .shstrtab). Every named section is zero-length: the linter
+// keys off a section's presence, not its contents, so this keeps the fixture
+// small enough to read.
+func elfWithSections(names ...string) []byte {
+	const (
+		ehsize    = 64
+		shentsize = 64
+	)
+
+	// Section header string table: a leading NUL, then each name NUL-terminated.
+	var shstrtab []byte
+	offsets := make([]uint32, 0, len(names)+1)
+	shstrtab = append(shstrtab, 0)
+	for _, n := range append(names, ".shstrtab") {
+		offsets = append(offsets, uint32(len(shstrtab)))
+		shstrtab = append(shstrtab, n...)
+		shstrtab = append(shstrtab, 0)
+	}
+
+	shstrtabOff := uint64(ehsize)
+	shoff := shstrtabOff + uint64(len(shstrtab))
+	// One header per named section, plus the null header and .shstrtab's own.
+	shnum := len(names) + 2
+
+	buf := make([]byte, shoff+uint64(shnum*shentsize))
+
+	// ELF header.
+	copy(buf, ElfMagic)
+	buf[4] = byte(elf.ELFCLASS64)
+	buf[5] = byte(elf.ELFDATA2LSB)
+	buf[6] = byte(elf.EV_CURRENT)
+	le := binary.LittleEndian
+	le.PutUint16(buf[16:], uint16(elf.ET_EXEC))
+	le.PutUint16(buf[18:], uint16(elf.EM_X86_64))
+	le.PutUint32(buf[20:], uint32(elf.EV_CURRENT))
+	le.PutUint64(buf[40:], shoff)
+	le.PutUint16(buf[52:], ehsize)
+	le.PutUint16(buf[58:], shentsize)
+	le.PutUint16(buf[60:], uint16(shnum))
+	le.PutUint16(buf[62:], uint16(shnum-1)) // .shstrtab is last
+
+	copy(buf[shstrtabOff:], shstrtab)
+
+	// Section headers. Index 0 is the null section, left zeroed.
+	putHeader := func(idx int, nameOff uint32, typ elf.SectionType, off, size uint64) {
+		h := buf[shoff+uint64(idx*shentsize):]
+		le.PutUint32(h[0:], nameOff)
+		le.PutUint32(h[4:], uint32(typ))
+		le.PutUint64(h[24:], off)
+		le.PutUint64(h[32:], size)
+	}
+	for i := range names {
+		putHeader(i+1, offsets[i], elf.SHT_PROGBITS, 0, 0)
+	}
+	putHeader(shnum-1, offsets[len(names)], elf.SHT_STRTAB, shstrtabOff, uint64(len(shstrtab)))
+
+	return buf
+}
+
+func TestStrippedLinter(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		path    string
+		mode    os.FileMode
+		content []byte
+		want    bool // want the file reported as unstripped
+	}{{
+		// The regression this test exists for: real DWARF is .debug_info and
+		// friends, never a bare ".debug", so an exact-name lookup missed it.
+		name:    "dwarf sections are unstripped",
+		path:    "usr/bin/dwarf",
+		mode:    0o755,
+		content: elfWithSections(".text", ".debug_info", ".debug_str", ".debug_line"),
+		want:    true,
+	}, {
+		name:    "compressed dwarf is unstripped",
+		path:    "usr/bin/zdwarf",
+		mode:    0o755,
+		content: elfWithSections(".text", ".zdebug_info"),
+		want:    true,
+	}, {
+		// The only shape the old exact-name check caught; keep catching it.
+		name:    "legacy bare .debug is unstripped",
+		path:    "usr/bin/legacy",
+		mode:    0o755,
+		content: elfWithSections(".text", ".debug"),
+		want:    true,
+	}, {
+		name:    "legacy bare .zdebug is unstripped",
+		path:    "usr/bin/legacyz",
+		mode:    0o755,
+		content: elfWithSections(".text", ".zdebug"),
+		want:    true,
+	}, {
+		name:    "stripped binary passes",
+		path:    "usr/bin/clean",
+		mode:    0o755,
+		content: elfWithSections(".text", ".rodata", ".symtab"),
+		want:    false,
+	}, {
+		// Not executable, but an object file, so still inspected.
+		name:    "unstripped shared object is caught",
+		path:    "usr/lib/libfoo.so",
+		mode:    0o644,
+		content: elfWithSections(".text", ".debug_abbrev"),
+		want:    true,
+	}, {
+		name:    "non-elf file is skipped",
+		path:    "usr/bin/script",
+		mode:    0o755,
+		content: []byte("#!/bin/sh\necho .debug_info\n"),
+		want:    false,
+	}, {
+		// Neither executable nor an object file.
+		name:    "non-executable non-object is skipped",
+		path:    "usr/share/foo/data",
+		mode:    0o644,
+		content: elfWithSections(".debug_info"),
+		want:    false,
+	}, {
+		name:    "sbom paths are ignored",
+		path:    "var/lib/db/sbom/foo.json",
+		mode:    0o755,
+		content: elfWithSections(".debug_info"),
+		want:    false,
+	}} {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := slogtest.Context(t)
+			dir := t.TempDir()
+			full := filepath.Join(dir, tt.path)
+			if err := os.MkdirAll(filepath.Dir(full), 0o700); err != nil {
+				t.Fatalf("MkdirAll: %v", err)
+			}
+			if err := os.WriteFile(full, tt.content, tt.mode); err != nil {
+				t.Fatalf("WriteFile: %v", err)
+			}
+
+			err := StrippedLinter(ctx, nil, "test-pkg", os.DirFS(dir))
+			if tt.want {
+				if err == nil {
+					t.Fatal("StrippedLinter returned nil, want an unstripped-binary error")
+				}
+				if !strings.Contains(err.Error(), "unstripped") {
+					t.Errorf("error = %q, want it to mention unstripped", err)
+				}
+				if !strings.Contains(err.Error(), "test-pkg") {
+					t.Errorf("error = %q, want it to name the package", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("StrippedLinter = %v, want nil", err)
+			}
+		})
+	}
+}
+
+// TestStrippedLinterFixtureIsParseable guards the hand-built ELF: if
+// debug/elf cannot read it, every case above would pass for the wrong reason.
+func TestStrippedLinterFixtureIsParseable(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bin")
+	if err := os.WriteFile(path, elfWithSections(".text", ".debug_info"), 0o755); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	f, err := elf.Open(path)
+	if err != nil {
+		t.Fatalf("elf.Open: %v", err)
+	}
+	defer f.Close()
+
+	for _, want := range []string{".text", ".debug_info", ".shstrtab"} {
+		if f.Section(want) == nil {
+			got := make([]string, 0, len(f.Sections))
+			for _, s := range f.Sections {
+				got = append(got, s.Name)
+			}
+			t.Errorf("section %q missing; fixture has %v", want, got)
+		}
+	}
+}


### PR DESCRIPTION
## The bug

`StrippedLinter` looked for a section named exactly `.debug` or `.zdebug`:

```go
// No debug sections allowed
if file.Section(".debug") != nil || file.Section(".zdebug") != nil {
```

`elf.File.Section` compares names for equality (`if s.Name == name`), but DWARF
is emitted as `.debug_info`, `.debug_str`, `.debug_line`, `.debug_abbrev`, … and
compressed DWARF as `.zdebug_*`. A section named exactly `.debug` is a legacy
convention that essentially nothing emits today, so the linter reported every
modern unstripped binary as clean.

Measured on a Chainguard OS host, across `/usr/bin` and `/usr/sbin`:

| | |
|---|---|
| ELF binaries | 2490 |
| carrying `.debug_*` sections | 446 (18%), 86 MiB of DWARF, 24 packages |
| with a section named exactly `.debug`/`.zdebug` | **0** |

So the rule fired on none of them. `util-linux` is one of those 24 packages —
its `/usr/bin/fstrim` is 376,784 bytes, and `strip -g` takes it to 119,912
(68% of the binary is debug info).

## The fix

Scan the section table and match on prefix, so real DWARF is caught and the
legacy bare names still are.

Verified against real binaries with the fix in place:

| binary | package | recipe has `uses: strip` | result |
|---|---|---|---|
| `/usr/bin/fstrim` | util-linux | no | **reported** |
| `/usr/bin/curl` | curl | yes | clean |
| `/usr/bin/accessdb` | man-db | yes | clean |

No false positives on genuinely stripped binaries.

## Severity is unchanged

`defaultBehavior` stays `Warn` (linter.go). A *working* detector at `Require`
would newly fail every package that never ran the opt-in `strip` pipeline, so
the recipes need fixing first — this PR only makes the existing warning tell the
truth. Expect it to start warning on packages that were silently passing;
`util-linux`, `iptables`, `libselinux`, `shadow`, `linux-pam`, `polkit`,
`bubblewrap` and `ca-certificates` are among them on the host I measured.

## Tests

New `pkg/linter/linters/strip_test.go`. There was no ELF fixture helper in the
repo (`pkg/linter/testdata` holds only real `.apk` files), so the test
synthesizes minimal ELF64 buffers with a controlled section-header string
table — no toolchain dependency, no new binary fixtures. Cases: `.debug_*`,
`.zdebug_*`, legacy bare `.debug` and `.zdebug`, a clean binary, an unstripped
non-executable `.so`, a non-ELF file, a non-executable non-object, and an
ignored SBOM path. A second test asserts `debug/elf` can actually parse the
fixture, so the table can't pass for the wrong reason.

Mutation-checked: reverting the detector to the exact-name form fails the
`.debug_*`, `.zdebug_*` and `.so` cases while the legacy cases keep passing.

`go build ./...`, `go vet ./pkg/linter/...`,
`golangci-lint run ./pkg/linter/...` (0 issues) and
`go test -count=1 ./pkg/linter/...` all pass. The real-APK tests
(`Test_lintApk`, `Test_lintApkWithOutput`) still pass and produce no new
unstripped warnings.

## Noted, not fixed here

`filepath.Ext("libfoo.so.1")` is `.1`, which `IsObjectFileRegex` doesn't match,
so a **non-executable** `libfoo.so.1` is skipped before the ELF check. Mostly
theoretical, since shared libraries are normally mode 0755 and caught by the
executable-bit branch. Left alone to keep this focused.
